### PR TITLE
Add play count tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # mca-gameday-camera
+
+This repository contains utilities for tracking play participation during a game.
+
+## play_count_tracker.py
+
+`play_count_tracker.py` is a simple command line tool for recording which players were on the field for each play. After each play, type the jersey numbers (1-17) separated by spaces. Enter `q` to finish. A log is written to `play_log.csv` and the final play counts are printed with alerts for any player that participated in fewer than seven plays.
+
+### Usage
+
+```bash
+python play_count_tracker.py
+```

--- a/play_count_tracker.py
+++ b/play_count_tracker.py
@@ -1,0 +1,44 @@
+# A simple play count tracker for 17 players.
+# Each play, enter the players who participated (numbers 1-17) separated by spaces.
+# Enter 'q' to quit. The script logs plays to play_log.csv and prints counts.
+
+import csv
+
+
+def main():
+    play_counts = {i: 0 for i in range(1, 18)}
+    play_number = 1
+
+    with open('play_log.csv', 'w', newline='') as logfile:
+        writer = csv.writer(logfile)
+        writer.writerow(['play_number', 'players'])
+
+        while True:
+            user_input = input(f"Enter player numbers for play {play_number} (or 'q' to quit): ")
+            if user_input.lower() in {'q', 'quit'}:
+                break
+            try:
+                players = [int(x) for x in user_input.split()]
+            except ValueError:
+                print('Invalid input. Use numbers 1-17 separated by spaces.')
+                continue
+            invalid = [p for p in players if p < 1 or p > 17]
+            if invalid:
+                print(f'Invalid player numbers: {invalid}. Valid range is 1-17.')
+                continue
+            writer.writerow([play_number, ' '.join(str(p) for p in players)])
+            for p in set(players):
+                play_counts[p] += 1
+            play_number += 1
+
+    print('\nPlay Counts:')
+    for player in range(1, 18):
+        count = play_counts[player]
+        if count < 7:
+            print(f'Player {player:2d}: {count} < 7! ALERT')
+        else:
+            print(f'Player {player:2d}: {count}')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- introduce `play_count_tracker.py` to log player participation via keyboard input
- document script usage in README

## Testing
- `python -m py_compile play_count_tracker.py`

------
https://chatgpt.com/codex/tasks/task_e_68837a76f150832d8131b95899b8ebeb