### PR TITLE
Add headless video capture utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,4 @@ This repository contains simple utilities for analyzing football plays.
 - `play_classifier.py` – provides the `PlayClassifier` class which wraps a
   YOLOv5 model to detect touchdown-like movements or fast exits of a
   player from the frame.
+- `record_video.py` – records 1280x720 video from /dev/video0 to output.mp4

--- a/record_video.py
+++ b/record_video.py
@@ -1,0 +1,56 @@
+import cv2
+import time
+
+
+def open_writer(path: str, fps: float, size: tuple[int, int]):
+    """Attempt to open H.264 writer and fallback to MJPG."""
+    fourcc = cv2.VideoWriter_fourcc(*"H264")
+    writer = cv2.VideoWriter(path, fourcc, fps, size)
+    if not writer.isOpened():
+        print("H.264 codec not available, falling back to MJPG")
+        fourcc = cv2.VideoWriter_fourcc(*"MJPG")
+        writer = cv2.VideoWriter(path, fourcc, fps, size)
+    return writer
+
+
+def record(device: str = "/dev/video0", duration: int = 30) -> None:
+    cap = cv2.VideoCapture(device)
+    if not cap.isOpened():
+        raise RuntimeError(f"Unable to open camera {device}")
+
+    cap.set(cv2.CAP_PROP_FRAME_WIDTH, 1280)
+    cap.set(cv2.CAP_PROP_FRAME_HEIGHT, 720)
+    fps = cap.get(cv2.CAP_PROP_FPS)
+    if not fps or fps <= 1:
+        fps = 30.0
+
+    writer = open_writer("output.mp4", fps, (1280, 720))
+    if not writer.isOpened():
+        raise RuntimeError("Failed to open video writer")
+
+    print("Recording started. Press Ctrl+C to stop.")
+    start = time.time()
+    next_report = 5
+    try:
+        while True:
+            ret, frame = cap.read()
+            if not ret:
+                print("Frame capture failed, stopping.")
+                break
+            writer.write(frame)
+            elapsed = time.time() - start
+            if elapsed >= next_report:
+                print(f"{int(elapsed)} seconds elapsed...")
+                next_report += 5
+            if elapsed >= duration:
+                break
+    except KeyboardInterrupt:
+        print("\nRecording interrupted by user.")
+    finally:
+        cap.release()
+        writer.release()
+        print("Recording complete.")
+
+
+if __name__ == "__main__":
+    record()


### PR DESCRIPTION
## Summary
- implement `record_video.py` for simple video capture
- document the new script in `README.md`

## Testing
- `python -m py_compile record_video.py camera_test.py motion_detector.py play_classifier.py play_count_tracker.py streamer.py`

------
https://chatgpt.com/codex/tasks/task_e_688393e1da54832d9864e01c35ba9a7e