### PR TITLE
Suppress OpenCV warnings in record_video

### DIFF
--- a/record_video.py
+++ b/record_video.py
@@ -1,4 +1,5 @@
 import cv2
+cv2.utils.logging.setLogLevel(cv2.utils.logging.LOG_LEVEL_ERROR)
 import time
 
 


### PR DESCRIPTION
## Summary
- silence GStreamer/FFmpeg warnings in `record_video.py` by setting the
  OpenCV log level to only show critical errors

## Testing
- `python -m py_compile record_video.py`

------
https://chatgpt.com/codex/tasks/task_e_688396a87eec832d9311bfc078791c9a