### PR TITLE
Add batch script to launch highlight_recorder via SSH

### DIFF
--- a/run_gameday_highlight.bat
+++ b/run_gameday_highlight.bat
@@ -1,0 +1,16 @@
+@echo off
+
+REM Launch highlight_recorder.py on remote Jetson Nano
+REM Usage: double-click or run from command prompt
+
+set USER=scott
+set HOST=192.168.6.35
+
+ssh %USER%@%HOST% "python3 ~/mca-gameday-camera/highlight_recorder.py"
+if %ERRORLEVEL% NEQ 0 (
+    echo.
+    echo Failed to connect or run highlight_recorder.py on %HOST%.
+    echo Ensure the Jetson Nano is reachable and SSH credentials are correct.
+)
+
+pause


### PR DESCRIPTION
## Summary
- add `run_gameday_highlight.bat` for running `highlight_recorder.py` on a Jetson Nano over SSH

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_6883be643f98832daa0a452201e1a8a3