### PR TITLE
Fix OpenCV logging for older versions

### DIFF
--- a/highlight_recorder.py
+++ b/highlight_recorder.py
@@ -1,5 +1,13 @@
 import cv2
-cv2.utils.logging.setLogLevel(cv2.utils.logging.LOG_LEVEL_ERROR)
+
+# Older OpenCV builds may not expose ``cv2.utils.logging``. Fall back to the
+# top-level ``setLogLevel`` function when necessary so that warnings are
+# suppressed on both new and old versions.
+try:
+    cv2.utils.logging.setLogLevel(cv2.utils.logging.LOG_LEVEL_ERROR)
+except AttributeError:  # pragma: no cover - depends on OpenCV version
+    if hasattr(cv2, "setLogLevel"):
+        cv2.setLogLevel(cv2.LOG_LEVEL_ERROR)
 import numpy as np
 import time
 from datetime import datetime

--- a/record_video.py
+++ b/record_video.py
@@ -1,5 +1,13 @@
 import cv2
-cv2.utils.logging.setLogLevel(cv2.utils.logging.LOG_LEVEL_ERROR)
+
+# ``cv2.utils.logging`` is not available in older OpenCV builds. Attempt to
+# suppress logging using whatever API is present so the script works across
+# versions.
+try:
+    cv2.utils.logging.setLogLevel(cv2.utils.logging.LOG_LEVEL_ERROR)
+except AttributeError:  # pragma: no cover - depends on OpenCV version
+    if hasattr(cv2, "setLogLevel"):
+        cv2.setLogLevel(cv2.LOG_LEVEL_ERROR)
 import time
 import subprocess
 


### PR DESCRIPTION
## Summary
- handle missing `cv2.utils.logging` in `highlight_recorder.py`
- apply same fix to `record_video.py`

## Testing
- `python -m py_compile highlight_recorder.py record_video.py`

------
https://chatgpt.com/codex/tasks/task_e_6883bf31d490832d9edc803ef3625396