### PR TITLE
Add gameday launcher script

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,9 @@ This repository contains simple utilities for analyzing football plays.
 ## update_code.sh
 
 Run `update_code.sh` to pull the latest changes from the remote `main` branch. The script handles errors like missing Git or network issues and prints whether new code was retrieved or if the repository was already current.
+
+## gameday.sh
+
+`gameday.sh` updates the repository and starts `highlight_recorder.py`.
+You can place the script on the Desktop, make it executable with `chmod +x`,
+and then right-click and select **Allow Launching** to use it like a shortcut.

--- a/gameday.sh
+++ b/gameday.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# gameday.sh - Update repo and run highlight_recorder.py
+set -euo pipefail
+
+REPO_DIR="$HOME/mca-gameday-camera"
+
+cd "$REPO_DIR"
+
+echo "Pulling latest code..."
+if git pull origin main; then
+  echo "Repository updated."
+else
+  echo "Failed to update repository" >&2
+fi
+
+echo "Running highlight_recorder.py"
+python3 highlight_recorder.py
+echo "highlight_recorder.py finished"


### PR DESCRIPTION
## Summary
- add a gameday launcher shell script
- note how to use `gameday.sh` in README

## Testing
- `python3 -m py_compile highlight_recorder.py`

------
https://chatgpt.com/codex/tasks/task_e_6883c6e7a0d4832db144801f95c33cde