### PR TITLE
Add automated gameday script

### DIFF
--- a/gameday.sh
+++ b/gameday.sh
@@ -1,46 +1,47 @@
 #!/usr/bin/env bash
-# gameday.sh - Pull latest code, start stream and recording
+# gameday.sh - Automate game day streaming and recording
 set -euo pipefail
 
+log() {
+    echo "$(date '+%Y-%m-%d %H:%M:%S') - $*"
+}
+
 REPO_DIR="$HOME/mca-gameday-camera"
+cd "$REPO_DIR" || { echo "Repository not found: $REPO_DIR" >&2; exit 1; }
 
-cd "$REPO_DIR" || { echo "Error: repository not found at $REPO_DIR" >&2; exit 1; }
-
-# Update repository
-echo "Pulling latest code..."
+log "Pulling latest code..."
 if ! git pull origin main; then
-  echo "Error: failed to pull latest code" >&2
-  exit 1
+    log "Failed to pull latest code"
+    exit 1
 fi
 
-echo "Starting livestream..."
-if [ ! -x ./start_stream.sh ]; then
-  echo "Error: start_stream.sh not found or not executable" >&2
-  exit 1
-fi
+TIMESTAMP=$(date +%Y%m%d_%H%M)
+FULL_DIR="$REPO_DIR/full_games/$TIMESTAMP"
+HIGHLIGHT_DIR="$REPO_DIR/highlights/$TIMESTAMP"
+mkdir -p "$FULL_DIR" "$HIGHLIGHT_DIR"
+
+log "Starting livestream..."
 ./start_stream.sh &
 STREAM_PID=$!
 
-# Check for camera before recording
-if [ ! -e /dev/video0 ]; then
-  echo "Error: /dev/video0 not found" >&2
-  kill "$STREAM_PID" 2>/dev/null || true
-  exit 1
-fi
-
-TIMESTAMP=$(date +%Y%m%d_%H%M%S)
-
-echo "Starting full game recording to fullgame_${TIMESTAMP}.mp4..."
+log "Starting full game recording..."
+FULLGAME_FILE="$FULL_DIR/fullgame_${TIMESTAMP}.mp4"
 ffmpeg -f v4l2 -framerate 30 -video_size 1280x720 -i /dev/video0 \
-  -c:v libx264 -b:v 1500k -pix_fmt yuv420p "fullgame_${TIMESTAMP}.mp4" &
-RECORD_PID=$!
+    -c:v libx264 -b:v 1500k -t 03:00:00 -pix_fmt yuv420p "$FULLGAME_FILE" &
+FFMPEG_PID=$!
 
-echo "Starting highlight recorder..."
-python3 highlight_recorder.py &
+log "Starting highlight recorder..."
+HIGHLIGHT_DIR="$HIGHLIGHT_DIR" python3 highlight_recorder.py "$HIGHLIGHT_DIR" &
 HIGHLIGHT_PID=$!
 
-echo "✅ Gameday Setup Complete"
+trap 'log "Stopping..."; kill $STREAM_PID $FFMPEG_PID $HIGHLIGHT_PID 2>/dev/null' INT TERM
 
-# Forward signals to background processes and wait for them
-trap 'kill $STREAM_PID $RECORD_PID $HIGHLIGHT_PID 2>/dev/null' INT TERM
-wait $STREAM_PID $RECORD_PID $HIGHLIGHT_PID
+log "Processes started. Recording for 3 hours..."
+sleep $((3 * 60 * 60))
+
+log "Time limit reached. Cleaning up..."
+kill $STREAM_PID $FFMPEG_PID $HIGHLIGHT_PID 2>/dev/null || true
+wait $STREAM_PID $FFMPEG_PID $HIGHLIGHT_PID 2>/dev/null || true
+
+log "✅ Gameday complete"
+


### PR DESCRIPTION
## Summary
- overhaul `gameday.sh` to automate 3‑hour stream/recording sessions
- allow `highlight_recorder.py` to take an output directory argument

## Testing
- `python3 -m py_compile highlight_recorder.py`

------
https://chatgpt.com/codex/tasks/task_e_6883d387bfac832da2f1299d1bf8ff2b