### PR TITLE
Add reliable Firefox ESR installer

### DIFF
--- a/install_firefox_esr.sh
+++ b/install_firefox_esr.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Download and extract the latest Firefox ESR for Jetson Nano (ARM64)
 
-set -e
+set -euo pipefail
 
 BASE_URL="https://ftp.mozilla.org/pub/firefox/releases/"
 
@@ -9,37 +9,40 @@ log() {
     echo -e "$1"
 }
 
-# Fetch ESR versions
-log "🔍 Checking Firefox ESR versions..."
-releases=$(wget -qO- "$BASE_URL" | grep -oE 'href="[0-9]+(\.[0-9]+)*esr/' | sed 's/href="//;s#/##' | sort -V)
+log "🔍 Fetching Firefox ESR versions..."
+if ! html=$(wget -qO- "$BASE_URL"); then
+    log "❌ Failed to fetch release index."
+    exit 1
+fi
 
+releases=$(echo "$html" | grep -oE 'href="[0-9]+(\.[0-9]+)*esr/' | sed 's#href="##;s#/##' | sort -V)
 latest=$(echo "$releases" | tail -n1)
 
-if [ -z "$latest" ]; then
+if [[ -z "$latest" ]]; then
     log "❌ No ESR versions found."
     exit 1
 fi
 
 log "✅ Latest ESR version detected: $latest"
-
 archive="firefox-${latest}.tar.bz2"
 url="${BASE_URL}${latest}/linux-aarch64/en-US/${archive}"
+rm -f "$archive"
 
-log "📦 Downloading ${archive}..."
+log "📦 Downloading $archive..."
 if ! wget -q "$url"; then
     log "❌ Download failed."
     exit 1
 fi
 
-log "📦 Extracting ${archive}..."
+log "📦 Extracting $archive..."
+# Remove old installation if present
+[ -d firefox ] && rm -rf firefox
 if ! tar -xjf "$archive"; then
     log "❌ Extraction failed."
     rm -f "$archive"
     exit 1
 fi
-
 rm -f "$archive"
 
-firefox_path="$(pwd)/firefox/firefox"
-log "✅ Firefox ${latest} installed."
-log "🚀 Launch with: $firefox_path"
+version_no_suffix=${latest%esr}
+log "🚀 Firefox ESR ${version_no_suffix} is ready to run at ./firefox/firefox"


### PR DESCRIPTION
## Summary
- fix the `install_firefox_esr.sh` script
- handle errors when fetching releases, downloading and extracting
- remove previous installation to make the script safe to run multiple times

## Testing
- `bash -n install_firefox_esr.sh`
- `pytest -q` *(fails: ImportError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_6883eb5e90ac832db025ee9635083f34