### PR TITLE
Use specific Firefox ESR ARM64 build

### DIFF
--- a/install_firefox_esr.py
+++ b/install_firefox_esr.py
@@ -1,11 +1,9 @@
 #!/usr/bin/env python3
-"""Download and extract the latest Firefox ESR for ARM64 Linux."""
+"""Download and extract a known Firefox ESR build for ARM64 Linux."""
 import os
-import re
 import sys
 import tarfile
 import shutil
-import subprocess
 from pathlib import Path
 
 try:
@@ -14,103 +12,65 @@ except ImportError:
     print("Error: The 'requests' package is required. Install it with 'pip install requests'.")
     sys.exit(1)
 
-BASE_URL = "https://ftp.mozilla.org/pub/firefox/releases/"
+VERSION = "115.23.0esr"
+URL = "https://ftp.mozilla.org/pub/firefox/releases/115.23.0esr/linux-aarch64/en-US/firefox-115.23.0esr.tar.bz2"
+ARCHIVE = Path(f"firefox-{VERSION}.tar.bz2")
+TARGET_DIR = Path("firefox-esr")
 
 
-def log(message: str) -> None:
-    print(message)
+def log(msg: str) -> None:
+    print(msg)
 
 
-def fetch_latest_esr() -> str:
-    """Return the latest ESR version string, e.g. '115.13.0esr'."""
-    log("Fetching Firefox releases...")
+def download() -> Path:
+    log(f"Downloading Firefox ESR {VERSION}...")
     try:
-        resp = requests.get(BASE_URL, timeout=10)
-        resp.raise_for_status()
-    except Exception as e:
-        log(f"Error fetching release index: {e}")
-        sys.exit(1)
-
-    entries = re.findall(r'href="([^"/]+/)"', resp.text)
-    esr_versions = [e.strip('/') for e in entries if e.endswith('esr/') and re.match(r'^\d', e)]
-    if not esr_versions:
-        log("No ESR versions found.")
-        sys.exit(1)
-
-    def version_key(v: str):
-        parts = v[:-3].split('.')
-        return [int(p) for p in parts]
-
-    esr_versions.sort(key=version_key)
-    latest = esr_versions[-1]
-    log(f"Detected ESR version: {latest}")
-    return latest
-
-
-def download_esr(version: str) -> Path:
-    sub_url = f"{BASE_URL}{version}/linux-aarch64/en-US/"
-    log(f"Checking {sub_url} for archive...")
-    try:
-        resp = requests.get(sub_url, timeout=10)
-        resp.raise_for_status()
-    except Exception as e:
-        log(f"Error fetching directory listing: {e}")
-        sys.exit(1)
-
-    pattern = rf'href="(firefox-{re.escape(version)}\.tar\.bz2)"'
-    match = re.search(pattern, resp.text)
-    if not match:
-        log("Firefox archive not found.")
-        sys.exit(1)
-
-    filename = match.group(1)
-    url = f"{sub_url}{filename}"
-    dest = Path.home() / filename
-    log(f"Downloading {url} to {dest} ...")
-    try:
-        with requests.get(url, stream=True, timeout=10) as r:
+        with requests.get(URL, stream=True, timeout=10) as r:
             r.raise_for_status()
-            with open(dest, 'wb') as f:
+            with open(ARCHIVE, 'wb') as f:
                 shutil.copyfileobj(r.raw, f)
     except Exception as e:
-        log(f"Error downloading file: {e}")
+        log(f"Error downloading archive: {e}")
         sys.exit(1)
-
-    log("Download complete.")
-    return dest
+    return ARCHIVE
 
 
-def extract_archive(tar_path: Path, version: str) -> Path:
-    extract_dir = Path.home() / f"firefox-{version}"
-    log(f"Extracting to {extract_dir} ...")
+def extract(tar_path: Path) -> None:
+    log("Extracting archive...")
+    if TARGET_DIR.exists():
+        shutil.rmtree(TARGET_DIR)
+    TARGET_DIR.mkdir(parents=True)
     try:
-        if extract_dir.exists():
-            shutil.rmtree(extract_dir)
         with tarfile.open(tar_path, 'r:bz2') as tar:
-            tar.extractall(extract_dir)
+            members = []
+            for m in tar.getmembers():
+                parts = m.name.split('/', 1)
+                if len(parts) == 2:
+                    m.name = parts[1]
+                else:
+                    m.name = parts[0]
+                members.append(m)
+            tar.extractall(TARGET_DIR, members)
     except Exception as e:
         log(f"Error extracting archive: {e}")
         sys.exit(1)
-    log("Extraction complete.")
-    return extract_dir / "firefox"
+    os.chmod(TARGET_DIR / "firefox", 0o755)
+
+    launcher = TARGET_DIR / "run_firefox.sh"
+    launcher.write_text(
+        "#!/usr/bin/env bash\n"
+        "DIR=\"$(cd \"$(dirname \"${BASH_SOURCE[0]}\")\" && pwd)\"\n"
+        "exec \"$DIR/firefox\" \"$@\"\n"
+    )
+    launcher.chmod(0o755)
 
 
-def main():
-    version = fetch_latest_esr()
-    tarball = download_esr(version)
-    firefox_dir = extract_archive(tarball, version)
-    log("Firefox ready to run.")
-
-    choice = input("Launch Firefox now? [y/N] ").strip().lower()
-    if choice == 'y':
-        firefox_path = firefox_dir / 'firefox'
-        log(f"Launching {firefox_path} ...")
-        try:
-            subprocess.Popen([str(firefox_path)])
-        except Exception as e:
-            log(f"Failed to launch Firefox: {e}")
-    else:
-        log("Installation finished.")
+def main() -> None:
+    tarball = download()
+    extract(tarball)
+    ARCHIVE.unlink(missing_ok=True)
+    log(f"Firefox ESR {VERSION} installed in ./{TARGET_DIR}")
+    log(f"Launch it with ./{TARGET_DIR}/run_firefox.sh")
 
 
 if __name__ == "__main__":

--- a/install_firefox_esr.sh
+++ b/install_firefox_esr.sh
@@ -1,17 +1,18 @@
 #!/usr/bin/env bash
-# Download and extract the latest Firefox ESR using Mozilla's redirect service
+# Download and extract a known Firefox ESR build for ARM64 Linux
 
 set -euo pipefail
 
-URL="https://download.mozilla.org/?product=firefox-esr-latest&os=linux64&lang=en-US"
-ARCHIVE="firefox-latest-esr.tar.bz2"
+VERSION="115.23.0esr"
+URL="https://ftp.mozilla.org/pub/firefox/releases/${VERSION}/linux-aarch64/en-US/firefox-${VERSION}.tar.bz2"
+ARCHIVE="firefox-${VERSION}.tar.bz2"
 TARGET_DIR="firefox-esr"
 
 log() {
     echo -e "$1"
 }
 
-log "🌐 Downloading latest Firefox ESR..."
+log "🌐 Downloading Firefox ESR $VERSION..."
 if ! curl -L "$URL" -o "$ARCHIVE"; then
     log "❌ Download failed."
     exit 1


### PR DESCRIPTION
## Summary
- update the shell installer to pull Firefox 115.23.0esr from Mozilla
- rewrite the Python installer to also fetch the fixed ARM64 archive
- keep previous install steps (extract, chmod, launcher script)

## Testing
- `bash -n install_firefox_esr.sh`
- `python -m py_compile install_firefox_esr.py`


------
https://chatgpt.com/codex/tasks/task_e_68841cd2f9dc832d9bddcdf0d87e2590