### PR TITLE
Lock Firefox ESR version in install script

### DIFF
--- a/.install/install_firefox_esr.sh
+++ b/.install/install_firefox_esr.sh
@@ -2,8 +2,10 @@
 
 set -e
 
-VERSION="115.3.1esr"
+# Hardcode the desired Firefox ESR version instead of scraping Mozilla's site
+VERSION="115.11.0esr"
 TARBALL="firefox-${VERSION}.tar.bz2"
+# Construct the download URL directly from the version
 DOWNLOAD_URL="https://ftp.mozilla.org/pub/firefox/releases/${VERSION}/linux-aarch64/en-US/${TARBALL}"
 INSTALL_DIR=".install/firefox-esr"
 


### PR DESCRIPTION
## Summary
- hardcode version `115.11.0esr` in `.install/install_firefox_esr.sh`
- construct the download URL from this version

## Testing
- `bash -n .install/install_firefox_esr.sh`
- `apt-get update` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6884cba41914832d933e754a0614e7e6