### PR TITLE
Update Firefox ESR install script to use 115.8

### DIFF
--- a/.install/install_firefox_esr.sh
+++ b/.install/install_firefox_esr.sh
@@ -1,12 +1,8 @@
 #!/usr/bin/env bash
-
 set -euo pipefail
 
-# Desired Firefox ESR version
-VERSION="115.10.0esr"
-
-# Download URL and archive name
-URL="https://ftp.mozilla.org/pub/firefox/releases/${VERSION}/linux-aarch64/en-US/firefox-${VERSION}.tar.bz2"
+VERSION="115.8.0esr"
+URL="https://ftp.mozilla.org/pub/firefox/releases/115.8.0esr/linux-aarch64/en-US/firefox-115.8.0esr.tar.bz2"
 ARCHIVE="firefox-${VERSION}.tar.bz2"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -15,13 +11,20 @@ INSTALL_DIR="${SCRIPT_DIR}/firefox-esr"
 mkdir -p "$INSTALL_DIR"
 
 echo "Downloading Firefox ESR ${VERSION}..."
-curl -L -o "$ARCHIVE" "$URL"
+if ! curl -L -o "$ARCHIVE" "$URL"; then
+    echo "Error: failed to download ${URL}" >&2
+    exit 1
+fi
+
+echo "Validating archive..."
+if ! tar -tjf "$ARCHIVE" > /dev/null 2>&1; then
+    echo "Error: downloaded file is not a valid tar archive" >&2
+    rm -f "$ARCHIVE"
+    exit 1
+fi
 
 echo "Extracting archive..."
 tar -xjf "$ARCHIVE" --strip-components=1 -C "$INSTALL_DIR"
-
 rm -f "$ARCHIVE"
 
-echo "✅ Firefox ESR ${VERSION} installed successfully"
-echo "📂 Installed at: .install/firefox-esr/"
-echo "👉 Launch it using: .install/firefox-esr/firefox"
+echo "Firefox ESR installed to .install/firefox-esr/"


### PR DESCRIPTION
## Summary
- update `.install/install_firefox_esr.sh` to install Firefox ESR 115.8.0esr
- validate archive before extraction and echo location when finished

## Testing
- `bash .install/install_firefox_esr.sh --help` *(fails: no --help option)*

------
https://chatgpt.com/codex/tasks/task_e_6884d16ae828832daa01228e1e0af11f