### PR TITLE
Update Firefox ESR installer

### DIFF
--- a/.install/install_firefox_esr.sh
+++ b/.install/install_firefox_esr.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-VERSION="115.8.0esr"
-URL="https://ftp.mozilla.org/pub/firefox/releases/115.8.0esr/linux-aarch64/en-US/firefox-115.8.0esr.tar.bz2"
-ARCHIVE="firefox-${VERSION}.tar.bz2"
+VERSION="115.3.0esr"
+URL="https://ftp.mozilla.org/pub/firefox/releases/115.3.0esr/linux-aarch64/en-US/firefox-115.3.0esr.tar.bz2"
+ARCHIVE="$(basename "$URL")"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 INSTALL_DIR="${SCRIPT_DIR}/firefox-esr"
@@ -11,8 +11,14 @@ INSTALL_DIR="${SCRIPT_DIR}/firefox-esr"
 mkdir -p "$INSTALL_DIR"
 
 echo "Downloading Firefox ESR ${VERSION}..."
-if ! curl -L -o "$ARCHIVE" "$URL"; then
-    echo "Error: failed to download ${URL}" >&2
+if ! curl -LO "$URL"; then
+    echo "❌ Download failed or version not available for ARM64" >&2
+    exit 1
+fi
+
+if [ ! -s "$ARCHIVE" ] || [ $(stat -c%s "$ARCHIVE") -le 1048576 ]; then
+    echo "❌ Download failed or version not available for ARM64" >&2
+    rm -f "$ARCHIVE"
     exit 1
 fi
 
@@ -27,4 +33,4 @@ echo "Extracting archive..."
 tar -xjf "$ARCHIVE" --strip-components=1 -C "$INSTALL_DIR"
 rm -f "$ARCHIVE"
 
-echo "Firefox ESR installed to .install/firefox-esr/"
+echo "✅ Firefox ESR ${VERSION} installed successfully!"


### PR DESCRIPTION
## Summary
- use Firefox ESR 115.3.0esr
- validate download size before extracting
- use `curl -LO` to download archive
- print a success message on install

## Testing
- `bash -n .install/install_firefox_esr.sh`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_6884d2832850832d9d45bedef9d9b74a