### PR TITLE
Update Firefox ESR install script

### DIFF
--- a/.install/install_firefox_esr.sh
+++ b/.install/install_firefox_esr.sh
@@ -3,38 +3,47 @@ set -euo pipefail
 
 VERSION="115.11.0esr"
 URL="https://ftp.mozilla.org/pub/firefox/releases/${VERSION}/linux-aarch64/en-US/firefox-${VERSION}.tar.bz2"
-ARCHIVE="$(basename "$URL")"
+ARCHIVE="firefox-${VERSION}.tar.bz2"
+INSTALL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/firefox-esr"
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-INSTALL_DIR="${SCRIPT_DIR}/firefox-esr"
+# Ensure the download exists before attempting to fetch it
+printf 'Checking availability of %s...\n' "$URL"
+if ! curl -sfI "$URL" > /dev/null; then
+    echo "Error: Firefox ESR ${VERSION} not found at ${URL}" >&2
+    exit 1
+fi
 
-mkdir -p "$INSTALL_DIR"
-
-echo "Downloading Firefox ESR ${VERSION}..."
+# Download the archive
+printf 'Downloading %s...\n' "$ARCHIVE"
 if ! curl -fL -o "$ARCHIVE" "$URL"; then
-    echo "Error: download failed" >&2
+    echo "Error: failed to download ${URL}" >&2
     exit 1
 fi
 
-if [ ! -s "$ARCHIVE" ] || [ $(stat -c%s "$ARCHIVE") -le 10485760 ]; then
-    echo "Error: downloaded file is too small or invalid" >&2
-    rm -f "$ARCHIVE"
-    exit 1
-fi
-
-echo "Validating archive..."
+# Verify the archive is valid
+printf 'Verifying archive...\n'
 if ! tar -tjf "$ARCHIVE" > /dev/null 2>&1; then
-    echo "Error: downloaded file is not a valid tar archive" >&2
+    echo "Error: downloaded file is not a valid tar.bz2 archive" >&2
     rm -f "$ARCHIVE"
     exit 1
 fi
 
+# Prepare installation directory
 rm -rf "$INSTALL_DIR"
 mkdir -p "$INSTALL_DIR"
 
-echo "Extracting archive..."
-tar -xjf "$ARCHIVE" --strip-components=1 -C "$INSTALL_DIR"
+# Extract the archive
+printf 'Extracting to %s...\n' "$INSTALL_DIR"
+if ! tar -xjf "$ARCHIVE" --strip-components=1 -C "$INSTALL_DIR"; then
+    echo "Error: extraction failed" >&2
+    rm -f "$ARCHIVE"
+    exit 1
+fi
+
+# Remove the archive
 rm -f "$ARCHIVE"
 
-echo "Firefox ESR ${VERSION} installed successfully in ${INSTALL_DIR}."
-echo "Launch it with: ${INSTALL_DIR}/firefox &"
+# Ensure the Firefox binary is executable
+chmod +x "$INSTALL_DIR/firefox"
+
+printf '✅ Firefox ESR %s installed. Launch with `%s/firefox &`\n' "$VERSION" "$INSTALL_DIR"


### PR DESCRIPTION
## Summary
- rewrite `.install/install_firefox_esr.sh` to install Firefox ESR 115.11.0esr
- verify the URL before downloading
- check archive validity, extract, clean up and set executable

## Testing
- `bash .install/install_firefox_esr.sh` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6884d5186c14832d92faf29b8eb2a436