### PR TITLE
Fix Firefox ESR installer

### DIFF
--- a/.install/install_firefox_esr.sh
+++ b/.install/install_firefox_esr.sh
@@ -1,43 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-VERSION="115.11.0esr"
-ARCHIVE=".install/firefox.tar.bz2"
-URL="https://ftp.mozilla.org/pub/firefox/releases/115.11.0esr/linux-aarch64/en-US/firefox-115.11.0esr.tar.bz2"
-INSTALL_DIR=".install/firefox-esr"
-
-echo "Installing Firefox ESR ${VERSION}..."
-
-echo "Preparing installation directory..."
-rm -rf "$INSTALL_DIR"
-mkdir -p "$INSTALL_DIR"
-
-echo "Downloading from ${URL}..."
-if curl -fL -o "$ARCHIVE" "$URL"; then
-    echo "Download completed."
-else
-    echo "❌ Failed to download Firefox." >&2
-    exit 1
-fi
-
-echo "Extracting archive..."
-if tar -xjf "$ARCHIVE" -C "$INSTALL_DIR" --strip-components=1; then
-    echo "Extraction complete."
-else
-    echo "❌ Failed to extract archive." >&2
-    rm -f "$ARCHIVE"
-    exit 1
-fi
-
-rm -f "$ARCHIVE"
-chmod +x "$INSTALL_DIR/firefox"
-
-if [ -x "$INSTALL_DIR/firefox" ]; then
-    echo "✅ Firefox ESR ${VERSION} installed."
-else
-    echo "❌ Firefox installation failed." >&2
-    exit 1
-fi
-
-echo "Launching Firefox..."
-"$INSTALL_DIR/firefox" &
+# Wrapper script to install the latest Firefox ESR using Python
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$SCRIPT_DIR"
+exec python3 install_firefox_esr.py "$@"


### PR DESCRIPTION
## Summary
- simplify `.install/install_firefox_esr.sh` so it calls the Python installer
- update `install_firefox_esr.py` to auto-detect the latest ESR version

## Testing
- `python -m py_compile install_firefox_esr.py`
- `for f in *.py; do python -m py_compile "$f"; done`
- `bash -n .install/install_firefox_esr.sh`


------
https://chatgpt.com/codex/tasks/task_e_6884d8ff0da8832d93738bb09b3cc61d