### PR TITLE
Add YouTube streaming script and gameday launcher

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copy this file to .env and fill in your YouTube RTMP URL
+YOUTUBE_RTMP_URL=rtmp://a.rtmp.youtube.com/live2/YOUR_STREAM_KEY

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .install/firefox-esr/
 .install/firefox-esr/libxul.so
 firefox-esr/
+.env
+

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ python motion_detector.py path/to/video.mp4
 ```
 
 You can adjust the detection sensitivity using `--threshold` and minimum segment length with `--min-duration`.
-This repository provides a simple script for streaming a camera feed to
-YouTube Live using RTMP. Frames are captured with OpenCV and piped to
-`ffmpeg` for encoding and upload.
+This repository provides simple scripts for streaming and recording a camera
+feed. Frames can be captured with OpenCV and piped to `ffmpeg` for encoding and
+upload.
 
 ## Usage
 
@@ -33,6 +33,24 @@ python streamer.py <youtube_rtmp_url> [device_index]
 Replace `<youtube_rtmp_url>` with the RTMP URL and stream key supplied by
 YouTube. The optional `device_index` selects which local camera to use
 (the default is `0`). Press `Ctrl+C` to end the stream.
+
+## stream_to_youtube.py
+
+`stream_to_youtube.py` streams `/dev/video0` to YouTube using `ffmpeg`. The
+YouTube RTMP URL should be placed in a `.env` file:
+
+```ini
+YOUTUBE_RTMP_URL=rtmp://a.rtmp.youtube.com/live2/YOUR_STREAM_KEY
+```
+
+Logs are written to the `livestream_logs` folder and the script will
+automatically restart `ffmpeg` if it exits unexpectedly.
+
+Run it with:
+
+```bash
+python stream_to_youtube.py
+```
 
 ## Requirements
 
@@ -59,6 +77,13 @@ Run `update_code.sh` to pull the latest changes from the remote `main` branch. T
 `gameday.sh` updates the repository and starts `highlight_recorder.py`.
 You can place the script on the Desktop, make it executable with `chmod +x`,
 and then right-click and select **Allow Launching** to use it like a shortcut.
+
+## start_gameday.bat
+
+Windows users can run `start_gameday.bat` to launch livestreaming,
+recording and play tracking. The script loads the RTMP URL from `.env`,
+checks that the camera is connected and then starts several Python
+processes in separate terminal windows.
 
 ## youtube_uploader.py
 

--- a/start_gameday.bat
+++ b/start_gameday.bat
@@ -1,0 +1,50 @@
+@echo off
+REM One-click launcher for game day camera operations
+
+set SCRIPT_DIR=%~dp0
+cd /d %SCRIPT_DIR%
+
+if not exist logs mkdir logs
+
+REM Load environment variables from .env if present
+if exist .env (
+    for /f "usebackq tokens=1,* delims==" %%A in (".env") do (
+        if not defined %%A set %%A=%%B
+    )
+)
+
+if "%YOUTUBE_RTMP_URL%"=="" (
+    echo Missing YOUTUBE_RTMP_URL in environment or .env
+    pause
+    exit /b 1
+)
+
+REM Check camera availability using Python and OpenCV
+python - <<PY
+import cv2, sys
+cap = cv2.VideoCapture(0)
+if not cap.isOpened():
+    sys.exit(1)
+cap.release()
+PY
+if errorlevel 1 (
+    echo Camera not found. Connect the camera and try again.
+    pause
+    exit /b 1
+)
+
+REM Start livestream
+start "Livestream" cmd /k python stream_to_youtube.py
+
+REM Start local recording
+start "Recording" cmd /k python record_video.py
+
+REM Start highlight recorder
+start "Highlights" cmd /k python highlight_recorder.py
+
+REM Start play count tracker
+start "Play Tracker" cmd /k python play_count_tracker.py
+
+REM TODO: add battery and network status checks
+
+pause

--- a/stream_to_youtube.py
+++ b/stream_to_youtube.py
@@ -1,0 +1,66 @@
+import os
+import subprocess
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+
+
+def load_env(env_path: str = ".env") -> None:
+    if not os.path.exists(env_path):
+        return
+    with open(env_path) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, val = line.split("=", 1)
+            os.environ.setdefault(key.strip(), val.strip())
+
+
+def build_ffmpeg_command(url: str, device: str = "/dev/video0") -> list[str]:
+    return [
+        "ffmpeg",
+        "-f", "v4l2",
+        "-framerate", "60",
+        "-video_size", "1920x1080",
+        "-i", device,
+        "-f", "lavfi", "-i", "anullsrc=channel_layout=stereo:sample_rate=44100",
+        "-c:v", "libx264",
+        "-preset", "veryfast",
+        "-pix_fmt", "yuv420p",
+        "-b:v", "4500k",
+        "-maxrate", "4500k",
+        "-bufsize", "9000k",
+        "-g", "120",
+        "-c:a", "aac",
+        "-b:a", "128k",
+        "-f", "flv", url,
+    ]
+
+
+def main() -> None:
+    load_env()
+    url = os.environ.get("YOUTUBE_RTMP_URL")
+    if not url:
+        sys.exit("Missing YOUTUBE_RTMP_URL environment variable")
+
+    log_dir = Path("livestream_logs")
+    log_dir.mkdir(exist_ok=True)
+
+    while True:
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        log_file = log_dir / f"stream_{timestamp}.log"
+        with log_file.open("w") as lf:
+            process = subprocess.Popen(
+                build_ffmpeg_command(url), stdout=lf, stderr=lf
+            )
+            ret = process.wait()
+            lf.write(f"\nffmpeg exited with code {ret}\n")
+        if ret == 0:
+            break
+        time.sleep(5)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `stream_to_youtube.py` for ffmpeg livestreaming with auto-restart and logs
- ignore `.env` and provide `.env.example` for configuring the stream key
- create `start_gameday.bat` for one-click launch of streaming/recording on Windows
- document new scripts in README

## Testing
- `python -m py_compile stream_to_youtube.py highlight_recorder.py record_video.py play_count_tracker.py play_tracker.py streamer.py camera_test.py motion_detector.py install_firefox_esr.py youtube_uploader.py`

------
https://chatgpt.com/codex/tasks/task_e_6884e06b7d18832da1ab6db0d257f489