### PR TITLE
Add play count tracker with email alerts

### DIFF
--- a/email_alerts.py
+++ b/email_alerts.py
@@ -1,0 +1,43 @@
+import os
+import smtplib
+from email.message import EmailMessage
+from typing import Iterable
+
+
+def load_env() -> dict:
+    env = {}
+    if os.path.exists('.env'):
+        with open('.env') as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith('#') or '=' not in line:
+                    continue
+                key, val = line.split('=', 1)
+                env.setdefault(key, val)
+    env.update(os.environ)
+    return env
+
+
+def send_email(subject: str, body: str, recipients: Iterable[str]) -> None:
+    env = load_env()
+    smtp_user = env.get('SMTP_USER')
+    smtp_pass = env.get('SMTP_PASS')
+    if not smtp_user or not smtp_pass:
+        print('Missing SMTP_USER/SMTP_PASS environment variables; email not sent.')
+        return
+    smtp_server = env.get('SMTP_SERVER', 'smtp.gmail.com')
+    smtp_port = int(env.get('SMTP_PORT', '587'))
+
+    msg = EmailMessage()
+    msg['From'] = smtp_user
+    msg['To'] = ', '.join(recipients)
+    msg['Subject'] = subject
+    msg.set_content(body)
+
+    try:
+        with smtplib.SMTP(smtp_server, smtp_port) as smtp:
+            smtp.starttls()
+            smtp.login(smtp_user, smtp_pass)
+            smtp.send_message(msg)
+    except Exception as exc:
+        print(f'Failed to send email: {exc}')

--- a/play_count_tracker.py
+++ b/play_count_tracker.py
@@ -1,44 +1,99 @@
-# A simple play count tracker for 17 players.
-# Each play, enter the players who participated (numbers 1-17) separated by spaces.
-# Enter 'q' to quit. The script logs plays to play_log.csv and prints counts.
+"""Manual play count tracker with periodic email summaries."""
+
+from __future__ import annotations
 
 import csv
+import os
+import schedule
+import time
+from typing import Dict, Iterable, List
+
+from email_alerts import load_env, send_email
+
+JERSEY_NUMBERS: List[int] = [2, 3, 5, 7, 8, 9, 10, 11, 12, 14, 15, 17, 20, 21, 22, 24, 25]
+COUNTS_PATH = "jersey_counts.csv"
 
 
-def main():
-    play_counts = {i: 0 for i in range(1, 18)}
+def summary_lines(counts: Dict[int, int]) -> List[str]:
+    lines = []
+    for num in JERSEY_NUMBERS:
+        cnt = counts.get(num, 0)
+        alert = " < 7!" if cnt < 7 else ""
+        lines.append(f"#{num}: {cnt}{alert}")
+    return lines
+
+
+def email_summary(counts: Dict[int, int]) -> None:
+    env = load_env()
+    recipients = [e for e in env.get("COACH_EMAILS", "").split(',') if e]
+    if not recipients:
+        print("No coach email addresses configured; skipping email.")
+        return
+    subject = f"Play Count Update {time.strftime('%H:%M')}"
+    body = "\n".join(summary_lines(counts))
+    print("\n".join(["\nEmail Summary:"] + summary_lines(counts)))
+    send_email(subject, body, recipients)
+
+
+def manual_input_loop(counts: Dict[int, int]) -> None:
     play_number = 1
-
-    with open('play_log.csv', 'w', newline='') as logfile:
-        writer = csv.writer(logfile)
-        writer.writerow(['play_number', 'players'])
-
+    with open(COUNTS_PATH, "w", newline="") as csvfile:
+        writer = csv.writer(csvfile)
+        writer.writerow(["play_number", "jerseys"])
         while True:
-            user_input = input(f"Enter player numbers for play {play_number} (or 'q' to quit): ")
-            if user_input.lower() in {'q', 'quit'}:
+            schedule.run_pending()
+            user_input = input(f"Players for play {play_number} (or q): ")
+            if user_input.lower() in {"q", "quit"}:
                 break
             try:
-                players = [int(x) for x in user_input.split()]
+                nums = [int(x) for x in user_input.split()]
             except ValueError:
-                print('Invalid input. Use numbers 1-17 separated by spaces.')
+                print("Invalid input. Use jersey numbers separated by spaces.")
                 continue
-            invalid = [p for p in players if p < 1 or p > 17]
+            invalid = [n for n in nums if n not in JERSEY_NUMBERS]
             if invalid:
-                print(f'Invalid player numbers: {invalid}. Valid range is 1-17.')
+                print(f"Invalid jersey numbers: {invalid}")
                 continue
-            writer.writerow([play_number, ' '.join(str(p) for p in players)])
-            for p in set(players):
-                play_counts[p] += 1
+            writer.writerow([play_number, " ".join(str(n) for n in nums)])
+            for n in set(nums):
+                counts[n] = counts.get(n, 0) + 1
             play_number += 1
 
-    print('\nPlay Counts:')
-    for player in range(1, 18):
-        count = play_counts[player]
-        if count < 7:
-            print(f'Player {player:2d}: {count} < 7! ALERT')
-        else:
-            print(f'Player {player:2d}: {count}')
+
+def detect_jerseys_stub() -> List[int]:
+    """Placeholder for future AI-based detection."""
+    return []
 
 
-if __name__ == '__main__':
+def ai_loop(counts: Dict[int, int]) -> None:
+    print("AI mode stub running. Press Ctrl+C to stop.")
+    try:
+        while True:
+            detected = detect_jerseys_stub()
+            for n in set(detected):
+                if n in JERSEY_NUMBERS:
+                    counts[n] = counts.get(n, 0) + 1
+            schedule.run_pending()
+            time.sleep(1)
+    except KeyboardInterrupt:
+        pass
+
+
+def main() -> None:
+    counts: Dict[int, int] = {n: 0 for n in JERSEY_NUMBERS}
+    schedule.every(20).minutes.do(email_summary, counts)
+
+    mode = os.environ.get("PLAY_TRACKER_MODE", "manual")
+    if mode == "ai":
+        ai_loop(counts)
+    else:
+        manual_input_loop(counts)
+
+    print("\nFinal Counts:")
+    for line in summary_lines(counts):
+        print(line)
+    email_summary(counts)
+
+
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- create `email_alerts.py` for sending summary emails using `.env` vars
- overhaul `play_count_tracker.py` with scheduled email summaries and optional AI stub
- keep launcher `.bat` calling the tracker

## Testing
- `python -m py_compile email_alerts.py play_count_tracker.py`

------
https://chatgpt.com/codex/tasks/task_e_6884e2e270a4832db1b65f0c62f2a3d6