### PR TITLE
Add overlay and auto-tracking for livestream

### DIFF
--- a/auto_tracker.py
+++ b/auto_tracker.py
@@ -1,0 +1,41 @@
+"""Automatic camera panning using YOLOv8 detections."""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import cv2
+
+try:
+    from ultralytics import YOLO
+except Exception:  # pragma: no cover - optional
+    YOLO = None  # type: ignore
+
+
+class AutoTracker:
+    """Crop frames around the main action using YOLOv8."""
+
+    def __init__(self, model_path: str = "yolov8n.pt") -> None:
+        if YOLO is None:
+            raise ImportError("ultralytics package not installed")
+        self.model = YOLO(model_path)
+
+    def track(self, frame) -> Tuple[int, int, int, int]:
+        """Return crop (x, y, w, h) focused on detected players."""
+        height, width = frame.shape[:2]
+        res = self.model(frame, verbose=False)[0]
+        if not res.boxes:
+            return 0, 0, width, height
+        boxes = res.boxes.xyxy.cpu().numpy()
+        x1 = boxes[:, 0].min()
+        y1 = boxes[:, 1].min()
+        x2 = boxes[:, 2].max()
+        y2 = boxes[:, 3].max()
+        # expand box slightly
+        margin_x = int((x2 - x1) * 0.1)
+        margin_y = int((y2 - y1) * 0.1)
+        x1 = max(int(x1 - margin_x), 0)
+        y1 = max(int(y1 - margin_y), 0)
+        x2 = min(int(x2 + margin_x), width)
+        y2 = min(int(y2 + margin_y), height)
+        return x1, y1, x2 - x1, y2 - y1

--- a/game_uploader.py
+++ b/game_uploader.py
@@ -1,0 +1,29 @@
+"""Upload completed game video to Google Drive."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def upload_game(path: str, dest: str = "gdrive:/MCA/GameDayFull/") -> None:
+    file_path = Path(path)
+    if not file_path.exists():
+        raise FileNotFoundError(path)
+    result = subprocess.run(["rclone", "copy", str(file_path), dest], capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip())
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Upload game recording to Google Drive")
+    parser.add_argument("file", help="path to recording")
+    parser.add_argument("--dest", default="gdrive:/MCA/GameDayFull/", help="rclone destination")
+    args = parser.parse_args()
+    try:
+        upload_game(args.file, args.dest)
+        print("Upload successful")
+    except Exception as exc:
+        print(f"Upload failed: {exc}")

--- a/overlay_engine.py
+++ b/overlay_engine.py
@@ -1,0 +1,24 @@
+"""Utility for drawing a game overlay on video frames."""
+
+from __future__ import annotations
+
+import cv2
+
+from scoreboard_reader import ScoreboardState
+
+
+class OverlayEngine:
+    """Render scoreboard information on frames."""
+
+    def __init__(self, *, font_scale: float = 1.0, color: tuple[int, int, int] = (255, 255, 255)) -> None:
+        self.font = cv2.FONT_HERSHEY_SIMPLEX
+        self.font_scale = font_scale
+        self.color = color
+        self.thickness = 2
+
+    def draw(self, frame, state: ScoreboardState) -> None:
+        """Draw the overlay in-place."""
+        text = f"Home {state.home} - {state.away} Away  Q{state.quarter}  {state.clock}"
+        if state.down is not None and state.distance is not None:
+            text += f"  {state.down} & {state.distance}"
+        cv2.putText(frame, text, (20, 40), self.font, self.font_scale, self.color, self.thickness, cv2.LINE_AA)

--- a/scoreboard_reader.py
+++ b/scoreboard_reader.py
@@ -1,0 +1,76 @@
+"""Scoreboard state detection using OCR or manual input."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from typing import Optional
+
+import cv2
+
+try:
+    import pytesseract
+except Exception:  # pragma: no cover - optional dependency
+    pytesseract = None  # type: ignore
+
+
+@dataclass
+class ScoreboardState:
+    home: int = 0
+    away: int = 0
+    quarter: int = 1
+    clock: str = "12:00"
+    down: Optional[int] = None
+    distance: Optional[int] = None
+
+
+class ScoreboardReader:
+    """Detect or manually update scoreboard state."""
+
+    def __init__(self, roi: tuple[int, int, int, int] | None = None) -> None:
+        self.roi = roi
+        self.state = ScoreboardState()
+        self._lock = threading.Lock()
+        self._manual_thread = threading.Thread(target=self._manual_input, daemon=True)
+        self._manual_thread.start()
+
+    def _manual_input(self) -> None:
+        """Background thread for manual scoreboard updates via console."""
+        while True:
+            try:
+                cmd = input(
+                    "Enter score as 'home away quarter clock [down distance]' or blank to keep: "
+                ).strip()
+            except EOFError:
+                break
+            if not cmd:
+                continue
+            parts = cmd.split()
+            with self._lock:
+                try:
+                    self.state.home = int(parts[0])
+                    self.state.away = int(parts[1])
+                    if len(parts) > 2:
+                        self.state.quarter = int(parts[2])
+                    if len(parts) > 3:
+                        self.state.clock = parts[3]
+                    if len(parts) > 4:
+                        self.state.down = int(parts[4])
+                    if len(parts) > 5:
+                        self.state.distance = int(parts[5])
+                except (IndexError, ValueError):
+                    print("Invalid scoreboard input")
+
+    def update(self, frame) -> ScoreboardState:
+        """Update state from frame using OCR if possible."""
+        if self.roi and pytesseract is not None:
+            x, y, w, h = self.roi
+            sb = frame[y : y + h, x : x + w]
+            gray = cv2.cvtColor(sb, cv2.COLOR_BGR2GRAY)
+            text = pytesseract.image_to_string(gray, config="--psm 7")
+            digits = [int(s) for s in text.split() if s.isdigit()]
+            with self._lock:
+                if len(digits) >= 2:
+                    self.state.home, self.state.away = digits[:2]
+        with self._lock:
+            return ScoreboardState(**vars(self.state))

--- a/start_gameday.bat
+++ b/start_gameday.bat
@@ -33,11 +33,8 @@ if errorlevel 1 (
     exit /b 1
 )
 
-REM Start livestream
+REM Start livestream with overlays and auto tracking
 start "Livestream" cmd /k python stream_to_youtube.py
-
-REM Start local recording
-start "Recording" cmd /k python record_video.py
 
 REM Start highlight recorder
 start "Highlights" cmd /k python highlight_recorder.py

--- a/stream_to_youtube.py
+++ b/stream_to_youtube.py
@@ -5,6 +5,13 @@ import time
 from datetime import datetime
 from pathlib import Path
 
+import cv2
+
+from auto_tracker import AutoTracker
+from overlay_engine import OverlayEngine
+from scoreboard_reader import ScoreboardReader
+from game_uploader import upload_game
+
 
 def load_env(env_path: str = ".env") -> None:
     if not os.path.exists(env_path):
@@ -18,24 +25,48 @@ def load_env(env_path: str = ".env") -> None:
             os.environ.setdefault(key.strip(), val.strip())
 
 
-def build_ffmpeg_command(url: str, device: str = "/dev/video0") -> list[str]:
+def build_ffmpeg_command(url: str, size: tuple[int, int], fps: float, output: Path) -> list[str]:
+    width, height = size
     return [
         "ffmpeg",
-        "-f", "v4l2",
-        "-framerate", "60",
-        "-video_size", "1920x1080",
-        "-i", device,
-        "-f", "lavfi", "-i", "anullsrc=channel_layout=stereo:sample_rate=44100",
-        "-c:v", "libx264",
-        "-preset", "veryfast",
-        "-pix_fmt", "yuv420p",
-        "-b:v", "4500k",
-        "-maxrate", "4500k",
-        "-bufsize", "9000k",
-        "-g", "120",
-        "-c:a", "aac",
-        "-b:a", "128k",
-        "-f", "flv", url,
+        "-y",
+        "-f",
+        "rawvideo",
+        "-vcodec",
+        "rawvideo",
+        "-pix_fmt",
+        "bgr24",
+        "-s",
+        f"{width}x{height}",
+        "-r",
+        str(fps),
+        "-i",
+        "-",
+        "-f",
+        "lavfi",
+        "-i",
+        "anullsrc=channel_layout=stereo:sample_rate=44100",
+        "-c:v",
+        "libx264",
+        "-preset",
+        "veryfast",
+        "-pix_fmt",
+        "yuv420p",
+        "-b:v",
+        "4500k",
+        "-maxrate",
+        "4500k",
+        "-bufsize",
+        "9000k",
+        "-g",
+        "120",
+        "-c:a",
+        "aac",
+        "-b:a",
+        "128k",
+        "-f",
+        "tee",
+        f"[f=flv]{url}|[f=mp4]{output}"
     ]
 
 
@@ -45,21 +76,70 @@ def main() -> None:
     if not url:
         sys.exit("Missing YOUTUBE_RTMP_URL environment variable")
 
+    cap = cv2.VideoCapture(0)
+    if not cap.isOpened():
+        sys.exit("Unable to open camera")
+
+    width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH) or 1280)
+    height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT) or 720)
+    fps = cap.get(cv2.CAP_PROP_FPS)
+    if not fps or fps <= 1:
+        fps = 30.0
+
+    state_reader = ScoreboardReader()
+    overlay = OverlayEngine()
+    tracker = None
+    try:
+        tracker = AutoTracker()
+    except Exception:
+        tracker = None
+
     log_dir = Path("livestream_logs")
     log_dir.mkdir(exist_ok=True)
+
+    output_dir = Path("video")
+    output_dir.mkdir(exist_ok=True)
 
     while True:
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         log_file = log_dir / f"stream_{timestamp}.log"
+        record_file = output_dir / f"game_{timestamp}.mp4"
         with log_file.open("w") as lf:
             process = subprocess.Popen(
-                build_ffmpeg_command(url), stdout=lf, stderr=lf
+                build_ffmpeg_command(url, (width, height), fps, record_file),
+                stdin=subprocess.PIPE,
+                stdout=lf,
+                stderr=lf,
             )
-            ret = process.wait()
-            lf.write(f"\nffmpeg exited with code {ret}\n")
+            try:
+                while True:
+                    ret, frame = cap.read()
+                    if not ret:
+                        break
+                    if tracker:
+                        x, y, w, h = tracker.track(frame)
+                        frame = frame[y : y + h, x : x + w]
+                        frame = cv2.resize(frame, (width, height))
+                    state = state_reader.update(frame)
+                    overlay.draw(frame, state)
+                    process.stdin.write(frame.tobytes())
+            except KeyboardInterrupt:
+                pass
+            finally:
+                if process.stdin:
+                    process.stdin.close()
+                ret = process.wait()
+                lf.write(f"\nffmpeg exited with code {ret}\n")
         if ret == 0:
+            try:
+                upload_game(str(record_file))
+            except Exception as exc:
+                with log_file.open("a") as lf:
+                    lf.write(f"\nUpload failed: {exc}\n")
             break
         time.sleep(5)
+
+    cap.release()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- implement `ScoreboardReader` for OCR/manual scoreboard updates
- implement `OverlayEngine` to draw scoreboard info
- implement `AutoTracker` that crops frames around YOLOv8 detections
- implement `game_uploader` helper for post-game uploads
- enhance `stream_to_youtube.py` with overlays, tracking, local recording and upload
- update Windows launcher to use new features

## Testing
- `python -m py_compile scoreboard_reader.py overlay_engine.py auto_tracker.py game_uploader.py stream_to_youtube.py`

------
https://chatgpt.com/codex/tasks/task_e_6884e60d2c50832d8b244fa7961ab498