### PR TITLE
Implement OCR scoreboard reader

### DIFF
--- a/scoreboard_reader.py
+++ b/scoreboard_reader.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import json
 import threading
+import time
 from dataclasses import dataclass
 from typing import Optional
 
@@ -27,12 +29,41 @@ class ScoreboardState:
 class ScoreboardReader:
     """Detect or manually update scoreboard state."""
 
-    def __init__(self, roi: tuple[int, int, int, int] | None = None) -> None:
+    def __init__(
+        self,
+        roi: tuple[int, int, int, int] | None = None,
+        *,
+        ocr_interval: float = 5.0,
+        state_file: str = "game_state.json",
+    ) -> None:
         self.roi = roi
+        self.ocr_interval = ocr_interval
+        self.state_file = state_file
         self.state = ScoreboardState()
         self._lock = threading.Lock()
+        self._last_ocr = 0.0
         self._manual_thread = threading.Thread(target=self._manual_input, daemon=True)
         self._manual_thread.start()
+
+    def calibrate(self, frame) -> None:
+        """Interactively select the scoreboard ROI."""
+        self.roi = tuple(int(v) for v in cv2.selectROI("Scoreboard ROI", frame, showCrosshair=False))
+        cv2.destroyWindow("Scoreboard ROI")
+
+    def _save_state(self) -> None:
+        try:
+            with open(self.state_file, "w", encoding="utf-8") as f:
+                json.dump(vars(self.state), f)
+        except Exception:
+            pass
+
+    def _filter_digit(self, new: int, prev: int) -> int:
+        """Filter common OCR digit mistakes."""
+        if new in {6, 8} and prev in {6, 8} and abs(new - prev) == 2:
+            return prev
+        if new in {1, 7} and prev in {1, 7} and abs(new - prev) == 6:
+            return prev
+        return new
 
     def _manual_input(self) -> None:
         """Background thread for manual scoreboard updates via console."""
@@ -56,21 +87,36 @@ class ScoreboardReader:
                         self.state.clock = parts[3]
                     if len(parts) > 4:
                         self.state.down = int(parts[4])
-                    if len(parts) > 5:
-                        self.state.distance = int(parts[5])
+                        if len(parts) > 5:
+                            self.state.distance = int(parts[5])
+                    self._save_state()
                 except (IndexError, ValueError):
                     print("Invalid scoreboard input")
 
     def update(self, frame) -> ScoreboardState:
         """Update state from frame using OCR if possible."""
-        if self.roi and pytesseract is not None:
+        now = time.time()
+        if self.roi and pytesseract is not None and now - self._last_ocr >= self.ocr_interval:
             x, y, w, h = self.roi
             sb = frame[y : y + h, x : x + w]
             gray = cv2.cvtColor(sb, cv2.COLOR_BGR2GRAY)
             text = pytesseract.image_to_string(gray, config="--psm 7")
             digits = [int(s) for s in text.split() if s.isdigit()]
+            clock_match = None
+            colon = text.find(":")
+            if colon >= 2:
+                candidate = text[colon - 2 : colon + 3]
+                if len(candidate) == 5 and candidate[2] == ":":
+                    clock_match = candidate
             with self._lock:
                 if len(digits) >= 2:
-                    self.state.home, self.state.away = digits[:2]
+                    self.state.home = self._filter_digit(digits[0], self.state.home)
+                    self.state.away = self._filter_digit(digits[1], self.state.away)
+                if len(digits) >= 3:
+                    self.state.quarter = self._filter_digit(digits[2], self.state.quarter)
+                if clock_match and len(clock_match) == 5:
+                    self.state.clock = clock_match
+                self._save_state()
+            self._last_ocr = now
         with self._lock:
             return ScoreboardState(**vars(self.state))

--- a/stream_to_youtube.py
+++ b/stream_to_youtube.py
@@ -88,6 +88,13 @@ def main() -> None:
 
     state_reader = ScoreboardReader()
     overlay = OverlayEngine()
+
+    # Calibrate scoreboard ROI once at startup
+    ret, calib_frame = cap.read()
+    if not ret:
+        sys.exit("Unable to read from camera")
+    if state_reader.roi is None:
+        state_reader.calibrate(calib_frame)
     tracker = None
     try:
         tracker = AutoTracker()


### PR DESCRIPTION
## Summary
- add scoreboard OCR with manual correction and JSON output
- calibrate ROI when streaming starts

## Testing
- `python -m py_compile scoreboard_reader.py overlay_engine.py stream_to_youtube.py`

------
https://chatgpt.com/codex/tasks/task_e_6884e739c5a4832d86f7186915a9557a