### PR TITLE
Add assignment analyzer stub

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,3 +120,16 @@ python install_firefox_esr.py
 ```
 
 The script prints progress messages and optionally launches Firefox when done. It requires the `requests` package.
+
+## assignment_analyzer.py
+
+`assignment_analyzer.py` is a stub for rating player assignments in recorded clips.
+It relies on `ai_detector.detect_jerseys` to find jersey numbers in each frame
+and appends the results to `player_ratings.csv`.
+
+```bash
+python assignment_analyzer.py path/to/clip.mp4 --playbook playbook.json
+```
+
+The optional JSON playbook maps jersey numbers to assignments. Real jersey
+detection and movement analysis are not implemented in this repository.

--- a/assignment_analyzer.py
+++ b/assignment_analyzer.py
@@ -1,0 +1,74 @@
+"""Placeholder player rating engine using jersey detection."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+from typing import Dict, List
+
+import cv2
+
+from ai_detector import detect_jerseys
+
+
+CSV_HEADER = ["play_id", "jersey", "assignment", "timestamp"]
+
+
+def analyze_clip(video_path: str, assignments: Dict[int, str] | None = None, *, output: str = "player_ratings.csv") -> None:
+    """Process a video clip and append results to ``output``.
+
+    The current implementation calls :func:`ai_detector.detect_jerseys` on each
+    frame and records which jerseys were seen at what time. Real movement
+    analysis and rating logic is not implemented because the required models and
+    playbook data are unavailable in this environment.
+    """
+
+    cap = cv2.VideoCapture(video_path)
+    if not cap.isOpened():
+        print(f"Unable to open {video_path}")
+        return
+
+    new_file = not os.path.exists(output)
+    with open(output, "a", newline="") as csvfile:
+        writer = csv.writer(csvfile)
+        if new_file:
+            writer.writerow(CSV_HEADER)
+
+        while True:
+            ret, frame = cap.read()
+            if not ret:
+                break
+            jerseys: List[int] = detect_jerseys(frame)
+            timestamp = cap.get(cv2.CAP_PROP_POS_MSEC) / 1000.0
+            for num in jerseys:
+                assignment = assignments.get(num, "unknown") if assignments else "unknown"
+                writer.writerow([os.path.basename(video_path), num, assignment, timestamp])
+
+    cap.release()
+
+
+def load_assignments(path: str) -> Dict[int, str]:
+    """Load a simple jersey->assignment mapping from JSON."""
+    with open(path, "r") as f:
+        data = json.load(f)
+    try:
+        return {int(k): str(v) for k, v in data.items()}
+    except Exception:
+        return {}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Rate players per play (stub)")
+    parser.add_argument("video", help="Path to a video clip")
+    parser.add_argument("--playbook", help="Path to playbook JSON", default=None)
+    parser.add_argument("--output", help="Output CSV file", default="player_ratings.csv")
+    args = parser.parse_args()
+
+    assignments = load_assignments(args.playbook) if args.playbook else {}
+    analyze_clip(args.video, assignments, output=args.output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement `assignment_analyzer.py` stub for per-play rating
- document usage in `README.md`

## Testing
- `python -m py_compile assignment_analyzer.py`

------
https://chatgpt.com/codex/tasks/task_e_6884e756a0f0832da406449824c07064