### PR TITLE
Improve FFmpeg logging in streaming scripts

### DIFF
--- a/gameday.sh
+++ b/gameday.sh
@@ -33,9 +33,10 @@ STREAM_PID=$!
 log "Starting full game recording..."
 FULLGAME_FILE="$FULL_DIR/fullgame_${TIMESTAMP}.mp4"
 LOG_FILE="$FULL_DIR/fullgame_ffmpeg.log"
-ffmpeg -f v4l2 -framerate 30 -video_size 1280x720 -i /dev/video0 \
-    -c:v libx264 -b:v 1500k -t 03:00:00 -pix_fmt yuv420p "$FULLGAME_FILE" \
-    >"$LOG_FILE" 2>&1 &
+cmd=(ffmpeg -loglevel verbose -f v4l2 -framerate 30 -video_size 1280x720 -i /dev/video0 \
+    -c:v libx264 -b:v 1500k -t 03:00:00 -pix_fmt yuv420p "$FULLGAME_FILE")
+echo "Running FFmpeg command: ${cmd[*]}" | tee "$LOG_FILE"
+"${cmd[@]}" >>"$LOG_FILE" 2>&1 &
 FFMPEG_PID=$!
 
 log "Starting highlight recorder..."

--- a/start_stream.sh
+++ b/start_stream.sh
@@ -38,13 +38,19 @@ LOG_DIR="livestream_logs"
 mkdir -p "$LOG_DIR"
 LOG_FILE="$LOG_DIR/start_stream_$(date +%Y%m%d_%H%M%S).log"
 
-exec ffmpeg \
+cmd=(ffmpeg -loglevel verbose \
     -f v4l2 -framerate 30 -video_size 1280x720 -i /dev/video0 \
     -f lavfi -i anullsrc=channel_layout=stereo:sample_rate=44100 \
     -c:v libx264 -preset veryfast -pix_fmt yuv420p \
     -maxrate 1500k -bufsize 3000k -g 60 \
     -c:a aac -b:a 128k \
-    -f flv "$YOUTUBE_URL" >"$LOG_FILE" 2>&1
+    -f flv "$YOUTUBE_URL")
+
+echo "Running FFmpeg command: ${cmd[*]}"
+"${cmd[@]}" 2>&1 | tee "$LOG_FILE"
+ret=${PIPESTATUS[0]}
+echo "ffmpeg exited with code $ret" | tee -a "$LOG_FILE"
+exit $ret
 
 # To make this script executable, run:
 # chmod +x start_stream.sh


### PR DESCRIPTION
## Summary
- add verbose logging and command prints to all ffmpeg commands
- tee output from ffmpeg processes to console and log files
- capture return codes for easier troubleshooting

## Testing
- `python -m py_compile stream_to_youtube.py overlay_engine.py smart_crop_stream.py streamer.py`
- `bash -n start_stream.sh`
- `bash -n gameday.sh`

------
https://chatgpt.com/codex/tasks/task_e_68851e7de2e4832da575d666549749db