### PR TITLE
Improve ffmpeg logging and add fallback

### DIFF
--- a/overlay_engine.py
+++ b/overlay_engine.py
@@ -141,6 +141,8 @@ def stream(device: int, rtmp_url: str, *, json_path: str = "game_state.json", po
 
     def _reader(pipe, logf):
         for line in pipe:
+            if isinstance(line, bytes):
+                line = line.decode("utf-8", errors="ignore")
             print(line, end="")
             logf.write(line)
 

--- a/smart_crop_stream.py
+++ b/smart_crop_stream.py
@@ -133,6 +133,8 @@ def main() -> None:
 
         def _reader(pipe, logf):
             for line in pipe:
+                if isinstance(line, bytes):
+                    line = line.decode("utf-8", errors="ignore")
                 print(line, end="")
                 logf.write(line)
 

--- a/streamer.py
+++ b/streamer.py
@@ -80,6 +80,8 @@ def livestream(youtube_url: str, device_index: int = 0) -> None:
 
     def _reader(pipe, logf):
         for line in pipe:
+            if isinstance(line, bytes):
+                line = line.decode("utf-8", errors="ignore")
             print(line, end="")
             logf.write(line)
 


### PR DESCRIPTION
## Summary
- decode ffmpeg output before writing to log files
- add command builder using v4l2 camera input
- retry ffmpeg with direct camera input if piping frames fails

## Testing
- `python -m py_compile stream_to_youtube.py smart_crop_stream.py streamer.py overlay_engine.py`

------
https://chatgpt.com/codex/tasks/task_e_688537a36680832dab7cfb7ec0c5c6c8