### PR TITLE
Fix ffmpeg logging bytes issue

### DIFF
--- a/overlay_engine.py
+++ b/overlay_engine.py
@@ -127,7 +127,7 @@ def stream(device: int, rtmp_url: str, *, json_path: str = "game_state.json", po
     log_dir = Path("livestream_logs")
     log_dir.mkdir(exist_ok=True)
     log_file = log_dir / f"overlay_{datetime.now().strftime('%Y%m%d_%H%M%S')}.log"
-    lf = log_file.open("w")
+    lf = log_file.open("w", encoding="utf-8", errors="ignore")
     cmd = build_ffmpeg_command(rtmp_url, (width, height), fps)
     print("Running FFmpeg command:", " ".join(cmd))
     process = subprocess.Popen(
@@ -135,14 +135,13 @@ def stream(device: int, rtmp_url: str, *, json_path: str = "game_state.json", po
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
-        text=True,
+        text=False,
         bufsize=1,
     )
 
     def _reader(pipe, logf):
-        for line in pipe:
-            if isinstance(line, bytes):
-                line = line.decode("utf-8", errors="ignore")
+        for raw in pipe:
+            line = raw.decode("utf-8", errors="ignore")
             print(line, end="")
             logf.write(line)
 

--- a/smart_crop_stream.py
+++ b/smart_crop_stream.py
@@ -120,21 +120,20 @@ def main() -> None:
         log_dir = Path("livestream_logs")
         log_dir.mkdir(exist_ok=True)
         log_file = log_dir / f"smart_crop_{timestamp}.log"
-        lf = log_file.open("w")
+        lf = log_file.open("w", encoding="utf-8", errors="ignore")
         print("Running FFmpeg command:", " ".join(cmd))
         process = subprocess.Popen(
             cmd,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
-            text=True,
+            text=False,
             bufsize=1,
         )
 
         def _reader(pipe, logf):
-            for line in pipe:
-                if isinstance(line, bytes):
-                    line = line.decode("utf-8", errors="ignore")
+            for raw in pipe:
+                line = raw.decode("utf-8", errors="ignore")
                 print(line, end="")
                 logf.write(line)
 

--- a/stream_diagnostics.py
+++ b/stream_diagnostics.py
@@ -35,12 +35,19 @@ def test_stream(url: str | None = None, *, duration: int = 5, log_path: str = "t
     ensure_ffmpeg()
 
     log_file = Path(log_path)
-    with log_file.open("w") as log:
+    with log_file.open("w", encoding="utf-8", errors="ignore") as log:
         # Ping YouTube to check network connectivity
         log.write("Pinging youtube.com...\n")
-        ping = subprocess.run(["ping", "-c", "3", "youtube.com"], capture_output=True, text=True)
-        log.write(ping.stdout)
-        log.write(ping.stderr)
+        ping = subprocess.run([
+            "ping",
+            "-c",
+            "3",
+            "youtube.com",
+        ], capture_output=True)
+        stdout = ping.stdout.decode("utf-8", errors="ignore")
+        stderr = ping.stderr.decode("utf-8", errors="ignore")
+        log.write(stdout)
+        log.write(stderr)
         if ping.returncode != 0:
             raise RuntimeError("Ping to youtube.com failed")
 
@@ -54,9 +61,11 @@ def test_stream(url: str | None = None, *, duration: int = 5, log_path: str = "t
             "-f", "flv",
             url,
         ]
-        result = subprocess.run(cmd, capture_output=True, text=True)
-        log.write(result.stdout)
-        log.write(result.stderr)
+        result = subprocess.run(cmd, capture_output=True)
+        stdout = result.stdout.decode("utf-8", errors="ignore")
+        stderr = result.stderr.decode("utf-8", errors="ignore")
+        log.write(stdout)
+        log.write(stderr)
         if result.returncode != 0:
             raise RuntimeError("ffmpeg test stream failed")
         if "frame=" not in result.stderr:

--- a/stream_to_youtube.py
+++ b/stream_to_youtube.py
@@ -189,7 +189,7 @@ def main() -> None:
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         log_file = log_dir / f"stream_{timestamp}.log"
         record_file = output_dir / f"game_{timestamp}.mp4"
-        with log_file.open("w") as lf:
+        with log_file.open("w", encoding="utf-8", errors="ignore") as lf:
             cmd = build_ffmpeg_command(url, (width, height), fps, record_file)
             print("Running FFmpeg command:", " ".join(cmd))
             process = subprocess.Popen(
@@ -197,14 +197,13 @@ def main() -> None:
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
-                text=True,
+                text=False,
                 bufsize=1,
             )
 
             def _reader(pipe, logf):
-                for line in pipe:
-                    if isinstance(line, bytes):
-                        line = line.decode("utf-8", errors="ignore")
+                for raw in pipe:
+                    line = raw.decode("utf-8", errors="ignore")
                     print(line, end="")
                     logf.write(line)
 
@@ -240,7 +239,7 @@ def main() -> None:
             try:
                 upload_game(str(record_file))
             except Exception as exc:
-                with log_file.open("a") as lf:
+                with log_file.open("a", encoding="utf-8", errors="ignore") as lf:
                     lf.write(f"\nUpload failed: {exc}\n")
             break
         time.sleep(5)

--- a/streamer.py
+++ b/streamer.py
@@ -67,21 +67,20 @@ def livestream(youtube_url: str, device_index: int = 0) -> None:
     log_dir = Path("livestream_logs")
     log_dir.mkdir(exist_ok=True)
     log_file = log_dir / f"streamer_{datetime.now().strftime('%Y%m%d_%H%M%S')}.log"
-    lf = log_file.open("w")
+    lf = log_file.open("w", encoding="utf-8", errors="ignore")
     print("Running FFmpeg command:", " ".join(command))
     process = subprocess.Popen(
         command,
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
-        text=True,
+        text=False,
         bufsize=1,
     )
 
     def _reader(pipe, logf):
-        for line in pipe:
-            if isinstance(line, bytes):
-                line = line.decode("utf-8", errors="ignore")
+        for raw in pipe:
+            line = raw.decode("utf-8", errors="ignore")
             print(line, end="")
             logf.write(line)
 


### PR DESCRIPTION
## Summary
- write ffmpeg output with utf-8 decoding and ignore bad characters
- use binary mode for ffmpeg subprocess streams
- open log files with encoding to avoid crashes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_688539ed0c6c832daa77984230d6c618