### PR TITLE
Fix ffmpeg pipe mode for streaming

### DIFF
--- a/overlay_engine.py
+++ b/overlay_engine.py
@@ -135,8 +135,8 @@ def stream(device: int, rtmp_url: str, *, json_path: str = "game_state.json", po
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
-        text=True,
-        bufsize=1,
+        text=False,
+        bufsize=0,
     )
 
     def _reader(pipe, logf):

--- a/smart_crop_stream.py
+++ b/smart_crop_stream.py
@@ -127,8 +127,8 @@ def main() -> None:
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
-            text=True,
-            bufsize=1,
+            text=False,
+            bufsize=0,
         )
 
         def _reader(pipe, logf):

--- a/stream_to_youtube.py
+++ b/stream_to_youtube.py
@@ -197,8 +197,8 @@ def main() -> None:
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
-                text=True,
-                bufsize=1,
+                text=False,
+                bufsize=0,
             )
 
             def _reader(pipe, logf):

--- a/streamer.py
+++ b/streamer.py
@@ -74,8 +74,8 @@ def livestream(youtube_url: str, device_index: int = 0) -> None:
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
-        text=True,
-        bufsize=1,
+        text=False,
+        bufsize=0,
     )
 
     def _reader(pipe, logf):


### PR DESCRIPTION
## Summary
- set subprocess pipes to binary mode so frames are sent to ffmpeg

## Testing
- `python3 -m py_compile stream_to_youtube.py overlay_engine.py smart_crop_stream.py streamer.py`

------
https://chatgpt.com/codex/tasks/task_e_688539f638c0832d9b018f192cab3e2c