### PR TITLE
Fix repeated bufsize argument

### DIFF
--- a/overlay_engine.py
+++ b/overlay_engine.py
@@ -136,7 +136,6 @@ def stream(device: int, rtmp_url: str, *, json_path: str = "game_state.json", po
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=False,
-        bufsize=1,
         bufsize=0,
     )
 

--- a/smart_crop_stream.py
+++ b/smart_crop_stream.py
@@ -128,7 +128,6 @@ def main() -> None:
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=False,
-            bufsize=1,
             bufsize=0,
         )
 

--- a/stream_to_youtube.py
+++ b/stream_to_youtube.py
@@ -198,7 +198,6 @@ def main() -> None:
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 text=False,
-                bufsize=1,
                 bufsize=0,
             )
 

--- a/streamer.py
+++ b/streamer.py
@@ -75,7 +75,6 @@ def livestream(youtube_url: str, device_index: int = 0) -> None:
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=False,
-        bufsize=1,
         bufsize=0,
     )
 


### PR DESCRIPTION
## Summary
- remove duplicate `bufsize` parameters from multiple subprocess calls

## Testing
- `python -m py_compile stream_to_youtube.py overlay_engine.py smart_crop_stream.py streamer.py`

------
https://chatgpt.com/codex/tasks/task_e_68853e36bce4832d914460e6e1b21e02