### PR TITLE
Improve FFmpeg diagnostics

### DIFF
--- a/stream_to_youtube.py
+++ b/stream_to_youtube.py
@@ -259,6 +259,7 @@ def main() -> None:
     cap.set(cv2.CAP_PROP_FRAME_WIDTH, width)
     cap.set(cv2.CAP_PROP_FRAME_HEIGHT, height)
     cap.set(cv2.CAP_PROP_FPS, fps)
+    print(f"Capture settings: {width}x{height} @ {fps}fps")
     tracker = None
     try:
         tracker = AutoTracker()
@@ -282,7 +283,7 @@ def main() -> None:
                 cmd,
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
+                stderr=subprocess.PIPE,
                 text=False,
                 bufsize=0,
             )
@@ -293,13 +294,26 @@ def main() -> None:
                     print(line, end="")
                     logf.write(line)
 
-            thread = threading.Thread(target=_reader, args=(process.stdout, lf), daemon=True)
-            thread.start()
+            thread_out = threading.Thread(target=_reader, args=(process.stdout, lf), daemon=True)
+            thread_err = threading.Thread(target=_reader, args=(process.stderr, lf), daemon=True)
+            thread_out.start()
+            thread_err.start()
+            first_frame = True
             try:
                 while True:
                     ret, frame = cap.read()
                     if not ret:
                         break
+                    if first_frame:
+                        print("Frame shape:", frame.shape, "dtype:", frame.dtype)
+                        cv2.imwrite("debug_frame.jpg", frame)
+                        if frame.shape[0] != height or frame.shape[1] != width:
+                            print(
+                                f"Warning: frame size {frame.shape[1]}x{frame.shape[0]} != {width}x{height}"
+                            )
+                        if frame.dtype != "uint8" or (len(frame.shape) > 2 and frame.shape[2] != 3):
+                            print("Warning: frame is not bgr24 format")
+                        first_frame = False
                     if tracker:
                         x, y, w, h = tracker.track(frame)
                         frame = frame[y : y + h, x : x + w]
@@ -319,7 +333,13 @@ def main() -> None:
                 if process.stdin:
                     process.stdin.close()
                 ret = process.wait()
-                thread.join()
+                thread_out.join()
+                thread_err.join()
+                if process.stderr:
+                    err_output = process.stderr.read().decode("utf-8", errors="ignore")
+                    if err_output:
+                        print(err_output)
+                        lf.write(err_output)
                 lf.write(f"\nffmpeg exited with code {ret}\n")
                 if ret != 0:
                     print("FFmpeg exited with error:", ret)

--- a/streamer.py
+++ b/streamer.py
@@ -45,6 +45,7 @@ def livestream(youtube_url: str, device_index: int = 0) -> None:
     fps = cap.get(cv2.CAP_PROP_FPS)
     if not fps or fps <= 1:
         fps = 30.0
+    print(f"Capture settings: {width}x{height} @ {fps}fps")
 
     command = [
         ensure_ffmpeg(),
@@ -73,7 +74,7 @@ def livestream(youtube_url: str, device_index: int = 0) -> None:
         command,
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
+        stderr=subprocess.PIPE,
         text=False,
         bufsize=0,
     )
@@ -84,14 +85,27 @@ def livestream(youtube_url: str, device_index: int = 0) -> None:
             print(line, end="")
             logf.write(line)
 
-    thread = threading.Thread(target=_reader, args=(process.stdout, lf), daemon=True)
-    thread.start()
+    thread_out = threading.Thread(target=_reader, args=(process.stdout, lf), daemon=True)
+    thread_err = threading.Thread(target=_reader, args=(process.stderr, lf), daemon=True)
+    thread_out.start()
+    thread_err.start()
 
+    first_frame = True
     try:
         while True:
             ret, frame = cap.read()
             if not ret:
                 break
+            if first_frame:
+                print("Frame shape:", frame.shape, "dtype:", frame.dtype)
+                cv2.imwrite("debug_frame.jpg", frame)
+                if frame.shape[0] != height or frame.shape[1] != width:
+                    print(
+                        f"Warning: frame size {frame.shape[1]}x{frame.shape[0]} != {width}x{height}"
+                    )
+                if frame.dtype != "uint8" or (len(frame.shape) > 2 and frame.shape[2] != 3):
+                    print("Warning: frame is not bgr24 format")
+                first_frame = False
             process.stdin.write(frame.tobytes())
     except KeyboardInterrupt:
         pass
@@ -100,7 +114,13 @@ def livestream(youtube_url: str, device_index: int = 0) -> None:
         if process.stdin:
             process.stdin.close()
         ret = process.wait()
-        thread.join()
+        thread_out.join()
+        thread_err.join()
+        if process.stderr:
+            err_output = process.stderr.read().decode("utf-8", errors="ignore")
+            if err_output:
+                print(err_output)
+                lf.write(err_output)
         lf.write(f"\nffmpeg exited with code {ret}\n")
         lf.close()
         if ret != 0:


### PR DESCRIPTION
## Summary
- capture and print FFmpeg stderr
- show capture configuration and save first frame as a debug image
- warn when frame size or format doesn't match bgr24

## Testing
- `python -m py_compile overlay_engine.py streamer.py smart_crop_stream.py stream_to_youtube.py`

------
https://chatgpt.com/codex/tasks/task_e_68854bb5cd10832d829d83275343ec0a