### PR TITLE
Fix FFmpeg stream initialization

### DIFF
--- a/streamer.py
+++ b/streamer.py
@@ -60,9 +60,15 @@ def livestream(youtube_url: str, device_index: int = 0) -> None:
         "-s", f"{out_width}x{out_height}",
         "-r", str(fps),
         "-i", "-",
+        "-f", "lavfi",
+        "-i", "anullsrc=channel_layout=stereo:sample_rate=44100",
+        "-map", "0:v:0",
+        "-map", "1:a:0",
         "-c:v", select_codec(),
         "-pix_fmt", "yuv420p",
         "-preset", "veryfast",
+        "-c:a", "aac",
+        "-b:a", "128k",
         "-f", "flv",
         youtube_url,
     ]
@@ -71,73 +77,90 @@ def livestream(youtube_url: str, device_index: int = 0) -> None:
     log_dir.mkdir(exist_ok=True)
     log_file = log_dir / f"streamer_{datetime.now().strftime('%Y%m%d_%H%M%S')}.log"
     lf = log_file.open("w", encoding="utf-8", errors="ignore")
-    print("Running FFmpeg command:", " ".join(command))
-    process = subprocess.Popen(
-        command,
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=False,
-        bufsize=10**8,
-    )
+    retries = 0
+    max_retries = 1
+    while True:
+        cmd_str = " ".join(command)
+        print("Running FFmpeg command:", cmd_str)
+        lf.write("Running FFmpeg command: " + cmd_str + "\n")
+        process = subprocess.Popen(
+            command,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=False,
+            bufsize=10**8,
+        )
 
-    def _reader(pipe, logf):
-        for raw in pipe:
-            line = raw.decode("utf-8", errors="ignore")
-            print(line, end="")
-            logf.write(line)
+        def _reader(pipe, logf):
+            for raw in pipe:
+                line = raw.decode("utf-8", errors="ignore")
+                print(line, end="")
+                logf.write(line)
 
-    thread_out = threading.Thread(target=_reader, args=(process.stdout, lf), daemon=True)
-    thread_err = threading.Thread(target=_reader, args=(process.stderr, lf), daemon=True)
-    thread_out.start()
-    thread_err.start()
+        thread_out = threading.Thread(target=_reader, args=(process.stdout, lf), daemon=True)
+        thread_err = threading.Thread(target=_reader, args=(process.stderr, lf), daemon=True)
+        thread_out.start()
+        thread_err.start()
 
-    first_frame = True
-    frame_count = 0
-    try:
-        while True:
-            ret, frame = cap.read()
-            if not ret or frame is None:
-                raise RuntimeError("Captured empty frame from camera")
-            if frame.shape[2] == 2:
-                frame = cv2.cvtColor(frame, cv2.COLOR_YUV2BGR_YUYV)
-            elif frame.shape[2] == 1:
-                frame = cv2.cvtColor(frame, cv2.COLOR_GRAY2BGR)
-            if frame.shape[2] != 3 or frame.dtype != np.uint8:
-                raise ValueError(
-                    f"Unexpected frame shape: {frame.shape} or dtype: {frame.dtype}"
+        first_frame = True
+        frame_count = 0
+        try:
+            while True:
+                ret, frame = cap.read()
+                if not ret or frame is None:
+                    raise RuntimeError("Captured empty frame from camera")
+                if frame.shape[2] == 2:
+                    frame = cv2.cvtColor(frame, cv2.COLOR_YUV2BGR_YUYV)
+                elif frame.shape[2] == 1:
+                    frame = cv2.cvtColor(frame, cv2.COLOR_GRAY2BGR)
+                if frame.shape[2] != 3 or frame.dtype != np.uint8:
+                    raise ValueError(
+                        f"Unexpected frame shape: {frame.shape} or dtype: {frame.dtype}"
+                    )
+                if first_frame:
+                    print("Frame shape:", frame.shape, "dtype:", frame.dtype)
+                    cv2.imwrite("debug_frame.jpg", frame)
+                    first_frame = False
+                print(
+                    f"Frame shape: {frame.shape}, dtype: {frame.dtype}, min: {frame.min()}, max: {frame.max()}"
                 )
-            if first_frame:
-                print("Frame shape:", frame.shape, "dtype:", frame.dtype)
-                cv2.imwrite("debug_frame.jpg", frame)
-                first_frame = False
-            print(
-                f"Frame shape: {frame.shape}, dtype: {frame.dtype}, min: {frame.min()}, max: {frame.max()}"
-            )
-            frame_resized = cv2.resize(frame, (out_width, out_height))
-            cv2.imshow("Debug Preview", frame_resized)
-            cv2.waitKey(1)
-            print(f"Writing frame of shape {frame_resized.shape} to FFmpeg")
-            process.stdin.write(frame_resized.astype(np.uint8).tobytes())
-            frame_count += 1
-            if frame_count % 30 == 0:
-                print(f"Sent {frame_count} frames to FFmpeg")
-    except KeyboardInterrupt:
-        pass
-    finally:
-        cap.release()
-        if process.stdin:
-            process.stdin.close()
-        ret = process.wait()
-        thread_out.join()
-        thread_err.join()
-        cv2.destroyAllWindows()
-        if process.stderr:
-            err_output = process.stderr.read().decode("utf-8", errors="ignore")
-            if err_output:
-                print(err_output)
-                lf.write(err_output)
-        lf.write(f"\nffmpeg exited with code {ret}\n")
-        lf.close()
-        if ret != 0:
-            print("FFmpeg exited with error:", ret)
+                frame_resized = cv2.resize(frame, (out_width, out_height))
+                if frame_resized.shape != (out_height, out_width, 3) or frame_resized.dtype != np.uint8:
+                    raise ValueError(
+                        f"Resized frame has shape {frame_resized.shape} and dtype {frame_resized.dtype}"
+                    )
+                cv2.imshow("Debug Preview", frame_resized)
+                cv2.waitKey(1)
+                print(f"Writing frame of shape {frame_resized.shape} to FFmpeg")
+                process.stdin.write(frame_resized.astype(np.uint8).tobytes())
+                frame_count += 1
+                if frame_count % 30 == 0:
+                    print(f"Sent {frame_count} frames to FFmpeg")
+        except KeyboardInterrupt:
+            pass
+        finally:
+            cap.release()
+            if process.stdin:
+                process.stdin.close()
+            ret = process.wait()
+            thread_out.join()
+            thread_err.join()
+            cv2.destroyAllWindows()
+            if process.stderr:
+                err_output = process.stderr.read().decode("utf-8", errors="ignore")
+                if err_output:
+                    print(err_output)
+                    lf.write(err_output)
+            lf.write(f"\nffmpeg exited with code {ret}\n")
+            lf.flush()
+            if ret != 0:
+                print("FFmpeg exited with error:", ret)
+        if ret == 0:
+            break
+        if retries < max_retries:
+            retries += 1
+            print(f"FFmpeg failed with code {ret}. Restarting (attempt {retries})")
+            continue
+        break
+    lf.close()


### PR DESCRIPTION
## Summary
- fix FFmpeg command by mapping audio/video inputs
- verify frame format before writing to FFmpeg
- log FFmpeg command to logfile
- restart streaming once on failure

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68856276dfe0832db594966a0a8afcf5