### PR TITLE
Improve YouTube stream scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ Run it with:
 python stream_to_youtube.py
 ```
 
+Additional options:
+
+```bash
+python stream_to_youtube.py --output-size 1280x720 --debug
+```
+
 ## Requirements
 
 - Python 3


### PR DESCRIPTION
## Summary
- support specifying output resolution
- log input/output frame sizes
- add ffmpeg scale+pad filters to avoid letterboxing
- optional debug mode saves a few frames before streaming

## Testing
- `python -m py_compile stream_to_youtube.py streamer.py smart_crop_stream.py`

------
https://chatgpt.com/codex/tasks/task_e_688564cc1c18832d87c20ec2422ad93e