### PR TITLE
Fix syntax errors in stream_to_youtube

### DIFF
--- a/stream_to_youtube.py
+++ b/stream_to_youtube.py
@@ -145,7 +145,6 @@ def build_v4l2_command(
     output: Path,
     *,
     device: str = "/dev/video0",
-    *,
     filters: str | None = None,
     bitrate: str,
     maxrate: str,
@@ -205,7 +204,6 @@ def build_record_command(
     output: Path,
     *,
     device: str = "/dev/video0",
-    *,
     filters: str | None = None,
     bitrate: str,
     maxrate: str,
@@ -265,6 +263,7 @@ def main() -> None:
         "--output-size",
         default=os.environ.get("OUTPUT_RESOLUTION"),
         help="stream resolution WxH, defaults to camera size or OUTPUT_RESOLUTION env",
+    )
     parser.add_argument(
         "--resolution",
         default="1280x720",


### PR DESCRIPTION
## Summary
- fix duplicate `*` argument markers in build_v4l2_command and build_record_command
- close the `--output-size` argument definition

## Testing
- `python3 -m py_compile stream_to_youtube.py`

------
https://chatgpt.com/codex/tasks/task_e_688567b38e10832d8e42b0efcff90682