### PR TITLE
Update quarter duration default

### DIFF
--- a/scoreboard_reader.py
+++ b/scoreboard_reader.py
@@ -21,7 +21,8 @@ class ScoreboardState:
     home: int = 0
     away: int = 0
     quarter: int = 1
-    clock: str = "12:00"
+    # Updated default quarter length to 8:00 minutes per INFC rules
+    clock: str = "08:00"
     down: Optional[int] = None
     distance: Optional[int] = None
 


### PR DESCRIPTION
## Summary
- update scoreboard default quarter time to 8 minutes per INFC rules

## Testing
- `python -m py_compile scoreboard_reader.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688623c046e8832d9b587db87f527aad