### PR TITLE
Fix ffmpeg scaling filter in stream_to_youtube

### DIFF
--- a/stream_to_youtube.py
+++ b/stream_to_youtube.py
@@ -326,8 +326,8 @@ def main() -> None:
     height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT) or STREAM_HEIGHT)
     out_width, out_height = STREAM_WIDTH, STREAM_HEIGHT
     filter_str = (
-        f"scale={STREAM_WIDTH}:{STREAM_HEIGHT}:force_original_aspect_ratio=decrease,"
-        f"pad={STREAM_WIDTH}:{STREAM_HEIGHT}:(ow-iw)/2:(oh-ih)/2:color=black"
+        f"scale={STREAM_WIDTH}:{STREAM_HEIGHT}:force_original_aspect_ratio=increase,"
+        f"crop={STREAM_WIDTH}:{STREAM_HEIGHT}"
     )
     fps = cap.get(cv2.CAP_PROP_FPS)
     if not fps or fps <= 1:


### PR DESCRIPTION
## Summary
- ensure captured video frames fill the 1280x720 stream
- remove padding and crop after scaling

## Testing
- `python -m py_compile stream_to_youtube.py`

------
https://chatgpt.com/codex/tasks/task_e_68862a3b32bc832d9e71da7b7cd6d7a7