### PR TITLE
Add FFmpeg pipe error handling

### DIFF
--- a/overlay_engine.py
+++ b/overlay_engine.py
@@ -37,6 +37,15 @@ def select_codec() -> str:
     return "libx264"
 
 
+def log_ffmpeg_stderr(stderr, log_file=None) -> None:
+    """Continuously read and print FFmpeg stderr."""
+    for line in stderr:
+        text = line.decode("utf-8", errors="ignore")
+        if log_file is not None:
+            log_file.write(text)
+        print("[FFMPEG]", text, end="")
+
+
 class OverlayEngine:
     """Render scoreboard information on frames."""
 
@@ -141,6 +150,9 @@ def stream(device: int, rtmp_url: str, *, json_path: str = "game_state.json", po
         text=False,
         bufsize=10**8,
     )
+    if process.poll() is not None:
+        print("FFmpeg failed to launch. Exiting...")
+        return
 
     def _reader(pipe, logf):
         for raw in pipe:
@@ -149,7 +161,7 @@ def stream(device: int, rtmp_url: str, *, json_path: str = "game_state.json", po
             logf.write(line)
 
     thread_out = threading.Thread(target=_reader, args=(process.stdout, lf), daemon=True)
-    thread_err = threading.Thread(target=_reader, args=(process.stderr, lf), daemon=True)
+    thread_err = threading.Thread(target=log_ffmpeg_stderr, args=(process.stderr, lf), daemon=True)
     thread_out.start()
     thread_err.start()
     overlay = OverlayEngine(position=position)
@@ -176,7 +188,11 @@ def stream(device: int, rtmp_url: str, *, json_path: str = "game_state.json", po
             overlay.draw(frame, state)
             frame_resized = cv2.resize(frame, (out_width, out_height))
             print(f"Writing frame of shape {frame_resized.shape} to FFmpeg")
-            process.stdin.write(frame_resized.astype(np.uint8).tobytes())
+            try:
+                process.stdin.write(frame_resized.astype(np.uint8).tobytes())
+            except BrokenPipeError:
+                print("FFmpeg pipe closed unexpectedly. Aborting stream.")
+                break
     except KeyboardInterrupt:
         pass
     finally:


### PR DESCRIPTION
## Summary
- log ffmpeg stderr output via `log_ffmpeg_stderr`
- check ffmpeg launch failure using `poll()`
- handle `BrokenPipeError` during streaming

## Testing
- `python -m py_compile streamer.py overlay_engine.py smart_crop_stream.py stream_to_youtube.py`

------
https://chatgpt.com/codex/tasks/task_e_68863064b394832da2ea061124f19737