### PR TITLE
Improve Jetson streaming pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ Run it with:
 python stream_to_youtube.py
 ```
 
+The default settings use the Jetson hardware H.264 encoder at
+1920x1080 and 30fps with a bitrate around **7.5&nbsp;Mbps**
+(YouTube's recommended range for 1080p). Output is written with `tee`
+so a local MP4 recording is saved alongside the live RTMP stream.
+
 Additional options:
 
 ```bash
@@ -74,8 +79,10 @@ Install FFmpeg on Jetson with:
 sudo apt-get update && sudo apt-get install ffmpeg
 ```
 
-For hardware-accelerated encoding, build FFmpeg with `h264_nvmpi` or
-`h264_nvv4l2enc` support.
+For best performance on Jetson devices, build FFmpeg with the Jetson
+accelerated encoders (`h264_nvmpi` or `h264_nvv4l2enc`). The streaming
+scripts automatically fall back to `libx264` when these encoders are
+unavailable.
 
 This repository contains simple utilities for analyzing football plays.
 


### PR DESCRIPTION
## Summary
- enhance instructions for Jetson hardware encoders
- update default instructions on running `stream_to_youtube.py`
- detect camera resolution via `v4l2-ctl`
- prefer Jetson H.264 encoders when available
- adjust bitrate defaults and aspect ratio filter

## Testing
- `python -m py_compile stream_to_youtube.py`
- `python -m py_compile streamer.py smart_crop_stream.py overlay_engine.py list_hw_encoders.py`


------
https://chatgpt.com/codex/tasks/task_e_688638060890832db59efc8f6d5fc978