### PR TITLE
Update streaming defaults in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ Run it with:
 python stream_to_youtube.py
 ```
 
-The default settings use the Jetson hardware H.264 encoder at
-1920x1080 and 30fps with a bitrate around **7.5&nbsp;Mbps**
-(YouTube's recommended range for 1080p). Output is written with `tee`
-so a local MP4 recording is saved alongside the live RTMP stream.
+The default settings use the software `libx264` encoder at
+1920x1080 and 30fps with a bitrate around **13.5&nbsp;Mbps**.
+Output is written with `tee` so a local MP4 recording is saved
+alongside the live RTMP stream.
 
 Additional options:
 


### PR DESCRIPTION
## Summary
- update README to describe streaming defaults after ffmpeg command changes

## Testing
- `python -m py_compile stream_to_youtube.py`


------
https://chatgpt.com/codex/tasks/task_e_6886c9cc9a1c832dacca12fc8c49604a