### PR TITLE
Update ffmpeg defaults for youtube

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ python stream_to_youtube.py
 ```
 
 The default settings use the software `libx264` encoder at
-1920x1080 and 30fps with a bitrate around **13.5&nbsp;Mbps**.
+1920x1080 and 30fps with a bitrate around **9&nbsp;Mbps**.
 Output is written with `tee` so a local MP4 recording is saved
 alongside the live RTMP stream.
 


### PR DESCRIPTION
## Summary
- tune ffmpeg for stability and fullscreen 1080p
- drop scaling filter when input already 1920x1080
- default to 9 Mbps bitrate and faster keyframes
- document new bitrate in README

## Testing
- `python -m py_compile stream_to_youtube.py`


------
https://chatgpt.com/codex/tasks/task_e_6886cb7a8260832d91a7dd831666fe59