### PR TITLE
Add periodic stream status logging

### DIFF
--- a/stream_to_youtube.py
+++ b/stream_to_youtube.py
@@ -89,6 +89,7 @@ def main() -> None:
     frame_interval = 1.0 / FPS
     frame_count = 0
     start = time.time()
+    last_log = start
 
     try:
         while True:
@@ -112,13 +113,16 @@ def main() -> None:
                 break
 
             frame_count += 1
-            if frame_count % 30 == 0:
-                elapsed = time.time() - start
+            now = time.time()
+            if now - last_log >= 5:
+                elapsed = now - start
+                minutes, seconds = divmod(int(elapsed), 60)
+                avg_fps = frame_count / elapsed if elapsed > 0 else 0.0
                 print(
-                    f"Sent {frame_count} frames in {elapsed:.2f} seconds",
-                    file=sys.stderr,
+                    f"[STREAM STATUS] \u23F1\ufe0f {minutes:02d}:{seconds:02d} | Frames Sent: {frame_count} | Avg FPS: {avg_fps:.2f}",
                     flush=True,
                 )
+                last_log = now
 
             if process.poll() is not None:
                 print(f"FFmpeg exited with code {process.returncode}")


### PR DESCRIPTION
## Summary
- enhance `stream_to_youtube.py` with live stats logging

## Testing
- `python -m py_compile stream_to_youtube.py`


------
https://chatgpt.com/codex/tasks/task_e_688771a9a9c4832d9d4b7e9ec098cd07