### PR TITLE
Upload play log alongside video

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ firefox-esr/
 
 # Video recordings
 /video/*.mp4
+video/*_play_log.csv
 video/uploaded/
 *.mp4
 *.mov

--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ The default settings use the software `libx264` encoder at
 Output is written with `tee` so a local MP4 recording is saved
 alongside the live RTMP stream.
 
+If `GDRIVE_FOLDER_ID` is set, the MP4 and a matching
+`*_play_log.csv` are uploaded to that Drive folder after streaming
+finishes. Set `GDRIVE_USE_GAME_FOLDER=1` to place both files in a
+dedicated subfolder named after the game timestamp.
+
 Additional options:
 
 ```bash


### PR DESCRIPTION
## Summary
- stream_to_youtube uploads play_log.csv to Drive in the same folder as the MP4
- optionally create a game subfolder when `GDRIVE_USE_GAME_FOLDER` is set
- document Drive upload behaviour for stream_to_youtube
- ignore generated play log files

## Testing
- `python -m py_compile stream_to_youtube.py`

------
https://chatgpt.com/codex/tasks/task_e_688774c68200832d876bc421386b574f