### PR TITLE
Add Google Drive upload to manual film pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@ This repository contains utilities for tracking play participation during a game
 
 Large video recordings (`.mp4`) are saved in the `video/` folder but individual recording files are ignored by Git. Use `upload_to_drive.py` to sync these videos to Google Drive instead of committing them.
 
+## Processing uploaded game film
+
+Place a video inside `video/manual_uploads/` and run:
+
+```bash
+python run_uploaded_film.py --video my_game.mp4 --purge_after True
+```
+
+The clip is analyzed locally and both the raw video and summary JSON are uploaded to Google Drive. The local video is removed only after a successful upload while the logs remain under `output/summary/` and `output/manual_logs/`.
+
 ## play_count_tracker.py
 
 `play_count_tracker.py` is a command line tool for recording which players were on the field for each play. It now supports optional in-game alerts, SMS notifications and quarter summaries. After each play, type the jersey numbers separated by spaces. Enter `q` to finish. A log is written to `jersey_counts.csv` and the final play counts are printed with color-coded warnings for any player under the threshold.

--- a/gdrive_utils.py
+++ b/gdrive_utils.py
@@ -1,0 +1,84 @@
+"""Google Drive upload helpers using PyDrive."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+try:
+    from pydrive.auth import GoogleAuth
+    from pydrive.drive import GoogleDrive
+except Exception as exc:  # pragma: no cover - optional import
+    raise ImportError(
+        "PyDrive is required for Google Drive uploads"
+    ) from exc
+
+TOKEN_FILE = "drive_token.json"
+
+
+def _get_drive() -> GoogleDrive:
+    """Authenticate and return a ``GoogleDrive`` instance."""
+    gauth = GoogleAuth()
+    gauth.LoadCredentialsFile(TOKEN_FILE)
+    if gauth.credentials is None:
+        if os.getenv("DISPLAY"):
+            try:
+                gauth.LocalWebserverAuth()
+            except Exception:
+                gauth.CommandLineAuth()
+        else:
+            gauth.CommandLineAuth()
+    elif gauth.access_token_expired:
+        gauth.Refresh()
+    gauth.SaveCredentialsFile(TOKEN_FILE)
+    return GoogleDrive(gauth)
+
+
+def _ensure_folder(drive: GoogleDrive, name: str) -> str:
+    """Return folder ID for ``name``, creating it if necessary."""
+    query = (
+        f"title='{name}' and mimeType='application/vnd.google-apps.folder' and trashed=false"
+    )
+    results = drive.ListFile({"q": query}).GetList()
+    if results:
+        return results[0]["id"]
+    meta = {"title": name, "mimeType": "application/vnd.google-apps.folder"}
+    folder = drive.CreateFile(meta)
+    folder.Upload()
+    return folder["id"]
+
+
+def upload_to_google_drive(local_path: str | Path, drive_folder: str | None = None) -> bool:
+    """Upload ``local_path`` to Google Drive.
+
+    Parameters
+    ----------
+    local_path:
+        File path to upload.
+    drive_folder:
+        Optional Drive folder name to place the file in. The folder is created if
+        it does not exist.
+
+    Returns
+    -------
+    bool
+        ``True`` on success, ``False`` otherwise.
+    """
+    try:
+        drive = _get_drive()
+        path = Path(local_path)
+        meta = {"title": path.name}
+        if drive_folder:
+            folder_id = _ensure_folder(drive, drive_folder)
+            meta["parents"] = [{"id": folder_id}]
+        gfile = drive.CreateFile(meta)
+        gfile.SetContentFile(str(path))
+        gfile.Upload()
+        view_url = f"https://drive.google.com/file/d/{gfile['id']}/view"
+        print(f"Uploaded {path.name} -> {view_url}")
+        return True
+    except Exception as exc:  # pragma: no cover - network/auth
+        print(f"Failed to upload {local_path}: {exc}")
+        return False
+
+__all__ = ["upload_to_google_drive"]

--- a/run_uploaded_film.py
+++ b/run_uploaded_film.py
@@ -10,9 +10,14 @@ def main() -> None:
         required=True,
         help="Video file name within video/manual_uploads",
     )
+    parser.add_argument(
+        "--purge_after",
+        action="store_true",
+        help="Delete local video after successful upload",
+    )
     args = parser.parse_args()
     video_path = Path("video/manual_uploads") / args.video
-    process_uploaded_game_film(str(video_path))
+    process_uploaded_game_film(str(video_path), purge_after=args.purge_after)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- allow manual game film processing to upload results to Google Drive
- new helper `gdrive_utils.upload_to_google_drive`
- keep log files locally and optionally purge the uploaded video
- update CLI helper and README for instructions

## Testing
- `python -m py_compile gdrive_utils.py manual_video_processor.py run_uploaded_film.py`
- ❌ `pip install PyDrive` *(fails: Tunnel connection failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_688792830328832da1dbee9ea301f27e