### PR TITLE
Add pipeline log capture

### DIFF
--- a/process_all_uploaded_videos.py
+++ b/process_all_uploaded_videos.py
@@ -1,7 +1,18 @@
 from __future__ import annotations
 
+import sys
 import os
+from datetime import datetime
 from pathlib import Path
+
+log_dir = "/logs/pipeline"
+os.makedirs(log_dir, exist_ok=True)
+timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+log_path = os.path.join(log_dir, f"run_{timestamp}.log")
+original_stdout = sys.stdout
+original_stderr = sys.stderr
+sys.stdout = open(log_path, "w")
+sys.stderr = sys.stdout
 
 from gdrive_utils import upload_to_google_drive
 from manual_video_processor import process_uploaded_game_film
@@ -58,3 +69,7 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+    sys.stdout.close()
+    sys.stdout = original_stdout
+    sys.stderr = original_stderr
+    print(f"[✅] Log saved at: {log_path}")

--- a/run_uploaded_film.py
+++ b/run_uploaded_film.py
@@ -1,5 +1,18 @@
+import sys
+import os
+from datetime import datetime
 import argparse
 from pathlib import Path
+
+log_dir = "/logs/pipeline"
+os.makedirs(log_dir, exist_ok=True)
+timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+log_path = os.path.join(log_dir, f"run_{timestamp}.log")
+original_stdout = sys.stdout
+original_stderr = sys.stderr
+sys.stdout = open(log_path, "w")
+sys.stderr = sys.stdout
+
 from manual_video_processor import process_uploaded_game_film
 
 
@@ -22,3 +35,7 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+    sys.stdout.close()
+    sys.stdout = original_stdout
+    sys.stderr = original_stderr
+    print(f"[✅] Log saved at: {log_path}")


### PR DESCRIPTION
## Summary
- log all console output for `process_all_uploaded_videos.py` and `run_uploaded_film.py`
- store logs in `/logs/pipeline` with timestamped filenames

## Testing
- `python -m py_compile process_all_uploaded_videos.py run_uploaded_film.py`

------
https://chatgpt.com/codex/tasks/task_e_6887ac7de51c832db75a7275b64d166c