### PR TITLE
Implement play frame snapshot dataset

### DIFF
--- a/run_uploaded_film.py
+++ b/run_uploaded_film.py
@@ -28,9 +28,19 @@ def main() -> None:
         action="store_true",
         help="Delete local video after successful upload",
     )
+    parser.add_argument(
+        "--max_frames_per_play",
+        type=int,
+        default=2,
+        help="Maximum training frames to save per play",
+    )
     args = parser.parse_args()
     video_path = Path("video/manual_uploads") / args.video
-    process_uploaded_game_film(str(video_path), purge_after=args.purge_after)
+    process_uploaded_game_film(
+        str(video_path),
+        purge_after=args.purge_after,
+        max_frames_per_play=args.max_frames_per_play,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- create training frame and label directories
- capture start and midpoint frames for each detected play
- store JSON labels alongside saved frames
- allow run_uploaded_film to configure frames saved per play

## Testing
- `python -m py_compile manual_video_processor.py run_uploaded_film.py`

------
https://chatgpt.com/codex/tasks/task_e_6887bae76d28832dbfe8dd489477c6c3