### PR TITLE
Add review queue for failed detections

### DIFF
--- a/ai_detector.py
+++ b/ai_detector.py
@@ -13,6 +13,9 @@ except Exception:  # pragma: no cover - optional dependency
     pytesseract = None  # type: ignore
 
 
+from review_queue import add_entry
+
+
 def extract_jersey_number(
     frame: np.ndarray,
     player_bbox: Tuple[int, int, int, int],
@@ -21,6 +24,7 @@ def extract_jersey_number(
     frame_id: Optional[int] = None,
     bbox_id: Optional[int] = None,
     timestamp: Optional[str] = None,
+    play_id: Optional[int] = None,
 ) -> Tuple[str | None, float]:
     """Return jersey number string and OCR confidence.
 
@@ -101,6 +105,16 @@ def extract_jersey_number(
 
         with open(label_path, "w", encoding="utf-8") as f:
             json.dump(labels, f, indent=2)
+
+        add_entry(
+            {
+                "type": "uncertain_jersey",
+                "frame": str(out_dir / fname),
+                "bbox": [int(x1), int(y1), int(x2 - x1), int(y2 - y1)],
+                "play_id": play_id,
+                "timestamp": timestamp or "",
+            }
+        )
 
     return result, best_conf
 

--- a/review_queue.py
+++ b/review_queue.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List
+import json
+
+QUEUE_PATH = Path("training/review_queue.json")
+
+
+def _load_queue() -> List[Dict[str, Any]]:
+    try:
+        with open(QUEUE_PATH, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if isinstance(data, list):
+            return data
+    except Exception:
+        pass
+    return []
+
+
+def add_entry(entry: Dict[str, Any]) -> None:
+    queue = _load_queue()
+    for existing in queue:
+        if existing.get("frame") == entry.get("frame"):
+            return
+        if entry.get("timestamp") and existing.get("timestamp") == entry.get("timestamp"):
+            return
+    queue.append(entry)
+    QUEUE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with open(QUEUE_PATH, "w", encoding="utf-8") as f:
+        json.dump(queue, f, indent=2)
+
+
+def queue_length() -> int:
+    return len(_load_queue())


### PR DESCRIPTION
## Summary
- track unclear jersey detections and unknown plays in `training/review_queue.json`
- add helper module `review_queue.py`
- include play_id when extracting jersey numbers
- record unknown plays and print pending count after processing

## Testing
- `python -m py_compile manual_video_processor.py ai_detector.py review_queue.py`
- `python -m pip install opencv-python-headless` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6887bc1629cc832d81e2ad33705897ae