### PR TITLE
Add learning statistics logging and retraining bundle option

### DIFF
--- a/process_all_uploaded_videos.py
+++ b/process_all_uploaded_videos.py
@@ -4,6 +4,7 @@ import sys
 import os
 from datetime import datetime
 from pathlib import Path
+import argparse
 
 log_dir = "/logs/pipeline"
 os.makedirs(log_dir, exist_ok=True)
@@ -23,6 +24,14 @@ SUMMARY_DIR = Path("output/summary")
 
 
 def main() -> None:
+    parser = argparse.ArgumentParser(description="Process all uploaded videos")
+    parser.add_argument(
+        "--prepare_retrain",
+        action="store_true",
+        help="Create retraining bundle after processing each video",
+    )
+    args = parser.parse_args()
+
     videos = [p for p in UPLOAD_DIR.iterdir() if p.suffix.lower() in {".mp4", ".mov"}]
     print(f"Found {len(videos)} video(s) to process\n")
 
@@ -32,7 +41,9 @@ def main() -> None:
     for video in videos:
         print(f"Processing {video.name}...")
         try:
-            process_uploaded_game_film(str(video), purge_after=False)
+            process_uploaded_game_film(
+                str(video), purge_after=False, prepare_retrain=args.prepare_retrain
+            )
         except Exception as exc:
             print(f"⚠️ Failed to process {video.name}: {exc}")
             retained.append(video.name)

--- a/run_uploaded_film.py
+++ b/run_uploaded_film.py
@@ -34,12 +34,18 @@ def main() -> None:
         default=2,
         help="Maximum training frames to save per play",
     )
+    parser.add_argument(
+        "--prepare_retrain",
+        action="store_true",
+        help="Create retraining bundle after processing",
+    )
     args = parser.parse_args()
     video_path = Path("video/manual_uploads") / args.video
     process_uploaded_game_film(
         str(video_path),
         purge_after=args.purge_after,
         max_frames_per_play=args.max_frames_per_play,
+        prepare_retrain=args.prepare_retrain,
     )
 
 


### PR DESCRIPTION
## Summary
- track OCR failures and training frames in `manual_video_processor`
- write detailed learning stats JSON per video
- append to running `self_learning_log.json`
- add optional `--prepare_retrain` flag to bundle training data
- expose new flag via `run_uploaded_film.py` and `process_all_uploaded_videos.py`

## Testing
- `python -m py_compile manual_video_processor.py run_uploaded_film.py process_all_uploaded_videos.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6887be31d0c0832dbd0e7b55aab1b858