### PR TITLE
Fix logging path permissions

### DIFF
--- a/clean_labels.py
+++ b/clean_labels.py
@@ -5,11 +5,11 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Tuple
 
-JERSEY_PATH = Path("/training/labels/confirmed_jerseys.json")
-PLAY_PATH = Path("/training/labels/confirmed_play_types.json")
-CLEANED_JERSEY_PATH = Path("/training/labels/cleaned_jerseys.json")
-CLEANED_PLAY_PATH = Path("/training/labels/cleaned_play_types.json")
-LOG_PATH = Path("/training/logs/label_cleaning_log.json")
+JERSEY_PATH = Path("./training/labels/confirmed_jerseys.json")
+PLAY_PATH = Path("./training/labels/confirmed_play_types.json")
+CLEANED_JERSEY_PATH = Path("./training/labels/cleaned_jerseys.json")
+CLEANED_PLAY_PATH = Path("./training/labels/cleaned_play_types.json")
+LOG_PATH = Path("./training/logs/label_cleaning_log.json")
 
 
 def load_entries(path: Path) -> List[Dict]:

--- a/coach_review_app.py
+++ b/coach_review_app.py
@@ -4,12 +4,12 @@ from datetime import datetime
 import streamlit as st
 
 
-OCR_REVIEW_PATH = Path('/training/labels/ocr_review.json')
-CONFIRMED_JERSEYS_PATH = Path('/training/labels/confirmed_jerseys.json')
-UNCERTAIN_DIR = Path('/training/uncertain_jerseys')
-LABELS_DIR = Path('/training/labels')
-FRAMES_DIR = Path('/training/frames')
-CONFIRMED_PLAYS_PATH = Path('/training/labels/confirmed_play_types.json')
+OCR_REVIEW_PATH = Path('./training/labels/ocr_review.json')
+CONFIRMED_JERSEYS_PATH = Path('./training/labels/confirmed_jerseys.json')
+UNCERTAIN_DIR = Path('./training/uncertain_jerseys')
+LABELS_DIR = Path('./training/labels')
+FRAMES_DIR = Path('./training/frames')
+CONFIRMED_PLAYS_PATH = Path('./training/labels/confirmed_play_types.json')
 
 
 st.set_page_config(page_title='Coach Review', layout='wide')

--- a/manual_video_processor.py
+++ b/manual_video_processor.py
@@ -292,7 +292,7 @@ def process_uploaded_game_film(
         print(f"\u2705 Retraining bundle created: {bundle_path.name}")
 
     print(
-        f"\u26a0\ufe0f  Review queue updated: {queue_length()} items pending in /training/review_queue.json"
+        f"\u26a0\ufe0f  Review queue updated: {queue_length()} items pending in ./training/review_queue.json"
     )
 
 

--- a/process_all_uploaded_videos.py
+++ b/process_all_uploaded_videos.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from pathlib import Path
 import argparse
 
-log_dir = "/logs/pipeline"
+log_dir = "./logs/pipeline"
 os.makedirs(log_dir, exist_ok=True)
 timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
 log_path = os.path.join(log_dir, f"run_{timestamp}.log")

--- a/retrain_models.py
+++ b/retrain_models.py
@@ -6,7 +6,7 @@ from typing import Dict, List
 
 
 def load_confirmed_jerseys() -> List[Dict[str, str]]:
-    path = Path("/training/labels/confirmed_jerseys.json")
+    path = Path("./training/labels/confirmed_jerseys.json")
     try:
         with open(path, "r", encoding="utf-8") as f:
             data = json.load(f)
@@ -17,12 +17,12 @@ def load_confirmed_jerseys() -> List[Dict[str, str]]:
     for item in data:
         fname = item.get("filename")
         if fname:
-            item["image_path"] = str(Path("/training/uncertain_jerseys") / fname)
+            item["image_path"] = str(Path("./training/uncertain_jerseys") / fname)
     return data
 
 
 def load_confirmed_play_types() -> List[Dict[str, str]]:
-    path = Path("/training/labels/confirmed_play_types.json")
+    path = Path("./training/labels/confirmed_play_types.json")
     try:
         with open(path, "r", encoding="utf-8") as f:
             data = json.load(f)
@@ -33,7 +33,7 @@ def load_confirmed_play_types() -> List[Dict[str, str]]:
     for item in data:
         fname = item.get("filename")
         if fname:
-            item["image_path"] = str(Path("/training/frames") / fname)
+            item["image_path"] = str(Path("./training/frames") / fname)
     return data
 
 

--- a/run_uploaded_film.py
+++ b/run_uploaded_film.py
@@ -4,7 +4,7 @@ from datetime import datetime
 import argparse
 from pathlib import Path
 
-log_dir = "/logs/pipeline"
+log_dir = "./logs/pipeline"
 os.makedirs(log_dir, exist_ok=True)
 timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
 log_path = os.path.join(log_dir, f"run_{timestamp}.log")


### PR DESCRIPTION
## Summary
- write logs into `./logs` instead of `/logs`
- use project-relative paths under `./training`
- update message in manual_video_processor

## Testing
- `python -m py_compile run_uploaded_film.py process_all_uploaded_videos.py clean_labels.py coach_review_app.py retrain_models.py manual_video_processor.py`

------
https://chatgpt.com/codex/tasks/task_e_6887cc3ebab0832d8d81db692c6f5c2c