### PR TITLE
Improve Google Drive OAuth handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,9 +168,10 @@ python youtube_uploader.py --file path/to/video.mp4 --title "My Title" \
 ## upload_to_drive.py
 
 `upload_to_drive.py` sends finished recordings to Google Drive using
-[PyDrive](https://github.com/googledrive/PyDrive). The first run will prompt for
-OAuth2 authentication and store credentials in `drive_token.json`. Set the
-destination folder ID with the `GDRIVE_FOLDER_ID` environment variable:
+[PyDrive](https://github.com/googledrive/PyDrive). The first run requires a
+`client_secrets.json` OAuth file in this directory. After authenticating,
+credentials are stored in `drive_token.json` so future runs reuse them.
+Set the destination folder ID with the `GDRIVE_FOLDER_ID` environment variable:
 
 ```bash
 export GDRIVE_FOLDER_ID=your_folder_id

--- a/gdrive_utils.py
+++ b/gdrive_utils.py
@@ -19,17 +19,33 @@ TOKEN_FILE = "drive_token.json"
 def _get_drive() -> GoogleDrive:
     """Authenticate and return a ``GoogleDrive`` instance."""
     gauth = GoogleAuth()
-    gauth.LoadCredentialsFile(TOKEN_FILE)
+
+    # Attempt to load existing credentials
+    try:
+        gauth.LoadCredentialsFile(TOKEN_FILE)
+    except Exception:
+        print("[\u26A0\uFE0F] No drive_token.json found. Starting OAuth flow.")
+
     if gauth.credentials is None:
-        if os.getenv("DISPLAY"):
-            try:
+        if not os.path.exists("client_secrets.json"):
+            print("[\u274C] Missing client_secrets.json. Cannot authenticate with Google Drive.")
+            print("Visit https://console.cloud.google.com to create and download it.")
+            raise RuntimeError("client_secrets.json missing")
+
+        try:
+            if os.getenv("DISPLAY"):
                 gauth.LocalWebserverAuth()
-            except Exception:
+            else:
                 gauth.CommandLineAuth()
-        else:
-            gauth.CommandLineAuth()
-    elif gauth.access_token_expired:
-        gauth.Refresh()
+            gauth.SaveCredentialsFile(TOKEN_FILE)
+            print("[\u2705] OAuth success. Credentials saved to drive_token.json")
+        except Exception as exc:
+            raise RuntimeError(f"Google Drive login failed: {exc}") from exc
+    else:
+        if gauth.access_token_expired:
+            gauth.Refresh()
+        gauth.Authorize()
+
     gauth.SaveCredentialsFile(TOKEN_FILE)
     return GoogleDrive(gauth)
 


### PR DESCRIPTION
## Summary
- improve Google Drive authentication logic
- update drive helper to handle missing `client_secrets.json`
- store OAuth token in `drive_token.json` for reuse
- clarify setup instructions in README

## Testing
- `python -m py_compile gdrive_utils.py upload_to_drive.py`

------
https://chatgpt.com/codex/tasks/task_e_6887d6f3c408832db675eeacd8c7d1b7