### PR TITLE
Add debug logs and pipe error handling

### DIFF
--- a/stream_to_youtube.py
+++ b/stream_to_youtube.py
@@ -364,6 +364,10 @@ def main() -> None:
         while True:
             loop_start = time.time()
             ret, frame = cap.read()
+            if not ret:
+                print("[ERROR] Failed to grab frame from camera")
+            else:
+                print(f"[DEBUG] Captured frame shape: {frame.shape}")
             now = time.time()
             if ret and frame is not None:
                 fps_counter += 1
@@ -482,12 +486,8 @@ def main() -> None:
                     process.stdin.write(frame.tobytes())
                     process.stdin.flush()
                 except BrokenPipeError:
-                    print("[\u274C ERROR] FFmpeg pipe closed (BrokenPipeError)")
-                    print("\a", end="")
-                    ffmpeg_error = True
-                    if process.poll() is not None:
-                        process.wait()
-                    process = None
+                    print("[ERROR] FFmpeg pipe broken. Check if FFmpeg process is running.")
+                    break
 
             frame_count += 1
             now = time.time()


### PR DESCRIPTION
## Summary
- log captured frame shape and notify when frames fail to grab
- break the main loop if the FFmpeg input pipe is broken

## Testing
- `python -m py_compile stream_to_youtube.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688a0d403558832d99096f4c15a3d44c