### PR TITLE
Add game folder creation for Drive uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,11 @@ Output is written with `tee` so a local MP4 recording is saved
 alongside the live RTMP stream.
 
 If `GDRIVE_FOLDER_ID` is set, the MP4 and a matching
-`*_play_log.csv` are uploaded to that Drive folder after streaming
-finishes. Set `GDRIVE_USE_GAME_FOLDER=1` to place both files in a
-dedicated subfolder named after the game timestamp.
+`*_play_log.csv` are uploaded to Google Drive after streaming
+finishes. A new folder is created for each game using the pattern
+`TEAM_NAME_YYYY-MM-DD_vs_OPPONENT`. The opponent name and game date can
+be provided via the `OPPONENT` and `GAME_DATE` environment variables
+(the script prompts for the opponent if unset).
 
 Additional options:
 


### PR DESCRIPTION
## Summary
- create per-game Google Drive folder named after date and opponent
- make highlight clips upload to a `highlights` subfolder
- update README with new environment variables

## Testing
- `python -m py_compile stream_to_youtube.py`

------
https://chatgpt.com/codex/tasks/task_e_688a36ca1708832dbd645c850abe6155