### PR TITLE
Add live dashboard for play predictions

### DIFF
--- a/live_dashboard.py
+++ b/live_dashboard.py
@@ -1,0 +1,114 @@
+import sqlite3
+import threading
+import time
+from pathlib import Path
+from typing import Iterable
+
+from flask import Flask, jsonify, redirect, render_template, request, url_for
+
+DB_PATH = Path("output/live_play_log.db")
+CLIP_DIR = Path("video/highlights")
+
+app = Flask(__name__)
+
+
+def get_db() -> sqlite3.Connection:
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def init_db() -> None:
+    DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    conn = get_db()
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS predictions ("
+        "id INTEGER PRIMARY KEY AUTOINCREMENT,"
+        "timestamp TEXT, label TEXT, confidence REAL)"
+    )
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS scoreboard ("
+        "id INTEGER PRIMARY KEY CHECK(id=1), home TEXT, away TEXT)"
+    )
+    conn.execute(
+        "INSERT OR IGNORE INTO scoreboard(id, home, away) VALUES (1, '0', '0')"
+    )
+    conn.commit()
+    conn.close()
+
+
+_last_ts: float | None = None
+
+
+def classify_clip(path: Path) -> tuple[str, float]:
+    """Placeholder classifier returning a deterministic pseudo-random label."""
+    import random
+
+    labels = ["Jet Sweep", "Dive", "Power R", "Pass", "Screen"]
+    random.seed(path.stat().st_mtime)
+    label = random.choice(labels)
+    confidence = random.uniform(0.75, 0.99)
+    return label, confidence
+
+
+def new_clips() -> Iterable[Path]:
+    global _last_ts
+    clips = sorted(CLIP_DIR.glob("*.mp4"), key=lambda p: p.stat().st_mtime)
+    for clip in clips:
+        mtime = clip.stat().st_mtime
+        if _last_ts is None or mtime > _last_ts:
+            _last_ts = mtime
+            yield clip
+
+
+def classifier_loop() -> None:
+    CLIP_DIR.mkdir(parents=True, exist_ok=True)
+    while True:
+        for clip in new_clips():
+            label, conf = classify_clip(clip)
+            ts = time.strftime("%H:%M:%S")
+            conn = get_db()
+            conn.execute(
+                "INSERT INTO predictions(timestamp, label, confidence) VALUES (?,?,?)",
+                (ts, label, conf),
+            )
+            conn.commit()
+            conn.close()
+        time.sleep(10)
+
+
+@app.route("/", methods=["GET", "POST"])
+def index():
+    conn = get_db()
+    if request.method == "POST":
+        home = request.form.get("home", "0")
+        away = request.form.get("away", "0")
+        conn.execute("UPDATE scoreboard SET home=?, away=? WHERE id=1", (home, away))
+        conn.commit()
+        return redirect(url_for("index"))
+
+    preds = conn.execute(
+        "SELECT timestamp, label, confidence FROM predictions ORDER BY id DESC"
+    ).fetchall()
+    score = conn.execute("SELECT home, away FROM scoreboard WHERE id=1").fetchone()
+    conn.close()
+    log = [dict(r) for r in preds][::-1]
+    latest = log[-1] if log else None
+    return render_template("dashboard.html", log=log, latest=latest, score=score)
+
+
+@app.route("/data.json")
+def data_json():
+    conn = get_db()
+    rows = conn.execute(
+        "SELECT label, COUNT(*) as count FROM predictions GROUP BY label"
+    ).fetchall()
+    conn.close()
+    return jsonify({r["label"]: r["count"] for r in rows})
+
+
+if __name__ == "__main__":
+    init_db()
+    thread = threading.Thread(target=classifier_loop, daemon=True)
+    thread.start()
+    app.run(host="0.0.0.0", port=5000)

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Live Dashboard</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        table { border-collapse: collapse; width: 100%; }
+        th, td { border: 1px solid #ddd; padding: 8px; }
+        th { background-color: #f2f2f2; }
+    </style>
+</head>
+<body>
+<h1>Live Play Dashboard</h1>
+<div>
+    <h2>Scoreboard</h2>
+    <form method="post">
+        Home: <input type="text" name="home" value="{{ score['home'] }}" size="3">
+        Away: <input type="text" name="away" value="{{ score['away'] }}" size="3">
+        <button type="submit">Update</button>
+    </form>
+    <p>{{ score['home'] }} - {{ score['away'] }}</p>
+</div>
+
+<div>
+    <h2>Most Recent Prediction</h2>
+    {% if latest %}
+    <p><strong>{{ latest.label }}</strong> ({{ '%.2f'|format(latest.confidence) }}) at {{ latest.timestamp }}</p>
+    {% else %}
+    <p>No predictions yet.</p>
+    {% endif %}
+</div>
+
+<div>
+    <h2>Play Type Distribution</h2>
+    <canvas id="pie" width="400" height="400"></canvas>
+</div>
+
+<div>
+    <h2>Play Log</h2>
+    <table>
+        <tr><th>Timestamp</th><th>Label</th><th>Confidence</th></tr>
+        {% for row in log %}
+        <tr>
+            <td>{{ row.timestamp }}</td>
+            <td>{{ row.label }}</td>
+            <td>{{ '%.2f'|format(row.confidence) }}</td>
+        </tr>
+        {% endfor %}
+    </table>
+</div>
+
+<script>
+function loadData() {
+    fetch('/data.json').then(r => r.json()).then(data => {
+        const labels = Object.keys(data);
+        const counts = Object.values(data);
+        new Chart(document.getElementById('pie'), {
+            type: 'pie',
+            data: { labels: labels, datasets: [{ data: counts, backgroundColor: ['#4e79a7','#f28e2b','#e15759','#76b7b2','#59a14f','#edc949'] }] },
+            options: { responsive: true }
+        });
+    });
+}
+loadData();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement `live_dashboard.py` to show play predictions in realtime
- add background classifier loop stub
- create HTML template for dashboard with pie chart and log

## Testing
- `python -m py_compile live_dashboard.py`

------
https://chatgpt.com/codex/tasks/task_e_688a45457504832daca2391d8a437e56