### PR TITLE
Update reclassify_old_clips

### DIFF
--- a/reclassify_old_clips.py
+++ b/reclassify_old_clips.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import argparse
 import csv
 import json
-import time
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List
@@ -17,32 +16,25 @@ except Exception:  # pragma: no cover - optional
 
 from play_inference import ToFloatNormalize, load_model, read_clip
 
-LOG_PATH = Path("training/logs/learning_log.json")
+LOG_PATH = Path("logs/learning_log.json")
 
 
 def load_dataset(path: Path) -> List[Dict[str, Any]]:
-    """Load clip metadata from CSV or JSON."""
-    if path.suffix.lower() == ".csv":
-        with open(path, newline="") as f:
-            reader = csv.DictReader(f)
-            return list(reader)
-    with open(path) as f:
-        return json.load(f)
+    """Load clip metadata from CSV."""
+    with open(path, newline="") as f:
+        reader = csv.DictReader(f)
+        return list(reader)
 
 
 def save_dataset(path: Path, rows: List[Dict[str, Any]]) -> None:
-    """Write updated metadata."""
-    if path.suffix.lower() == ".csv":
-        if not rows:
-            return
-        fieldnames = list(rows[0].keys())
-        with open(path, "w", newline="") as f:
-            writer = csv.DictWriter(f, fieldnames=fieldnames)
-            writer.writeheader()
-            writer.writerows(rows)
-    else:
-        with open(path, "w", encoding="utf-8") as f:
-            json.dump(rows, f, indent=2)
+    """Write updated metadata back to the CSV."""
+    if not rows:
+        return
+    fieldnames = list(rows[0].keys())
+    with open(path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
 
 
 def find_latest_model(dir_path: Path) -> Path:
@@ -71,8 +63,7 @@ def reclassify(
     dataset_path: Path,
     model_dir: Path = Path("models/play_classifier"),
     clip_len: int = 16,
-    rename: bool = False,
-    regenerate_summary: bool = False,
+    dry_run: bool = False,
 ) -> None:
     """Reclassify clips and update labels if predictions change."""
     if torch is None:
@@ -88,10 +79,16 @@ def reclassify(
     model, inv_map = load_model(str(model_path), device)
     transform = transforms.Compose([transforms.Resize((224, 224)), ToFloatNormalize()])
 
+    dataset_dir = dataset_path.parent
     updated = False
     for item in entries:
-        clip_path = Path(item["filepath"])
+        rel_clip = Path(item["filepath"])
+        clip_path = rel_clip if rel_clip.is_absolute() else dataset_dir / rel_clip
         old_label = item.get("label", "")
+        player = item.get("player", "")
+        quarter = item.get("quarter", "")
+        time_code = item.get("time", "")
+
         clip = read_clip(clip_path, clip_len, transform)
         clip = clip.unsqueeze(0).to(device)
         with torch.no_grad():
@@ -99,67 +96,50 @@ def reclassify(
         pred_idx = output.argmax(1).item()
         new_label = inv_map.get(pred_idx, "unknown")
         if new_label != old_label:
-            print(f"[update] {clip_path.name}: {old_label} -> {new_label}")
-            item["label"] = new_label
-            log_entry = {
-                "clip": str(clip_path),
-                "old_label": old_label,
-                "new_label": new_label,
-                "timestamp": datetime.now().isoformat(timespec="seconds"),
-            }
-            append_log(log_entry)
+            print(f"Updated: {item['filepath']} | {old_label} → {new_label}")
             updated = True
-            if rename:
-                new_path = clip_path.with_name(f"{clip_path.stem}_{new_label}{clip_path.suffix}")
+            if not dry_run:
+                item["label"] = new_label
+                new_name = f"{new_label.replace(' ', '_')}_{player.replace(' ', '')}_Q{quarter}_{time_code}{clip_path.suffix}"
+                new_path = clip_path.with_name(new_name)
+                new_path.parent.mkdir(parents=True, exist_ok=True)
                 clip_path.rename(new_path)
-                item["filepath"] = str(new_path)
+                # store path relative to dataset directory
+                try:
+                    item["filepath"] = str(new_path.relative_to(dataset_dir))
+                except ValueError:
+                    item["filepath"] = str(new_path)
 
-    if updated:
+                log_entry = {
+                    "clip": clip_path.name,
+                    "old_label": old_label,
+                    "new_label": new_label,
+                    "timestamp": datetime.now().isoformat(timespec="seconds"),
+                }
+                append_log(log_entry)
+
+    if updated and not dry_run:
         save_dataset(dataset_path, entries)
-        if regenerate_summary:
-            try:
-                from generate_coaches_cut_and_summary import generate_summary
-
-                generate_summary(Path("analysis"))
-            except Exception:
-                print("[!] Failed to regenerate summary report")
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Reclassify highlight clips")
-    parser.add_argument("dataset", help="Path to CSV or JSON with clip metadata")
     parser.add_argument(
-        "--model_dir", default="models/play_classifier", help="Directory with model checkpoints"
+        "dataset",
+        default="data/highlights/labels.csv",
+        nargs="?",
+        help="Path to CSV with clip metadata",
+    )
+    parser.add_argument(
+        "--model_dir",
+        default="models/play_classifier",
+        help="Directory with model checkpoints",
     )
     parser.add_argument("--clip_len", type=int, default=16)
-    parser.add_argument("--rename", action="store_true", help="Rename clip when label changes")
-    parser.add_argument(
-        "--summary", action="store_true", help="Regenerate summary report if any label changes"
-    )
-    parser.add_argument(
-        "--schedule", action="store_true", help="Run weekly instead of once"
-    )
+    parser.add_argument("--dry-run", action="store_true", help="Preview changes without modifying files")
     args = parser.parse_args()
 
-    if args.schedule:
-        try:
-            import schedule
-        except Exception:
-            raise ImportError("schedule package is required for --schedule option")
-
-        schedule.every().week.do(
-            reclassify,
-            Path(args.dataset),
-            Path(args.model_dir),
-            args.clip_len,
-            args.rename,
-            args.summary,
-        )
-        while True:  # pragma: no cover - scheduling loop
-            schedule.run_pending()
-            time.sleep(60)
-    else:
-        reclassify(Path(args.dataset), Path(args.model_dir), args.clip_len, args.rename, args.summary)
+    reclassify(Path(args.dataset), Path(args.model_dir), args.clip_len, args.dry_run)
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI helper


### PR DESCRIPTION
## Summary
- simplify the reclassification script
- default to `data/highlights/labels.csv`
- automatically rename clips with new label info
- log updates to `logs/learning_log.json`
- add `--dry-run` flag

## Testing
- `python -m py_compile reclassify_old_clips.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_688a48d73edc832d8c88b22159f55a7e