### PR TITLE
Link play data with roster info

### DIFF
--- a/google_sheets_uploader.py
+++ b/google_sheets_uploader.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import datetime as _dt
 from typing import Iterable, List
 
+from roster import get_player_name
+
 import gspread
 from google.oauth2.service_account import Credentials
 
@@ -22,6 +24,7 @@ def upload_rows(service_account_json: str, spreadsheet_id: str, rows: Iterable[L
 
 
 def format_row(jersey: int, total: int, quarters: List[int]) -> List[str]:
+    """Return a row for uploading play counts including the player name."""
     timestamp = _dt.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     breakdown = ",".join(str(q) for q in quarters)
-    return [timestamp, str(jersey), str(total), breakdown]
+    return [timestamp, str(jersey), get_player_name(jersey), str(total), breakdown]

--- a/manual_video_processor.py
+++ b/manual_video_processor.py
@@ -4,6 +4,8 @@ import json
 import os
 from pathlib import Path
 from typing import Dict, List, Set, Tuple
+
+import roster
 from datetime import datetime
 import zipfile
 
@@ -238,7 +240,8 @@ def process_uploaded_game_film(
     print("Jersey numbers tracked:", sorted(jersey_counts.keys()))
     print("Player participation counts:")
     for j, cnt in participation_counts.items():
-        print(f"  #{j}: {cnt} plays")
+        name = roster.get_player_name(int(j)) if str(j).isdigit() else str(j)
+        print(f"  #{j} {name}: {cnt} plays")
     print("Play types identified:")
     for name, cnt in play_counts.items():
         print(f"  {name}: {cnt}")

--- a/play_tracker.py
+++ b/play_tracker.py
@@ -14,6 +14,8 @@ import time
 from email.message import EmailMessage
 from typing import Iterable, List
 
+import roster
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Track play counts and send periodic email updates.")
@@ -56,7 +58,7 @@ def load_jerseys(args: argparse.Namespace) -> List[int]:
         except Exception as exc:  # pragma: no cover - runtime failure is user error
             raise SystemExit(f"Failed to read config file: {exc}")
     if not jerseys:
-        raise SystemExit("No jersey numbers provided")
+        jerseys.extend(roster.ROSTER.keys())
     return sorted(set(jerseys))
 
 
@@ -96,7 +98,10 @@ def main() -> None:
 
     def email_job() -> None:
         nonlocal quarter
-        lines = [f"#{j} – {play_counts[j]} plays" for j in jerseys]
+        lines = [
+            f"#{j} {roster.get_player_name(j)} – {play_counts[j]} plays"
+            for j in jerseys
+        ]
         body = "\n".join(lines)
         subject = f"Play Count Update – Q{quarter}"
         send_email(

--- a/stream_to_youtube.py
+++ b/stream_to_youtube.py
@@ -7,6 +7,8 @@ import os
 import re
 from collections import deque
 
+import roster
+
 try:
     from reportlab.lib.pagesizes import letter
     from reportlab.pdfgen import canvas
@@ -61,7 +63,7 @@ def generate_compliance_report(
         status_str = "Met" if count >= FINAL_MIN_PLAYS else "Below"
         summary.append(
             {
-                "player": f"#{pid}",
+                "player": f"#{pid} {roster.get_player_name(int(pid))}",
                 "plays": count,
                 "status": f"{'✅' if status_str == 'Met' else '❌'} {status_str}",
             }
@@ -296,7 +298,10 @@ def main() -> None:
         if elapsed_secs >= HALFTIME_SECS:
             for pid, cnt in play_counts.items():
                 if cnt < HALFTIME_MIN_PLAYS and pid not in halftime_alerted:
-                    msg = f"[\u26A0\uFE0F ALERT] #{pid} has only {cnt} plays at halftime"
+                    msg = (
+                        f"[\u26A0\uFE0F ALERT] #{pid} {roster.get_player_name(int(pid))} "
+                        f"has only {cnt} plays at halftime"
+                    )
                     print(msg)
                     alert_fp.write(msg + "\n")
                     halftime_alerted.add(pid)
@@ -306,8 +311,8 @@ def main() -> None:
             for pid, cnt in play_counts.items():
                 if cnt < FINAL_MIN_PLAYS and pid not in final_alerted:
                     msg = (
-                        f"[\U0001F6A8 FINAL WARNING] #{pid} has only {cnt} plays "
-                        f"\u2014 {mins}:{secs:02d} remaining"
+                        f"[\U0001F6A8 FINAL WARNING] #{pid} {roster.get_player_name(int(pid))} "
+                        f"has only {cnt} plays \u2014 {mins}:{secs:02d} remaining"
                     )
                     print(msg)
                     alert_fp.write(msg + "\n")
@@ -340,14 +345,14 @@ def main() -> None:
                 new_state = "warn"
                 mins, secs = divmod(remaining_secs, 60)
                 msg = (
-                    f"[\u23F1 TIME WARNING] #{pid} unlikely to hit 7 plays \u2014 "
-                    f"{mins}:{secs:02d} remaining"
+                    f"[\u23F1 TIME WARNING] #{pid} {roster.get_player_name(int(pid))} "
+                    f"unlikely to hit 7 plays \u2014 {mins}:{secs:02d} remaining"
                 )
             elif cnt < 4:
                 new_state = "sub"
                 msg = (
-                    f"[\U0001F45F SUB IN] #{pid} needs {need} more plays \u2014 "
-                    "recommend subbing now"
+                    f"[\U0001F45F SUB IN] #{pid} {roster.get_player_name(int(pid))} "
+                    f"needs {need} more plays \u2014 recommend subbing now"
                 )
             if new_state and sub_state.get(pid) != new_state:
                 print(msg)


### PR DESCRIPTION
## Summary
- pull player names from `roster` for Google Sheets rows
- derive jersey number lists from `roster` and show names in `play_count_tracker`
- default jersey numbers from `roster` and show names in `play_tracker`
- include player names in compliance reports and alerts
- show roster names in manual video processor output

## Testing
- `python -m py_compile google_sheets_uploader.py play_count_tracker.py play_tracker.py stream_to_youtube.py manual_video_processor.py roster.py`

------
https://chatgpt.com/codex/tasks/task_e_688a53bdf8bc832da8627086003fbac9