### PR TITLE
Add scouting alerts in dashboard

### DIFF
--- a/analysis/Victory_Christian_scouting_report.json
+++ b/analysis/Victory_Christian_scouting_report.json
@@ -1,0 +1,6 @@
+{
+  "patterns": [
+    {"formation": "Trips", "quarter": 2, "play": "Jet Sweep", "rate": 0.6},
+    {"formation": "I-Formation", "quarter": 1, "play": "Dive", "rate": 0.5}
+  ]
+}

--- a/live_dashboard.py
+++ b/live_dashboard.py
@@ -6,10 +6,29 @@ from pathlib import Path
 
 from flask import Flask, jsonify, render_template, request
 
+SCOUTING_PATH = Path("analysis/Victory_Christian_scouting_report.json")
+
 LOG_PATH = Path("live_log.json")
 SCORE_PATH = Path("live_score.json")
 
+
+def load_scouting() -> list[dict]:
+    try:
+        with SCOUTING_PATH.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+            if isinstance(data, list):
+                return [d for d in data if isinstance(d, dict)]
+            if isinstance(data, dict):
+                pats = data.get("patterns", [])
+                if isinstance(pats, list):
+                    return [d for d in pats if isinstance(d, dict)]
+    except Exception:
+        pass
+    return []
+
 app = Flask(__name__)
+
+SCOUTING_PATTERNS = load_scouting()
 
 
 def load_plays() -> list[dict]:
@@ -48,6 +67,11 @@ def index() -> str:
 @app.route("/api/plays")
 def api_plays() -> tuple[str, int] | tuple[str, int, dict]:
     return jsonify(load_plays())
+
+
+@app.route("/api/scouting")
+def api_scouting() -> tuple[str, int] | tuple[str, int, dict]:
+    return jsonify(SCOUTING_PATTERNS)
 
 
 @app.route("/api/score", methods=["GET", "POST"])

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -30,7 +30,14 @@
             <canvas id="pie"></canvas>
         </div>
     </div>
-    <h3 class="mt-4">Play Log</h3>
+    <div class="d-flex align-items-center mt-4 mb-2">
+        <h3 class="me-auto mb-0">Play Log</h3>
+        <div class="form-check form-switch">
+            <input class="form-check-input" type="checkbox" id="alert-toggle" checked>
+            <label class="form-check-label" for="alert-toggle">Show Alerts</label>
+        </div>
+    </div>
+    <div id="alert-box" class="alert alert-info d-none" role="alert"></div>
     <table class="table" id="play-table">
         <thead>
             <tr><th>Timestamp</th><th>Label</th><th>Confidence</th></tr>
@@ -45,6 +52,16 @@
 </div>
 <script>
 let playChart;
+let scouting = [];
+fetch('/api/scouting').then(r => r.json()).then(data => { scouting = data; });
+
+function showAlert(msg) {
+    const box = document.getElementById('alert-box');
+    if (!msg || !document.getElementById('alert-toggle').checked) return;
+    box.textContent = msg;
+    box.classList.remove('d-none');
+    setTimeout(() => box.classList.add('d-none'), 7000);
+}
 function updatePlays() {
     fetch('/api/plays').then(r => r.json()).then(data => {
         const tbody = document.querySelector('#play-table tbody');
@@ -69,6 +86,22 @@ function updatePlays() {
                 data: { labels: labels, datasets: [{ data: values }] },
                 options: { responsive: true }
             });
+        }
+        const last = data[data.length - 1];
+        if (last && scouting.length) {
+            const form = (last.formation || '').toLowerCase();
+            let q = last.quarter;
+            if (!q && last.timestamp) {
+                const m = /Q(\d)/.exec(last.timestamp);
+                if (m) q = parseInt(m[1]);
+            }
+            const pat = scouting.find(s =>
+                s.formation.toLowerCase() === form && parseInt(s.quarter) === parseInt(q)
+            );
+            if (pat) {
+                const conf = last.confidence ? ` (${(last.confidence * 100).toFixed(0)}%)` : '';
+                showAlert(`\uD83D\uDCA1 High ${pat.play} rate from ${pat.formation} in Q${pat.quarter} - Predicted: ${last.label}${conf}`);
+            }
         }
     });
 }


### PR DESCRIPTION
## Summary
- load scouting patterns from new JSON report
- expose `/api/scouting` route
- display alerts on the dashboard when a play matches scouting tendencies
- include toggle and alert area in UI
- add example Victory Christian scouting report

## Testing
- `python -m py_compile live_dashboard.py`

------
https://chatgpt.com/codex/tasks/task_e_688a59ce77cc832db65cf6b087262a54