### PR TITLE
Add play prediction in dashboard

### DIFF
--- a/predict_next_play.py
+++ b/predict_next_play.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import csv
+from collections import Counter
+from pathlib import Path
+from typing import List, Dict, Union
+
+CSV_PATH = Path("scouting_data.csv")
+
+
+def _parse_int(val: str | int | None) -> int | None:
+    try:
+        return int(str(val).strip().lstrip("Q"))
+    except Exception:
+        return None
+
+
+def _norm_form(form: str | None) -> str:
+    return (form or "").lower().replace(" ", "").replace("-", "")
+
+
+def _similar_form(a: str | None, b: str | None) -> bool:
+    fa = _norm_form(a)
+    fb = _norm_form(b)
+    return fa == fb or fa in fb or fb in fa
+
+
+def predict_play(
+    opponent: str,
+    formation: str | None,
+    down: int | None,
+    distance: int | None,
+    quarter: int | None,
+) -> List[Dict[str, int]] | str:
+    """Predict next play from scouting data.
+
+    Returns top two play labels with percentages or a message string if data is
+    insufficient.
+    """
+
+    if not CSV_PATH.exists():
+        return "No prediction available"
+
+    rows = []
+    with CSV_PATH.open(newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            if row.get("opponent", "").lower() != opponent.lower():
+                continue
+            if formation and row.get("formation") and not _similar_form(
+                row["formation"], formation
+            ):
+                continue
+            r_down = _parse_int(row.get("down"))
+            if down is not None and r_down is not None and r_down != down:
+                continue
+            r_qtr = _parse_int(row.get("quarter"))
+            if quarter is not None and r_qtr is not None and abs(r_qtr - quarter) > 1:
+                continue
+            r_dist = _parse_int(row.get("distance") or row.get("yards_to_go"))
+            if distance is not None and r_dist is not None and abs(r_dist - distance) > 2:
+                continue
+            rows.append(row)
+
+    if len(rows) < 3:
+        return "No prediction available"
+
+    counts = Counter(r.get("label", "Unknown") for r in rows)
+    total = sum(counts.values())
+    preds: List[Dict[str, int]] = []
+    for label, cnt in counts.most_common(2):
+        pct = int(round((cnt / total) * 100)) if total else 0
+        preds.append({"label": label, "percent": pct})
+    return preds
+
+
+__all__ = ["predict_play"]

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -38,6 +38,7 @@
         </div>
     </div>
     <div id="alert-box" class="alert alert-info d-none" role="alert"></div>
+    <div id="prediction-box" class="alert alert-warning d-none" role="alert"></div>
     <table class="table" id="play-table">
         <thead>
             <tr><th>Timestamp</th><th>Label</th><th>Confidence</th></tr>
@@ -54,6 +55,7 @@
 let playChart;
 let scouting = [];
 fetch('/api/scouting').then(r => r.json()).then(data => { scouting = data; });
+const OPPONENT = "{{ opponent }}";
 
 function showAlert(msg) {
     const box = document.getElementById('alert-box');
@@ -61,6 +63,13 @@ function showAlert(msg) {
     box.textContent = msg;
     box.classList.remove('d-none');
     setTimeout(() => box.classList.add('d-none'), 7000);
+}
+function showPrediction(msg) {
+    const box = document.getElementById('prediction-box');
+    if (!msg) return;
+    box.textContent = msg;
+    box.classList.remove('d-none');
+    setTimeout(() => box.classList.add('d-none'), 10000);
 }
 function updatePlays() {
     fetch('/api/plays').then(r => r.json()).then(data => {
@@ -88,13 +97,16 @@ function updatePlays() {
             });
         }
         const last = data[data.length - 1];
-        if (last && scouting.length) {
-            const form = (last.formation || '').toLowerCase();
-            let q = last.quarter;
+        let q = null;
+        if (last) {
+            q = last.quarter;
             if (!q && last.timestamp) {
                 const m = /Q(\d)/.exec(last.timestamp);
                 if (m) q = parseInt(m[1]);
             }
+        }
+        if (last && scouting.length) {
+            const form = (last.formation || '').toLowerCase();
             const pat = scouting.find(s =>
                 s.formation.toLowerCase() === form && parseInt(s.quarter) === parseInt(q)
             );
@@ -102,6 +114,27 @@ function updatePlays() {
                 const conf = last.confidence ? ` (${(last.confidence * 100).toFixed(0)}%)` : '';
                 showAlert(`\uD83D\uDCA1 High ${pat.play} rate from ${pat.formation} in Q${pat.quarter} - Predicted: ${last.label}${conf}`);
             }
+        }
+        if (last) {
+            const params = new URLSearchParams({
+                opponent: OPPONENT,
+                formation: last.formation || '',
+                down: last.down || '',
+                distance: last.distance || '',
+                quarter: q ? String(q) : ''
+            });
+            fetch('/api/predict?' + params.toString()).then(r => r.json()).then(res => {
+                if (Array.isArray(res)) {
+                    if (res.length) {
+                        const txt = res.map(p => `${p.label} (${p.percent}%)`).join(', ');
+                        showPrediction(`\uD83D\uDCA1 Prediction: ${txt}`);
+                    }
+                } else if (res && res.message) {
+                    showPrediction(res.message);
+                } else if (typeof res === 'string') {
+                    showPrediction(res);
+                }
+            });
         }
     });
 }


### PR DESCRIPTION
## Summary
- create `predict_next_play.py` for basic scouting predictions
- show next play predictions in the dashboard
- expose new `/api/predict` endpoint

## Testing
- `python -m py_compile predict_next_play.py live_dashboard.py`

------
https://chatgpt.com/codex/tasks/task_e_688a5c52eb44832d904aa8b99a92c0a9