### PR TITLE
Add play clip classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,10 @@ This repository contains simple utilities for analyzing football plays.
 
 ## Modules
 
-- `play_classifier.py` – provides the `PlayClassifier` class which wraps a
-  YOLOv5 model to detect touchdown-like movements or fast exits of a
-  player from the frame.
+- `play_classifier.py` – includes the `PlayClassifier` class for touchdown detection
+  and a `classify_play` function to label short clips using a pretrained video model.
+  Run `python play_classifier.py --folder clips/ --output predictions.json` to classify
+  a directory of clips.
 - `record_video.py` – records 1280x720 video from /dev/video0 to output.mp4
 - `highlight_recorder.py` – automatically captures 10-second clips when motion is detected
 - `play_recognizer.py` – identifies plays based on formations in `mca_playbook.json` and writes results to `play_log.json`.

--- a/run_gameday_highlight.py
+++ b/run_gameday_highlight.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import argparse
+import json
 from pathlib import Path
 
 from generate_highlights import generate
 from ai_tracking import analyze_video
+from play_classifier import classify_play
 
 
 def main() -> None:
@@ -17,6 +19,11 @@ def main() -> None:
         action="store_true",
         help="Run player tracking analysis before generating highlights",
     )
+    parser.add_argument(
+        "--classify",
+        action="store_true",
+        help="Label highlight clips with play type predictions",
+    )
     args = parser.parse_args()
 
     video_path = Path(args.input)
@@ -26,7 +33,23 @@ def main() -> None:
     if args.track:
         analyze_video(str(video_path))
 
-    generate(str(video_path))
+    output_dir = Path("highlights")
+    generate(str(video_path), str(output_dir))
+
+    if args.classify:
+        preds = []
+        for clip in sorted(output_dir.glob("*.mp4")):
+            meta = clip.with_suffix(".json")
+            meta_path = str(meta) if meta.exists() else None
+            result = classify_play(str(clip), meta_path)
+            preds.append({
+                "clip": clip.name,
+                "play_type": result["play_type"],
+                "confidence": result["confidence"],
+            })
+        with open(output_dir / "predictions.json", "w", encoding="utf-8") as f:
+            json.dump(preds, f, indent=2)
+        print(f"\u2705 Saved predictions to {output_dir / 'predictions.json'}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- expand README with instructions for classifying highlight clips
- add a CNN-based `classify_play` function with CLI to `play_classifier.py`
- enhance `run_gameday_highlight.py` with `--classify` flag to label highlights

## Testing
- `python -m py_compile play_classifier.py run_gameday_highlight.py`

------
https://chatgpt.com/codex/tasks/task_e_688a630adc84832dabceace3c6f8300b