### PR TITLE
Add play recommendation module

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -6,6 +6,8 @@ from collections import Counter
 from pathlib import Path
 from typing import Any, Dict, List
 
+from play_recommender import recommend_play
+
 import pandas as pd
 import streamlit as st
 
@@ -82,6 +84,13 @@ def main() -> None:
     player_options = ['All'] + sorted(player_counts) if player_counts else ['All']
     selected_play = st.sidebar.selectbox('Play Type', play_options)
     selected_player = st.sidebar.selectbox('Player', player_options)
+
+    if st.sidebar.checkbox('Show Recommended Plays'):
+        defense_look = st.sidebar.text_input('Defense Look', '')
+        recs = recommend_play(pred_data[-5:], defense_look)
+        st.sidebar.markdown('**Top Suggestions**')
+        for r in recs:
+            st.sidebar.write(f"{r['wristband_code']}: {r['play_name']} - {r['reason']}")
 
     filtered_df = df.copy()
     if selected_play != 'All':

--- a/play_recommender.py
+++ b/play_recommender.py
@@ -1,0 +1,89 @@
+"""Play recommendation engine based on recent history and defense looks."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+PLAYBOOK_PATH = Path("plays/playbook.json")
+
+
+def _load_playbook() -> List[Dict[str, Any]]:
+    """Return playbook entries from :data:`PLAYBOOK_PATH`."""
+    if not PLAYBOOK_PATH.exists():
+        return []
+    try:
+        with PLAYBOOK_PATH.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+        if isinstance(data, list):
+            return [d for d in data if isinstance(d, dict)]
+        if isinstance(data, dict):
+            return [dict(name=k, **v) for k, v in data.items() if isinstance(v, dict)]
+    except Exception:
+        pass
+    return []
+
+
+def recommend_play(recent_plays: List[Dict[str, Any]], defense_look: str | None) -> List[Dict[str, str]]:
+    """Return top play recommendations.
+
+    Parameters
+    ----------
+    recent_plays:
+        List of recent play dictionaries. Each should include ``play_name`` and
+        ``success`` keys.
+    defense_look:
+        Detected defensive front, e.g. ``"4-4"`` or ``"5-2"``.
+
+    Returns
+    -------
+    List[Dict[str, str]]
+        Up to three play suggestions sorted by highest score. Each dictionary
+        contains ``play_name``, ``wristband_code`` and a short ``reason``.
+    """
+
+    playbook = _load_playbook()
+    if not playbook:
+        return []
+
+    # gather success rates from recent history
+    stats: Dict[str, Dict[str, int]] = {}
+    for p in recent_plays:
+        name = str(p.get("play_name") or p.get("play_type") or "").strip()
+        if not name:
+            continue
+        stat = stats.setdefault(name, {"cnt": 0, "success": 0})
+        stat["cnt"] += 1
+        if p.get("success"):
+            stat["success"] += 1
+
+    last_called = [str(p.get("play_name") or p.get("play_type") or "").strip() for p in recent_plays[-3:]]
+
+    scored: List[tuple[float, Dict[str, Any]]] = []
+    for entry in playbook:
+        name = str(entry.get("name"))
+        info = stats.get(name, {"cnt": 0, "success": 0})
+        rate = info["success"] / info["cnt"] if info["cnt"] else 0.0
+        score = rate
+        if defense_look and defense_look in entry.get("success_against", []):
+            score += 0.3
+        if name in last_called:
+            score -= 0.2
+        scored.append((score, entry))
+
+    scored.sort(key=lambda x: x[0], reverse=True)
+
+    recommendations: List[Dict[str, str]] = []
+    for score, entry in scored[:3]:
+        recommendations.append(
+            {
+                "play_name": entry.get("name", ""),
+                "wristband_code": str(entry.get("wristband_code", "")),
+                "reason": f"score {score:.2f}",
+            }
+        )
+    return recommendations
+
+
+__all__ = ["recommend_play"]

--- a/plays/playbook.json
+++ b/plays/playbook.json
@@ -1,0 +1,52 @@
+[
+  {
+    "play_number": "1",
+    "name": "Rit Dive",
+    "formation": "Rit",
+    "type": "Run",
+    "direction": "Right",
+    "wristband_code": "1",
+    "success_against": ["4-3", "5-2"],
+    "counters": ["Boot Pass", "Jet Fake + Dive"]
+  },
+  {
+    "play_number": "2",
+    "name": "Lit Sweep",
+    "formation": "Lit",
+    "type": "Run",
+    "direction": "Left",
+    "wristband_code": "2",
+    "success_against": ["4-4", "slow edge"],
+    "counters": ["Counter Trey"]
+  },
+  {
+    "play_number": "3",
+    "name": "Reo Flood",
+    "formation": "Reo",
+    "type": "Pass",
+    "direction": "Right",
+    "wristband_code": "10",
+    "success_against": ["soft corners"],
+    "counters": ["Screen Left"]
+  },
+  {
+    "play_number": "4",
+    "name": "Rit Jet Sweep",
+    "formation": "Rit",
+    "type": "Run",
+    "direction": "Right",
+    "wristband_code": "5",
+    "success_against": ["5-2", "slow edge"],
+    "counters": ["Jet Fake + Dive", "8 Option Left"]
+  },
+  {
+    "play_number": "5",
+    "name": "Jet Fake + Dive",
+    "formation": "Rit",
+    "type": "Run",
+    "direction": "Right",
+    "wristband_code": "6",
+    "success_against": ["aggressive flow"],
+    "counters": ["Rit Jet Sweep"]
+  }
+]


### PR DESCRIPTION
## Summary
- add small playbook JSON for wristband coding
- implement `play_recommender.py` with recommendation logic
- integrate play suggestions into `dashboard.py`

## Testing
- `python -m py_compile play_recommender.py dashboard.py`

------
https://chatgpt.com/codex/tasks/task_e_688a67019c7c832d94dd39699ded6508