### PR TITLE
feat: stream tee to youtube and mp4

### DIFF
--- a/stream_to_youtube.py
+++ b/stream_to_youtube.py
@@ -196,7 +196,7 @@ def parse_clock(clock: str) -> int | None:
 
 def launch_ffmpeg(width: int, height: int, record_path: Path) -> subprocess.Popen:
     """Start the FFmpeg subprocess for streaming and recording."""
-    cmd = [
+    ffmpeg_command = [
         "ffmpeg",
         "-f",
         "rawvideo",
@@ -221,24 +221,16 @@ def launch_ffmpeg(width: int, height: int, record_path: Path) -> subprocess.Pope
         "-preset",
         "veryfast",
         "-b:v",
-        "3000k",
-        "-maxrate",
-        "3000k",
-        "-bufsize",
-        "6000k",
-        "-g",
-        "60",
+        "2500k",
         "-c:a",
         "aac",
-        "-b:a",
-        "128k",
         "-ar",
         "44100",
         "-f",
         "tee",
         f"[f=flv]{RTMP_URL}|[f=mp4]{record_path}",
     ]
-    return subprocess.Popen(cmd, stdin=subprocess.PIPE)
+    return subprocess.Popen(ffmpeg_command, stdin=subprocess.PIPE)
 
 
 def open_camera() -> tuple[cv2.VideoCapture, "cv2.Mat"] | tuple[None, None]:


### PR DESCRIPTION
## Summary
- simplify FFmpeg pipeline and tee output to YouTube RTMP and local MP4 with a timestamped filename

## Testing
- `python -m py_compile stream_to_youtube.py`
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_688dfa1423f0832d82648f6042baa41e