### PR TITLE
Handle BrokenPipeError when streaming to FFmpeg

### DIFF
--- a/stream_to_youtube.py
+++ b/stream_to_youtube.py
@@ -557,12 +557,8 @@ def main() -> None:
                     process.stdin.write(frame.tobytes())
                     process.stdin.flush()
                 except BrokenPipeError:
-                    print("[\u274C ERROR] FFmpeg pipe closed (BrokenPipeError)")
-                    print("\a", end="")
-                    ffmpeg_error = True
-                    if process.poll() is not None:
-                        process.wait()
-                    process = None
+                    print("[\u274C Streaming ended: BrokenPipeError]")
+                    break
 
             frame_count += 1
             if frame_count % 30 == 0:


### PR DESCRIPTION
## Summary
- Gracefully handle `BrokenPipeError` in `stream_to_youtube.py`
- Log a clean shutdown message and stop streaming loop if FFmpeg pipe closes

## Testing
- `python -m py_compile stream_to_youtube.py`
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_688dfa214de4832d90d1289f8f3e8710