### PR TITLE
feat: centralize ffmpeg settings

### DIFF
--- a/ffmpeg_utils.py
+++ b/ffmpeg_utils.py
@@ -1,0 +1,120 @@
+import logging
+from typing import List, Optional
+
+def build_ffmpeg_args(
+    *,
+    video_source: str,
+    output_url: str,
+    audio_device: Optional[str],
+    audio_gain_db: float = 0.0,
+    resolution: str = "1280x720",
+    framerate: int = 30,
+    video_codec: str = "libx264",
+    video_is_pipe: bool = False,
+    video_format: str = "v4l2",
+    extra_args: Optional[List[str]] = None,
+) -> List[str]:
+    """Return a standardized FFmpeg command.
+
+    Parameters
+    ----------
+    video_source:
+        Path or identifier for the video input. Use "-" when piping raw frames.
+    output_url:
+        Destination URL or file path.
+    audio_device:
+        Identifier for the audio capture device. If ``None``, audio input is skipped
+        and a log message is emitted.
+    audio_gain_db:
+        Gain to apply via the ``volume`` filter in decibels.
+    resolution:
+        Target resolution (e.g. ``"1280x720"``).
+    framerate:
+        Target frames per second.
+    video_codec:
+        Video encoder to use (defaults to ``libx264``).
+    video_is_pipe:
+        If True, treat ``video_source`` as raw frames on stdin.
+    video_format:
+        Input format when ``video_is_pipe`` is False (default ``v4l2``).
+    extra_args:
+        Additional FFmpeg arguments to append before the output target.
+    """
+
+    cmd: List[str] = ["ffmpeg", "-loglevel", "verbose", "-y"]
+
+    if video_is_pipe:
+        cmd += [
+            "-f",
+            "rawvideo",
+            "-pix_fmt",
+            "bgr24",
+            "-s",
+            resolution,
+            "-framerate",
+            str(framerate),
+            "-i",
+            "-",
+        ]
+    else:
+        cmd += [
+            "-f",
+            video_format,
+            "-framerate",
+            str(framerate),
+            "-video_size",
+            resolution,
+            "-i",
+            video_source,
+        ]
+
+    if audio_device:
+        cmd += [
+            "-f",
+            "alsa",
+            "-ac",
+            "1",
+            "-ar",
+            "44100",
+            "-i",
+            audio_device,
+        ]
+    else:
+        logging.info("Audio capture intentionally skipped")
+
+    cmd += [
+        "-c:v",
+        video_codec,
+        "-preset",
+        "veryfast",
+        "-tune",
+        "zerolatency",
+        "-pix_fmt",
+        "yuv420p",
+        "-b:v",
+        "4500k",
+        "-maxrate",
+        "6000k",
+        "-bufsize",
+        "6000k",
+    ]
+
+    if audio_device:
+        cmd += [
+            "-c:a",
+            "aac",
+            "-b:a",
+            "128k",
+            "-ar",
+            "44100",
+            "-ac",
+            "1",
+            "-af",
+            f"volume={audio_gain_db}dB",
+        ]
+
+    if extra_args:
+        cmd += list(extra_args)
+
+    cmd += ["-f", "flv", output_url]
+    return cmd

--- a/overlay_engine.py
+++ b/overlay_engine.py
@@ -10,6 +10,7 @@ import subprocess
 import threading
 from datetime import datetime
 from pathlib import Path
+from ffmpeg_utils import build_ffmpeg_args
 
 import cv2
 import numpy as np
@@ -90,33 +91,16 @@ def load_state_from_json(path: str, fallback: ScoreboardState) -> ScoreboardStat
 def build_ffmpeg_command(url: str, size: tuple[int, int], fps: float) -> list[str]:
     """Return command list for launching ffmpeg."""
     width, height = size
-    return [
-        ensure_ffmpeg(),
-        "-loglevel",
-        "verbose",
-        "-y",
-        "-f",
-        "rawvideo",
-        "-vcodec",
-        "rawvideo",
-        "-pix_fmt",
-        "bgr24",
-        "-s",
-        f"{width}x{height}",
-        "-r",
-        str(int(fps)),
-        "-i",
-        "-",
-        "-c:v",
-        select_codec(),
-        "-preset",
-        "veryfast",
-        "-pix_fmt",
-        "yuv420p",
-        "-f",
-        "flv",
-        url,
-    ]
+    return build_ffmpeg_args(
+        video_source="-",
+        audio_device=None,
+        output_url=url,
+        audio_gain_db=0.0,
+        resolution=f"{width}x{height}",
+        framerate=int(fps),
+        video_codec=select_codec(),
+        video_is_pipe=True,
+    )
 
 
 def stream(device: int, rtmp_url: str, *, json_path: str = "game_state.json", position: str = "left") -> None:

--- a/stream_diagnostics.py
+++ b/stream_diagnostics.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import subprocess
 from pathlib import Path
+from ffmpeg_utils import build_ffmpeg_args
 
 
 def load_env(env_path: str = ".env") -> None:
@@ -52,15 +53,16 @@ def test_stream(url: str | None = None, *, duration: int = 5, log_path: str = "t
             raise RuntimeError("Ping to youtube.com failed")
 
         log.write("\nStarting ffmpeg test stream...\n")
-        cmd = [
-            ensure_ffmpeg(),
-            "-re",
-            "-f", "lavfi",
-            "-i", "testsrc=size=1280x720:rate=30",
-            "-t", str(duration),
-            "-f", "flv",
-            url,
-        ]
+        cmd = build_ffmpeg_args(
+            video_source="testsrc=size=1280x720:rate=30",
+            audio_device=None,
+            output_url=url,
+            audio_gain_db=0.0,
+            resolution="1280x720",
+            framerate=30,
+            video_format="lavfi",
+            extra_args=["-t", str(duration)],
+        )
         result = subprocess.run(cmd, capture_output=True)
         stdout = result.stdout.decode("utf-8", errors="ignore")
         stderr = result.stderr.decode("utf-8", errors="ignore")

--- a/youtube_livestream.py
+++ b/youtube_livestream.py
@@ -3,6 +3,7 @@ import os
 import platform
 import subprocess
 from datetime import datetime, timezone
+from ffmpeg_utils import build_ffmpeg_args
 
 from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials
@@ -125,40 +126,14 @@ def run_ffmpeg(stream_key: str, *, test: bool = False) -> None:
     rtmp_url = f"rtmp://a.rtmp.youtube.com/live2/{stream_key}"
     system = platform.system()
     if system == "Linux":
-        cmd = [
-            "ffmpeg",
-            "-f",
-            "v4l2",
-            "-framerate",
-            "30",
-            "-video_size",
-            "1280x720",
-            "-i",
-            "/dev/video0",
-            "-f",
-            "alsa",
-            "-ac",
-            "2",
-            "-ar",
-            "44100",
-            "-i",
-            "hw:1,0",
-            "-c:v",
-            "libx264",
-            "-preset",
-            "veryfast",
-            "-b:v",
-            "3000k",
-            "-c:a",
-            "aac",
-            "-b:a",
-            "128k",
-            "-af",
-            "volume=3.0",
-            "-f",
-            "flv",
-            rtmp_url,
-        ]
+        cmd = build_ffmpeg_args(
+            video_source="/dev/video0",
+            audio_device="hw:1,0",
+            output_url=rtmp_url,
+            audio_gain_db=3.0,
+            resolution="1280x720",
+            framerate=30,
+        )
     elif system == "Windows":
         # Retain Windows-specific command using DirectShow devices.
         cmd = [


### PR DESCRIPTION
## Summary
- add shared `build_ffmpeg_args` to unify audio/video configuration
- route streaming scripts through common FFmpeg settings
- log when audio capture is intentionally skipped

## Testing
- `python -m py_compile ffmpeg_utils.py stream_to_youtube.py streamer.py overlay_engine.py smart_crop_stream.py stream_diagnostics.py youtube_livestream.py`


------
https://chatgpt.com/codex/tasks/task_e_68938f04c1e8832d88f06ab2c56a1634