### PR TITLE
Add training and labeling CLI workflow

### DIFF
--- a/train_model.py
+++ b/train_model.py
@@ -1,0 +1,28 @@
+"""Train model on labeled clips.
+
+This is a minimal placeholder that demonstrates reading labels from
+``manual_review/labels.csv`` and would be replaced by the real training
+pipeline in production.
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+def main() -> None:
+    labels_path = Path("manual_review/labels.csv")
+    if not labels_path.exists():
+        print(f"No labels found at {labels_path}. Nothing to train.")
+        return
+
+    with labels_path.open(newline="") as f:
+        reader = csv.reader(f)
+        next(reader, None)  # skip header if present
+        clips = list(reader)
+
+    print(f"Training model on {len(clips)} labeled clips...")
+    # Placeholder: actual training logic would go here
+
+if __name__ == "__main__":  # pragma: no cover - script
+    main()

--- a/training_workflow.py
+++ b/training_workflow.py
@@ -1,0 +1,75 @@
+"""CLI entry point for training and manual labeling workflows."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import subprocess
+import sys
+from pathlib import Path
+
+REVIEW_DIR = Path("manual_review")
+LABELS_CSV = REVIEW_DIR / "labels.csv"
+
+
+def run_training() -> None:
+    """Invoke ``train_model.py`` to train on labeled clips."""
+    subprocess.run([sys.executable, "train_model.py"], check=False)
+
+
+def label_clips() -> None:
+    """Prompt the user to label clips located in ``manual_review/``.
+
+    Already labeled clips listed in ``labels.csv`` are skipped. New labels are
+    appended to the CSV file with columns ``filepath`` and ``label``.
+    """
+    REVIEW_DIR.mkdir(exist_ok=True)
+
+    labeled: set[str] = set()
+    if LABELS_CSV.exists():
+        with LABELS_CSV.open(newline="") as f:
+            reader = csv.reader(f)
+            next(reader, None)
+            for row in reader:
+                if row:
+                    labeled.add(row[0])
+
+    clips = [p for p in REVIEW_DIR.glob("*") if p.is_file() and p.suffix.lower() in {".mp4", ".mov", ".avi"}]
+    clips = [p for p in clips if str(p) not in labeled]
+
+    if not clips:
+        print("No untagged clips found.")
+        return
+
+    need_header = not LABELS_CSV.exists()
+    with LABELS_CSV.open("a", newline="") as f:
+        writer = csv.writer(f)
+        if need_header:
+            writer.writerow(["filepath", "label"])
+        for clip in clips:
+            label = input(f"Label for {clip.name} (Run/Pass/Sweep/Kickoff/etc): ").strip()
+            if not label:
+                label = "unknown"
+            writer.writerow([clip.as_posix(), label])
+            print(f"Recorded {clip.name} -> {label}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="AI training and labeling workflows")
+    parser.add_argument("--train", action="store_true", help="Train model on labeled clips")
+    parser.add_argument("--label", action="store_true", help="Manually label clips in manual_review/")
+    args = parser.parse_args()
+
+    ran = False
+    if args.label:
+        label_clips()
+        ran = True
+    if args.train:
+        run_training()
+        ran = True
+    if not ran:
+        parser.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()


### PR DESCRIPTION
## Summary
- add `training_workflow.py` CLI with `--train` and `--label` modes
- include placeholder `train_model.py` that reads labels and simulates training

## Testing
- `python -m py_compile training_workflow.py train_model.py`
- `python training_workflow.py --label`
- `python training_workflow.py --train`
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_6893be281bd0832dae1847b693ab4560