### PR TITLE
Detect hardware H.264 encoder for Jetson streaming

### DIFF
--- a/ffmpeg_utils.py
+++ b/ffmpeg_utils.py
@@ -146,13 +146,12 @@ def build_ffmpeg_args(
     else:
         logging.info("Audio capture intentionally skipped")
 
-    cmd += [
-        "-c:v",
-        video_codec,
-        "-preset",
-        preset,
-        "-tune",
-        "zerolatency",
+    if video_codec == "libx264":
+        encoder_flags = ["-c:v", video_codec, "-preset", preset, "-tune", "zerolatency"]
+    else:
+        encoder_flags = ["-c:v", video_codec]
+
+    cmd += encoder_flags + [
         "-pix_fmt",
         "yuv420p",
         "-b:v",


### PR DESCRIPTION
## Summary
- Detect available H.264 encoder (h264_nvmpi, h264_omx, or libx264) before starting FFmpeg
- Apply encoder-specific flags when building FFmpeg commands

## Testing
- `PYTHONDONTWRITEBYTECODE=1 python -m py_compile stream_to_youtube.py ffmpeg_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_6895f6eef120832d9ba532f04d7d6f5a