### PR TITLE
Use JPEG pipe for FFmpeg hardware encoding

### DIFF
--- a/ffmpeg_utils.py
+++ b/ffmpeg_utils.py
@@ -141,12 +141,10 @@ def build_ffmpeg_args(
     if video_is_pipe:
         cmd += [
             "-f",
-            "rawvideo",
-            "-pix_fmt",
-            "bgr24",
-            "-s",
-            resolution,
-            "-framerate",
+            "image2pipe",
+            "-vcodec",
+            "mjpeg",
+            "-r",
             str(framerate),
             "-i",
             "-",
@@ -180,13 +178,20 @@ def build_ffmpeg_args(
         logging.info("Audio capture intentionally skipped")
 
     if video_codec == "libx264":
-        encoder_flags = ["-c:v", video_codec, "-preset", preset, "-tune", "zerolatency"]
+        encoder_flags = [
+            "-c:v",
+            video_codec,
+            "-preset",
+            preset,
+            "-tune",
+            "zerolatency",
+            "-pix_fmt",
+            "yuv420p",
+        ]
     else:
-        encoder_flags = ["-c:v", video_codec]
+        encoder_flags = ["-c:v", video_codec, "-pix_fmt", "yuv420p"]
 
     cmd += encoder_flags + [
-        "-pix_fmt",
-        "yuv420p",
         "-b:v",
         bitrate,
         "-maxrate",

--- a/stream_to_youtube.py
+++ b/stream_to_youtube.py
@@ -729,7 +729,7 @@ def launch_ffmpeg(
 
     width, height, fps = WIDTH, HEIGHT, FPS
     video_encoder = detect_encoder()
-    print(f"[SELECTED ENCODER] {video_encoder}")
+    print("[INFO] Streaming via JPEG → FFmpeg image2pipe → RTMP using", video_encoder)
     log_dir = Path("livestream_logs")
     log_dir.mkdir(exist_ok=True)
     log_file = log_dir / f"ffmpeg_{datetime.now().strftime('%Y%m%d_%H%M%S')}.log"
@@ -1225,9 +1225,13 @@ def main() -> None:
                 continue
             try:
                 if ffmpeg_process.stdin:
-                    data = frm.tobytes()
-                    ffmpeg_process.stdin.write(data)
-                    bytes_sent += len(data)
+                    is_success, jpeg_frame = cv2.imencode(
+                        ".jpg", frm, [cv2.IMWRITE_JPEG_QUALITY, 85]
+                    )
+                    if is_success:
+                        data = jpeg_frame.tobytes()
+                        ffmpeg_process.stdin.write(data)
+                        bytes_sent += len(data)
             except Exception as e:
                 print(f"[❌ ERROR] Write to FFmpeg failed: {e}")
                 stop_evt.set()


### PR DESCRIPTION
## Summary
- stream frames to FFmpeg as JPEG over image2pipe for hardware encoder compatibility
- compress frames with cv2.imencode before writing to FFmpeg
- log selected encoder and pipeline mode at startup

## Testing
- `python -m py_compile ffmpeg_utils.py smart_crop_stream.py stream_to_youtube.py`


------
https://chatgpt.com/codex/tasks/task_e_689609062990832d9290cdbd79159842