### PR TITLE
Force libx264 for image2pipe streaming

### DIFF
--- a/smart_crop_stream.py
+++ b/smart_crop_stream.py
@@ -134,7 +134,7 @@ def main() -> None:
 
     tracker = SmartAutoTracker()
 
-    video_encoder = detect_encoder()
+    video_encoder = detect_encoder("image2pipe")
     print("[INFO] Streaming via JPEG → FFmpeg image2pipe → RTMP using", video_encoder)
 
     retries = 0

--- a/stream_to_youtube.py
+++ b/stream_to_youtube.py
@@ -728,7 +728,7 @@ def launch_ffmpeg(
     """
 
     width, height, fps = WIDTH, HEIGHT, FPS
-    video_encoder = detect_encoder()
+    video_encoder = detect_encoder("image2pipe")
     print("[INFO] Streaming via JPEG → FFmpeg image2pipe → RTMP using", video_encoder)
     log_dir = Path("livestream_logs")
     log_dir.mkdir(exist_ok=True)


### PR DESCRIPTION
## Summary
- detect image2pipe MJPEG input and force libx264 since Jetson hardware encoders produce empty streams
- pass `image2pipe` to encoder detection in streaming scripts

## Testing
- `python -m py_compile ffmpeg_utils.py stream_to_youtube.py smart_crop_stream.py`


------
https://chatgpt.com/codex/tasks/task_e_68960ce52470832da6be0a0bfb69f41a