### PR TITLE
Fix YouTube stream by piping raw frames to ffmpeg

### DIFF
--- a/ffmpeg_utils.py
+++ b/ffmpeg_utils.py
@@ -150,9 +150,11 @@ def build_ffmpeg_args(
     if video_is_pipe:
         cmd += [
             "-f",
-            "image2pipe",
-            "-vcodec",
-            "mjpeg",
+            "rawvideo",
+            "-pix_fmt",
+            "yuv420p",
+            "-s",
+            resolution,
             "-r",
             str(framerate),
             "-i",


### PR DESCRIPTION
## Summary
- Pipe camera frames to FFmpeg as raw YUV instead of JPEG over image2pipe
- Force libx264 for RTMP and adjust ffmpeg args to use rawvideo input
- Convert frames to planar YUV420 before writing to FFmpeg

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68961d8a4a44832d8d84b3960da4a86d