### PR TITLE
Lower default stream resolution to 426x240

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ dedicated subfolder named after the game timestamp.
 Additional options:
 
 ```bash
-python stream_to_youtube.py --output-size 640x360 --debug
+python stream_to_youtube.py --output-size 426x240 --debug
 ```
 
 ## Requirements
@@ -93,7 +93,7 @@ This repository contains simple utilities for analyzing football plays.
   and a `classify_play` function to label short clips using a pretrained video model.
   Run `python play_classifier.py --folder clips/ --output predictions.json` to classify
   a directory of clips.
-- `record_video.py` – records 640x360 video from /dev/video0 to output.mp4
+- `record_video.py` – records 426x240 video from /dev/video0 to output.mp4
 - `highlight_recorder.py` – automatically captures 10-second clips when motion is detected
 - `play_recognizer.py` – identifies plays based on formations in `mca_playbook.json` and writes results to `play_log.json`.
 - `practice_trainer.py` – analyzes labeled practice clips and stores motion

--- a/config.py
+++ b/config.py
@@ -16,16 +16,16 @@ except Exception:  # pragma: no cover - fallback if YAML not installed
 class StreamConfig:
     """Central configuration for streaming parameters."""
 
-    resolution: str = "640x360"
+    resolution: str = "426x240"
     fps: int = 30
     mic_device: str = "hw:1,0"
     gain_boost: float = 3.0
     stream_key: str = "rtmp://a.rtmp.youtube.com/live2/STREAM_KEY"
     encoder: str = "auto"
     preset: str = "veryfast"
-    maxrate: str = "6000k"
-    bitrate: str = "4500k"
-    bufsize: str = "6000k"
+    maxrate: str = "3000k"
+    bitrate: str = "2000k"
+    bufsize: str = "4000k"
     camera: int = 0
     model: str = "models/play_classifier/latest.pt"
     train: bool = False

--- a/config.yaml
+++ b/config.yaml
@@ -1,8 +1,10 @@
-resolution: 640x360
+resolution: 426x240
 fps: 30
 mic_device: hw:1,0
 gain_boost: 3.0
 stream_key: rtmp://a.rtmp.youtube.com/live2/STREAM_KEY
 encoder: auto
 preset: veryfast
-maxrate: 6000k
+maxrate: 3000k
+bitrate: 2000k
+bufsize: 4000k

--- a/ffmpeg_utils.py
+++ b/ffmpeg_utils.py
@@ -98,15 +98,15 @@ def build_ffmpeg_args(
     output_url: str,
     audio_device: Optional[str],
     audio_gain_db: float = 0.0,
-    resolution: str = "640x360",
+    resolution: str = "426x240",
     framerate: int = 30,
     video_codec: str = "libx264",
     video_is_pipe: bool = False,
     video_format: str = "v4l2",
     preset: str = "veryfast",
-    bitrate: str = "4500k",
-    maxrate: str = "6000k",
-    bufsize: str = "6000k",
+    bitrate: str = "2000k",
+    maxrate: str = "3000k",
+    bufsize: str = "4000k",
     gop: int = 60,
     keyint_min: int = 30,
     local_record: Optional[str] = None,
@@ -128,7 +128,7 @@ def build_ffmpeg_args(
     audio_gain_db:
         Gain to apply via the ``volume`` filter in decibels.
     resolution:
-        Target resolution (e.g. ``"640x360"``).
+        Target resolution (e.g. ``"426x240"``).
     framerate:
         Target frames per second.
     video_codec:

--- a/gameday.sh
+++ b/gameday.sh
@@ -33,8 +33,8 @@ STREAM_PID=$!
 log "Starting full game recording..."
 FULLGAME_FILE="$FULL_DIR/fullgame_${TIMESTAMP}.mp4"
 LOG_FILE="$FULL_DIR/fullgame_ffmpeg.log"
-cmd=(ffmpeg -loglevel verbose -f v4l2 -framerate 30 -video_size 640x360 -i /dev/video0 \
-    -c:v libx264 -b:v 13500k -maxrate 13500k -bufsize 27000k -t 03:00:00 -pix_fmt yuv420p \
+cmd=(ffmpeg -loglevel verbose -f v4l2 -framerate 30 -video_size 426x240 -i /dev/video0 \
+    -c:v libx264 -b:v 2000k -maxrate 3000k -bufsize 4000k -t 03:00:00 -pix_fmt yuv420p \
     -c:a aac -b:a 128k "$FULLGAME_FILE")
 echo "Running FFmpeg command: ${cmd[*]}" | tee "$LOG_FILE"
 "${cmd[@]}" >>"$LOG_FILE" 2>&1 &

--- a/record_video.py
+++ b/record_video.py
@@ -30,13 +30,13 @@ def record(device: str = "/dev/video0", duration: int = 30) -> None:
     if not cap.isOpened():
         raise RuntimeError(f"Unable to open camera {device}")
 
-    cap.set(cv2.CAP_PROP_FRAME_WIDTH, 640)
-    cap.set(cv2.CAP_PROP_FRAME_HEIGHT, 360)
+    cap.set(cv2.CAP_PROP_FRAME_WIDTH, 426)
+    cap.set(cv2.CAP_PROP_FRAME_HEIGHT, 240)
     fps = cap.get(cv2.CAP_PROP_FPS)
     if not fps or fps <= 1:
         fps = 30.0
 
-    writer = open_writer("output.mp4", fps, (640, 360))
+    writer = open_writer("output.mp4", fps, (426, 240))
     if not writer.isOpened():
         raise RuntimeError("Failed to open video writer")
 

--- a/start_stream.sh
+++ b/start_stream.sh
@@ -53,10 +53,10 @@ mkdir -p "$LOG_DIR"
 LOG_FILE="$LOG_DIR/start_stream_$(date +%Y%m%d_%H%M%S).log"
 
 cmd=(ffmpeg -loglevel verbose \
-    -f v4l2 -framerate 30 -video_size 640x360 -i /dev/video0 \
+    -f v4l2 -framerate 30 -video_size 426x240 -i /dev/video0 \
     -f lavfi -i anullsrc=channel_layout=stereo:sample_rate=44100 \
     -c:v libx264 -preset veryfast -pix_fmt yuv420p \
-    -b:v 13500k -maxrate 13500k -bufsize 27000k -g 60 \
+    -b:v 2000k -maxrate 3000k -bufsize 4000k -g 60 \
     -c:a aac -b:a 128k \
     -f flv "$YOUTUBE_URL")
 

--- a/stream_diagnostics.py
+++ b/stream_diagnostics.py
@@ -54,11 +54,11 @@ def test_stream(url: str | None = None, *, duration: int = 5, log_path: str = "t
 
         log.write("\nStarting ffmpeg test stream...\n")
         cmd = build_ffmpeg_args(
-            video_source="testsrc=size=640x360:rate=30",
+            video_source="testsrc=size=426x240:rate=30",
             audio_device=None,
             output_url=url,
             audio_gain_db=0.0,
-            resolution="640x360",
+            resolution="426x240",
             framerate=30,
             video_format="lavfi",
             extra_args=["-t", str(duration)],


### PR DESCRIPTION
## Summary
- Drop default stream and recording resolution to 426x240 with lower bitrates to ease Jetson CPU load
- Update FFmpeg helper and shell scripts to use 2000k bitrate and matching buffer settings
- Refresh docs and utilities to reflect the new lightweight 240p profile

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68964c39f5bc832daf77bb1172671d02