### PR TITLE
Use Jetson hardware encoder for streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ Run it with:
 python stream_to_youtube.py
 ```
 
-The default settings use the software `libx264` encoder at
-1920x1080 and 30fps with a bitrate around **9&nbsp;Mbps**.
+The default settings use the Jetson `h264_v4l2m2m` hardware encoder at
+426x240 and 30fps with a bitrate around **2&nbsp;Mbps**.
 Output is written with `tee` so a local MP4 recording is saved
 alongside the live RTMP stream.
 
@@ -80,10 +80,9 @@ Install FFmpeg on Jetson with:
 sudo apt-get update && sudo apt-get install ffmpeg
 ```
 
-For best performance on Jetson devices, build FFmpeg with the Jetson
-accelerated encoders (`h264_nvmpi` or `h264_nvv4l2enc`). The streaming
-scripts automatically fall back to `libx264` when these encoders are
-unavailable.
+For best performance on Jetson devices, the scripts use the Jetson
+hardware encoder `h264_v4l2m2m` by default and automatically fall back
+to `libx264` when no hardware encoder is available.
 
 This repository contains simple utilities for analyzing football plays.
 

--- a/ffmpeg_utils.py
+++ b/ffmpeg_utils.py
@@ -100,7 +100,7 @@ def build_ffmpeg_args(
     audio_gain_db: float = 0.0,
     resolution: str = "426x240",
     framerate: int = 30,
-    video_codec: str = "libx264",
+    video_codec: str = "h264_v4l2m2m",
     video_is_pipe: bool = False,
     video_format: str = "v4l2",
     preset: str = "veryfast",
@@ -132,7 +132,7 @@ def build_ffmpeg_args(
     framerate:
         Target frames per second.
     video_codec:
-        Video encoder to use (defaults to ``libx264``).
+        Video encoder to use (defaults to ``h264_v4l2m2m``).
     video_is_pipe:
         If True, treat ``video_source`` as raw frames on stdin.
     video_format:

--- a/gameday.sh
+++ b/gameday.sh
@@ -34,7 +34,7 @@ log "Starting full game recording..."
 FULLGAME_FILE="$FULL_DIR/fullgame_${TIMESTAMP}.mp4"
 LOG_FILE="$FULL_DIR/fullgame_ffmpeg.log"
 cmd=(ffmpeg -loglevel verbose -f v4l2 -framerate 30 -video_size 426x240 -i /dev/video0 \
-    -c:v libx264 -b:v 2000k -maxrate 3000k -bufsize 4000k -t 03:00:00 -pix_fmt yuv420p \
+    -c:v h264_v4l2m2m -b:v 2000k -maxrate 3000k -bufsize 4000k -t 03:00:00 -pix_fmt yuv420p \
     -c:a aac -b:a 128k "$FULLGAME_FILE")
 echo "Running FFmpeg command: ${cmd[*]}" | tee "$LOG_FILE"
 "${cmd[@]}" >>"$LOG_FILE" 2>&1 &

--- a/smart_crop_stream.py
+++ b/smart_crop_stream.py
@@ -9,7 +9,7 @@ import sys
 import threading
 from datetime import datetime
 from pathlib import Path
-from ffmpeg_utils import build_ffmpeg_args
+from ffmpeg_utils import build_ffmpeg_args, detect_encoder
 from queue import Queue, Full
 
 
@@ -134,7 +134,11 @@ def main() -> None:
 
     tracker = SmartAutoTracker()
 
-    video_encoder = "libx264"
+    try:
+        video_encoder = detect_encoder()
+    except RuntimeError as exc:
+        print(exc)
+        return
     print("[INFO] Streaming raw BGR → FFmpeg rawvideo → RTMP using", video_encoder)
 
     retries = 0

--- a/start_stream.sh
+++ b/start_stream.sh
@@ -55,7 +55,7 @@ LOG_FILE="$LOG_DIR/start_stream_$(date +%Y%m%d_%H%M%S).log"
 cmd=(ffmpeg -loglevel verbose \
     -f v4l2 -framerate 30 -video_size 426x240 -i /dev/video0 \
     -f lavfi -i anullsrc=channel_layout=stereo:sample_rate=44100 \
-    -c:v libx264 -preset veryfast -pix_fmt yuv420p \
+    -c:v h264_v4l2m2m -pix_fmt yuv420p \
     -b:v 2000k -maxrate 3000k -bufsize 4000k -g 60 \
     -c:a aac -b:a 128k \
     -f flv "$YOUTUBE_URL")

--- a/stream_to_youtube.py
+++ b/stream_to_youtube.py
@@ -33,7 +33,7 @@ except Exception:
     psutil = None  # type: ignore
 from datetime import datetime
 from pathlib import Path
-from ffmpeg_utils import build_ffmpeg_args, run_ffmpeg_command
+from ffmpeg_utils import build_ffmpeg_args, run_ffmpeg_command, detect_encoder
 from config import StreamConfig, load_config
 
 try:
@@ -728,7 +728,11 @@ def launch_ffmpeg(
     """
 
     width, height, fps = WIDTH, HEIGHT, FPS
-    video_encoder = "libx264"
+    try:
+        video_encoder = detect_encoder()
+    except RuntimeError as e:
+        print(e)
+        return None
     print("[INFO] Streaming raw BGR → FFmpeg rawvideo → RTMP using", video_encoder)
     log_dir = Path("livestream_logs")
     log_dir.mkdir(exist_ok=True)


### PR DESCRIPTION
## Summary
- Detect available H.264 encoder and prefer Jetson's `h264_v4l2m2m` for YouTube streaming
- Default FFmpeg args to Jetson hardware encoder and update docs
- Update shell scripts to use `h264_v4l2m2m` for video capture and recording

## Testing
- `python -m py_compile stream_to_youtube.py smart_crop_stream.py ffmpeg_utils.py`
- `bash -n start_stream.sh gameday.sh`


------
https://chatgpt.com/codex/tasks/task_e_68965161be3c832da83568787ac978dc