### PR TITLE
Force FFmpeg to convert YUYV422 input to yuv420p

### DIFF
--- a/ffmpeg_utils.py
+++ b/ffmpeg_utils.py
@@ -190,17 +190,17 @@ def build_ffmpeg_args(
 
     if video_codec == "libx264":
         encoder_flags = [
+            "-vf",
+            "format=yuv420p",
             "-c:v",
             video_codec,
             "-preset",
             preset,
             "-tune",
             "zerolatency",
-            "-pix_fmt",
-            "yuv420p",
         ]
     else:
-        encoder_flags = ["-c:v", video_codec, "-pix_fmt", "yuv420p"]
+        encoder_flags = ["-vf", "format=yuv420p", "-c:v", video_codec]
 
     cmd += encoder_flags + [
         "-b:v",

--- a/gameday.sh
+++ b/gameday.sh
@@ -34,7 +34,8 @@ log "Starting full game recording..."
 FULLGAME_FILE="$FULL_DIR/fullgame_${TIMESTAMP}.mp4"
 LOG_FILE="$FULL_DIR/fullgame_ffmpeg.log"
 cmd=(ffmpeg -loglevel verbose -f v4l2 -input_format yuyv422 -framerate 30 -video_size 640x480 -i /dev/video0 \
-    -c:v h264_v4l2m2m -pix_fmt yuv420p -b:v 2500k -maxrate 3000k -bufsize 4000k -t 03:00:00 \
+    -vf format=yuv420p \
+    -c:v h264_v4l2m2m -preset ultrafast -b:v 2500k -maxrate 3000k -bufsize 4000k -t 03:00:00 \
     -c:a aac -b:a 128k "$FULLGAME_FILE")
 echo "Running FFmpeg command: ${cmd[*]}" | tee "$LOG_FILE"
 "${cmd[@]}" >>"$LOG_FILE" 2>&1 &

--- a/start_stream.sh
+++ b/start_stream.sh
@@ -55,7 +55,8 @@ LOG_FILE="$LOG_DIR/start_stream_$(date +%Y%m%d_%H%M%S).log"
 cmd=(ffmpeg -loglevel verbose \
     -f v4l2 -input_format yuyv422 -framerate 30 -video_size 640x480 -i /dev/video0 \
     -f lavfi -i anullsrc=channel_layout=stereo:sample_rate=44100 \
-    -c:v h264_v4l2m2m -pix_fmt yuv420p \
+    -vf format=yuv420p \
+    -c:v h264_v4l2m2m -preset ultrafast \
     -b:v 2500k -maxrate 3000k -bufsize 4000k -g 60 \
     -c:a aac -b:a 128k \
     -f flv "$YOUTUBE_URL")

--- a/stream_to_youtube.py
+++ b/stream_to_youtube.py
@@ -386,10 +386,10 @@ def run_ffmpeg_direct(stream_url: str, audio_device: str = "hw:1,0") -> int:
         "44100",
         "-i",
         audio_device,
+        "-vf",
+        "format=yuv420p",  # Convert raw YUYV422 input for encoder compatibility
         "-c:v",
         "h264_v4l2m2m",
-        "-pix_fmt",
-        "yuv420p",
         "-preset",
         "ultrafast",
         "-b:v",


### PR DESCRIPTION
## Summary
- use `format=yuv420p` filter so FFmpeg accepts YUYV422 camera input
- apply explicit conversion in scripts and utilities for Jetson hardware encoding

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_689663955c20832d9835ee9fefeb1f44