### PR TITLE
Use MJPEG format for FFmpeg capture

### DIFF
--- a/gameday.sh
+++ b/gameday.sh
@@ -33,7 +33,7 @@ STREAM_PID=$!
 log "Starting full game recording..."
 FULLGAME_FILE="$FULL_DIR/fullgame_${TIMESTAMP}.mp4"
 LOG_FILE="$FULL_DIR/fullgame_ffmpeg.log"
-cmd=(ffmpeg -loglevel verbose -f v4l2 -input_format yuyv422 -framerate 30 -video_size 640x480 -i /dev/video0 \
+cmd=(ffmpeg -loglevel verbose -f v4l2 -input_format mjpeg -framerate 30 -video_size 640x480 -i /dev/video0 \
     -vf format=yuv420p \
     -c:v h264_v4l2m2m -preset ultrafast -b:v 2500k -maxrate 3000k -bufsize 4000k -t 03:00:00 \
     -c:a aac -b:a 128k "$FULLGAME_FILE")

--- a/start_stream.sh
+++ b/start_stream.sh
@@ -53,7 +53,7 @@ mkdir -p "$LOG_DIR"
 LOG_FILE="$LOG_DIR/start_stream_$(date +%Y%m%d_%H%M%S).log"
 
 cmd=(ffmpeg -loglevel verbose \
-    -f v4l2 -input_format yuyv422 -framerate 30 -video_size 640x480 -i /dev/video0 \
+    -f v4l2 -input_format mjpeg -framerate 30 -video_size 640x480 -i /dev/video0 \
     -f lavfi -i anullsrc=channel_layout=stereo:sample_rate=44100 \
     -vf format=yuv420p \
     -c:v h264_v4l2m2m -preset ultrafast \

--- a/stream_to_youtube.py
+++ b/stream_to_youtube.py
@@ -371,7 +371,7 @@ def run_ffmpeg_direct(stream_url: str, audio_device: str = "hw:1,0") -> int:
         "-f",
         "v4l2",
         "-input_format",
-        "yuyv422",
+        "mjpeg",
         "-video_size",
         "640x480",
         "-framerate",
@@ -387,7 +387,7 @@ def run_ffmpeg_direct(stream_url: str, audio_device: str = "hw:1,0") -> int:
         "-i",
         audio_device,
         "-vf",
-        "format=yuv420p",  # Convert raw YUYV422 input for encoder compatibility
+        "format=yuv420p",  # Ensure encoder-compatible format
         "-c:v",
         "h264_v4l2m2m",
         "-preset",

--- a/youtube_livestream.py
+++ b/youtube_livestream.py
@@ -141,7 +141,7 @@ def run_ffmpeg(cfg: StreamConfig, *, test: bool = False) -> None:
             maxrate=cfg.maxrate,
             bufsize=cfg.bufsize,
             force_ipv4=cfg.force_ipv4,
-            extra_args=["-input_format", "yuyv422"],
+            extra_args=["-input_format", "mjpeg"],
         )
     elif system == "Windows":
         # Retain Windows-specific command using DirectShow devices.


### PR DESCRIPTION
## Summary
- Switch FFmpeg input format from yuyv422 to mjpeg across streaming scripts
- Update video filter comment to note encoder compatibility

## Testing
- `bash -n start_stream.sh`
- `bash -n gameday.sh`
- `python -m py_compile stream_to_youtube.py youtube_livestream.py`
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*
- `sudo apt-get update` *(fails: repository is not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_68966938bcd8832da31d3d97c9931a71