### PR TITLE
feat: add configurable audio filter for livestream

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,23 @@ Additional options:
 python stream_to_youtube.py --output-size 640x480 --debug
 ```
 
+### Audio tuning
+
+The mic input can be adjusted on the fly via environment variables. Defaults
+favor sideline speech but can be tweaked for different environments:
+
+```bash
+# Stronger leveling for a noisy crowd
+export AUDIO_MODE=crowd
+export AUDIO_GAIN_DB=10
+
+# Cut more wind/rumble
+export AUDIO_HIGHPASS=150
+
+# If things sound over-compressed
+export AUDIO_GAIN_DB=6  # or set AUDIO_MODE=off
+```
+
 ## Requirements
 
 - Python 3


### PR DESCRIPTION
## Summary
- add `build_audio_filter` helper for safe gain, compression, limiting, and optional auto-normalization
- integrate audio filter and higher 160k bitrate into ffmpeg command
- document runtime audio tuning env vars in README

## Testing
- `python -m py_compile stream_to_youtube.py`


------
https://chatgpt.com/codex/tasks/task_e_68975066b9f0832dad9afcb8c72a292e