### PR TITLE
Add stub player identification subsystem

### DIFF
--- a/config/player_id.yaml
+++ b/config/player_id.yaml
@@ -1,0 +1,8 @@
+reid_backbone: "clip_vit_b32"
+tracker: "bytetrack"
+w_emb: 0.65
+w_attr: 0.30
+w_size: 0.05
+confidence_threshold: 0.72
+min_labels_per_player: 5
+ui_max_uncertain: 12

--- a/data/players.json
+++ b/data/players.json
@@ -1,0 +1,16 @@
+[
+  {
+    "player_id": "P01",
+    "name": "Player One",
+    "position": null,
+    "appearance": {"cleats": "green", "socks": "white"},
+    "embedding": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]
+  },
+  {
+    "player_id": "P02",
+    "name": "Player Two",
+    "position": null,
+    "appearance": {"cleats": "blue", "socks": "white"},
+    "embedding": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0]
+  }
+]

--- a/mca_film/analyze.py
+++ b/mca_film/analyze.py
@@ -18,6 +18,12 @@ import subprocess
 from .models import CoachSummary, PlayAnalysis, PlayerGrade
 from .grading import grade_play
 
+# Lightweight player identification pipeline components.  These are simple
+# stubs that enable unit tests to exercise the integration points without
+# requiring heavy ML dependencies.
+from player_id import assign_player_ids, io as pid_io, tracker as pid_tracker
+from schemas import Tracklet
+
 
 def _detect_fps(video_path: str) -> float:
     if cv2 is not None:
@@ -65,6 +71,16 @@ def analyze_game(video_path: str, side: str, roster: dict, settings: dict) -> Li
     """
 
     fps = _detect_fps(video_path)
+
+    # ------------------------------------------------------------------
+    # Player identification: run a stub tracker and attempt to associate
+    # tracklets with known player profiles.  The resulting IDs are not used in
+    # the toy grading logic but the call verifies the subsystem wiring.
+    pid_settings = settings.get("player_id", {})
+    player_profiles = pid_io.load_roster(pid_settings.get("roster_path", "data/players.json"))
+    tracklets: List[Tracklet] = pid_tracker.track([])
+    assign_player_ids(tracklets, player_profiles, pid_settings)
+
     # In the real system we would split plays and track players. Here we
     # simply fabricate a single play with neutral grades.
     analyses: List[PlayAnalysis] = []

--- a/mca_film/cli.py
+++ b/mca_film/cli.py
@@ -19,6 +19,11 @@ def main(argv: list[str] | None = None) -> None:
     analyze_p.add_argument("--side", choices=["offense", "defense"], default="offense")
     analyze_p.add_argument("--roster", default="config/roster.json")
     analyze_p.add_argument("--settings", default="config/settings.yaml")
+    analyze_p.add_argument("--calibrate", action="store_true")
+    analyze_p.add_argument("--min-confidence", type=float, default=0.72)
+    analyze_p.add_argument("--export-clips", action="store_true")
+    analyze_p.add_argument("--export-summary", action="store_true")
+    analyze_p.add_argument("--export-highlights", action="store_true")
 
     export_p = sub.add_parser("export", help="export reports or clips")
     export_p.add_argument("--report", choices=["coaches"], nargs="?")
@@ -40,6 +45,15 @@ def main(argv: list[str] | None = None) -> None:
             out_path.write_text(json.dumps(play, default=lambda o: o.__dict__, indent=2))
         # save a marker that analysis completed
         Path("out/analysis.done").write_text("ok")
+
+        # Optional exports triggered via flags to mirror the command line
+        if args.export_summary:
+            export_coach_summary(analyses)
+        if args.export_clips:
+            for pid in roster.keys():
+                export_player_clips(analyses, pid)
+        if args.export_highlights:
+            export_highlights(analyses)
     elif args.cmd == "export":
         # Load analyses from prior run if available
         analyses = []

--- a/player_id/README.md
+++ b/player_id/README.md
@@ -1,0 +1,11 @@
+# Player Identification Calibration
+
+This package contains a lightweight placeholder for the player appearance
+calibration flow.  In a full deployment coaches would open a small UI that
+presents uncertain tracklets and allows them to tag players by visual
+attributes (cleat color, socks, etc.).  The resulting labelled data is saved to
+`data/players.json` and reused on subsequent runs.
+
+The current implementation does not provide a full UI but exposes a
+`launch_ui` function so the analysis pipeline can request calibration when
+needed.

--- a/player_id/__init__.py
+++ b/player_id/__init__.py
@@ -1,0 +1,12 @@
+"""Player identification package."""
+
+from .io import load_roster, save_roster
+from .assign import assign_player_ids
+from .tracker import track
+
+__all__ = [
+    "load_roster",
+    "save_roster",
+    "assign_player_ids",
+    "track",
+]

--- a/player_id/assign.py
+++ b/player_id/assign.py
@@ -1,0 +1,58 @@
+"""Assignment of tracklets to known player profiles."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+import numpy as np
+
+from schemas import PlayerProfile, Tracklet
+from .reid import tracklet_signature
+
+
+def _color_distance(attrs: Dict[str, str], appearance: Dict[str, str]) -> float:
+    """Simple attribute distance: count mismatched string values."""
+
+    dist = 0.0
+    for key, val in appearance.items():
+        if attrs.get(key) != val:
+            dist += 1.0
+    return dist
+
+
+def assign_player_ids(
+    tracklets: List[Tracklet], roster: List[PlayerProfile], rules: Dict
+) -> List[Tracklet]:
+    """Assign stable player IDs to tracklets.
+
+    The matching uses a simple weighted distance combining cosine distance of
+    embeddings and mismatches in appearance attributes.  It greedily assigns
+    the best matching profile to each tracklet and records a confidence score.
+    """
+
+    profiles = {p.player_id: p for p in roster}
+    w_emb = rules.get("w_emb", 0.65)
+    w_attr = rules.get("w_attr", 0.30)
+    threshold = rules.get("confidence_threshold", 0.0)
+
+    for t in tracklets:
+        sig = tracklet_signature(t)
+        best_pid = None
+        best_score = float("inf")
+        for pid, prof in profiles.items():
+            emb = np.array(prof.embedding or np.zeros_like(sig["avg_emb"]))
+            if emb.size == 0:
+                d_emb = 1.0
+            else:
+                d_emb = 1.0 - float(np.dot(sig["avg_emb"], emb))
+            d_attr = _color_distance(sig["attr"], prof.appearance)
+            score = w_emb * d_emb + w_attr * d_attr
+            if score < best_score:
+                best_score = score
+                best_pid = pid
+        confidence = 1.0 - best_score
+        if confidence < threshold:
+            t.assigned_player_id = None
+        else:
+            t.assigned_player_id = best_pid
+        t.confidence = confidence
+    return tracklets

--- a/player_id/attributes.py
+++ b/player_id/attributes.py
@@ -1,0 +1,16 @@
+"""Attribute extraction heuristics."""
+
+from __future__ import annotations
+
+from typing import Dict, Tuple
+
+
+def extract_attributes(img_crop, full_frame_bbox: Tuple[int, int, int, int]) -> Dict[str, str]:
+    """Extract simple color attributes from a player crop.
+
+    This stub merely returns an empty dictionary.  Real implementations would
+    analyze the image to derive cleat/sock/glove colors and size estimates.
+    """
+
+    _ = (img_crop, full_frame_bbox)
+    return {}

--- a/player_id/calibration_ui.py
+++ b/player_id/calibration_ui.py
@@ -1,0 +1,14 @@
+"""Minimal calibration UI placeholder."""
+
+from __future__ import annotations
+
+
+def launch_ui(tracklets, roster):  # pragma: no cover - UI is not tested
+    """Pretend to launch a calibration interface.
+
+    A real implementation might use Streamlit or Flask.  Here we simply print a
+    message so the function can be invoked in scripts without failing.
+    """
+
+    print("Calibration UI requested for", len(tracklets), "tracklets")
+    _ = roster

--- a/player_id/detector.py
+++ b/player_id/detector.py
@@ -1,0 +1,14 @@
+"""Stub player detector."""
+
+from __future__ import annotations
+from typing import List, Dict
+
+
+def detect_players(frame) -> List[Dict]:
+    """Return bounding boxes for players in a frame.
+
+    The real system would run an object detector.  For the purposes of unit
+    tests we simply return an empty list which callers must handle.
+    """
+
+    return []

--- a/player_id/io.py
+++ b/player_id/io.py
@@ -1,0 +1,28 @@
+"""Persistence helpers for player profiles."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List
+
+from schemas import PlayerProfile
+
+
+def load_roster(path: str = "data/players.json") -> List[PlayerProfile]:
+    """Load player profiles from ``path`` if it exists."""
+
+    p = Path(path)
+    if not p.exists():
+        return []
+    data = json.loads(p.read_text())
+    return [PlayerProfile(**item) for item in data]
+
+
+def save_roster(roster: List[PlayerProfile], path: str = "data/players.json") -> None:
+    """Persist player profiles to ``path``."""
+
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    data = [r.__dict__ for r in roster]
+    p.write_text(json.dumps(data, indent=2))

--- a/player_id/reid.py
+++ b/player_id/reid.py
@@ -1,0 +1,37 @@
+"""Re-identification helpers."""
+
+from __future__ import annotations
+
+from typing import Dict
+import numpy as np
+
+from schemas import Tracklet
+from .attributes import extract_attributes
+
+
+def embed_crop(img_crop) -> np.ndarray:
+    """Return an L2-normalized embedding for a cropped player image.
+
+    In tests we use deterministic pseudo-random embeddings based on the image
+    bytes to avoid heavy model dependencies.
+    """
+
+    data = np.frombuffer(getattr(img_crop, "tobytes", lambda: b"")(), dtype=np.uint8)
+    if data.size == 0:
+        emb = np.zeros(8, dtype=np.float32)
+    else:
+        emb = (data[:8].astype(np.float32) + 1.0) / 255.0
+    norm = np.linalg.norm(emb) or 1.0
+    return emb / norm
+
+
+def tracklet_signature(track: Tracklet) -> Dict[str, object]:
+    """Compute an average embedding and merge attributes for a tracklet."""
+
+    if track.embeddings:
+        emb = np.mean(np.asarray(track.embeddings), axis=0)
+        emb = emb / (np.linalg.norm(emb) or 1.0)
+    else:
+        emb = np.zeros(8, dtype=np.float32)
+    attr = track.attributes.copy()
+    return {"avg_emb": emb, "attr": attr}

--- a/player_id/tracker.py
+++ b/player_id/tracker.py
@@ -1,0 +1,18 @@
+"""Simple tracker placeholder."""
+
+from __future__ import annotations
+from typing import Iterable, List
+
+from schemas import Tracklet
+
+
+def track(sequence_frames: Iterable[object]) -> List[Tracklet]:
+    """Run detection and tracking on a sequence of frames.
+
+    This placeholder implementation simply returns an empty list.  Real
+    detection/tracking would create :class:`Tracklet` instances with frame
+    indices, bounding boxes and embeddings.
+    """
+
+    _ = sequence_frames  # unused in stub
+    return []

--- a/schemas.py
+++ b/schemas.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+"""Core data schemas for player identification."""
+
+from dataclasses import dataclass, field
+from typing import List, Tuple, Dict, Optional
+
+
+@dataclass
+class PlayerProfile:
+    """Visual profile for a player used during identification."""
+
+    player_id: str
+    name: Optional[str] = None
+    position: Optional[str] = None
+    appearance: Dict[str, str] = field(default_factory=dict)
+    embedding: Optional[List[float]] = None
+    notes: Optional[str] = None
+
+
+@dataclass
+class Tracklet:
+    """Short term track of a single player within the video."""
+
+    tid: int
+    frames: List[int]
+    bboxes: List[Tuple[int, int, int, int]]
+    embeddings: List[List[float]]
+    attributes: Dict[str, object] = field(default_factory=dict)
+    assigned_player_id: Optional[str] = None
+    confidence: float = 0.0

--- a/tests/test_player_id.py
+++ b/tests/test_player_id.py
@@ -1,0 +1,35 @@
+import numpy as np
+
+from schemas import PlayerProfile, Tracklet
+from player_id.assign import assign_player_ids
+
+
+def make_tracklet(tid, emb, attr):
+    return Tracklet(tid=tid, frames=[0], bboxes=[(0, 0, 1, 1)], embeddings=[emb], attributes=attr)
+
+
+def test_stable_assignment():
+    p1 = PlayerProfile(player_id="P01", appearance={"cleats": "green"}, embedding=[1, 0, 0, 0, 0, 0, 0, 0])
+    p2 = PlayerProfile(player_id="P02", appearance={"cleats": "blue"}, embedding=[0, 1, 0, 0, 0, 0, 0, 0])
+    t1 = make_tracklet(1, np.array(p1.embedding), {"cleats": "green"})
+    t2 = make_tracklet(2, np.array(p2.embedding), {"cleats": "blue"})
+    tracks = assign_player_ids([t1, t2], [p1, p2], {"confidence_threshold": 0.0})
+    assert tracks[0].assigned_player_id == "P01"
+    assert tracks[1].assigned_player_id == "P02"
+
+
+def test_attribute_disambiguation():
+    p1 = PlayerProfile(player_id="P01", appearance={"cleats": "green", "socks": "white"}, embedding=[0]*8)
+    p2 = PlayerProfile(player_id="P02", appearance={"cleats": "blue", "socks": "white"}, embedding=[0]*8)
+    t1 = make_tracklet(1, np.zeros(8), {"cleats": "green", "socks": "white"})
+    t2 = make_tracklet(2, np.zeros(8), {"cleats": "blue", "socks": "white"})
+    tracks = assign_player_ids([t1, t2], [p1, p2], {"confidence_threshold": 0.0, "w_emb": 0.0, "w_attr": 1.0})
+    assert tracks[0].assigned_player_id == "P01"
+    assert tracks[1].assigned_player_id == "P02"
+
+
+def test_low_confidence_unassigned():
+    p1 = PlayerProfile(player_id="P01", appearance={}, embedding=[1,0,0,0,0,0,0,0])
+    t1 = make_tracklet(1, np.zeros(8), {})
+    tracks = assign_player_ids([t1], [p1], {"confidence_threshold": 0.5})
+    assert tracks[0].assigned_player_id is None


### PR DESCRIPTION
## Summary
- introduce PlayerProfile and Tracklet schemas
- add placeholder `player_id` package with detection, tracking, re-id and assignment helpers
- integrate player ID stubs into analysis pipeline and CLI with new flags
- include default config and sample players roster
- add unit tests for player assignment

## Testing
- `pytest tests/test_player_id.py tests/test_mca_film.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6898242c2b64832d91516c5601998d9d