### PR TITLE
Add defensive playbook parsing and grading support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,29 @@ coach report under `output/reports/`.
 The coach summary report includes per-play tables and player grades. A
 sample output is generated during tests under `tests/data`.
 
+## Playbook
+
+Playbooks may be authored in a legacy flat list format or using the
+new `split_sections` schema.  The latter separates offense and defense
+sections:
+
+```json
+{
+  "schema": "split_sections",
+  "offense": {"plays": [{"name": "Rit Dive", "formation": "Rit"}]},
+  "defense": {
+    "positions": [{"name": "DT1", "gap": "A"}],
+    "calls": [{"cue": "RUN", "trigger": "downfield blocking"}]
+  }
+}
+```
+
+When using `split_sections` the `defense.positions` array is required and
+the pipeline will raise an error if it is missing.  Defensive grading weights
+can be customised by editing
+`analysis/configs/grading_weights_defense.yaml`; defaults are used when the
+file is absent.
+
 ## Processing uploaded game film
 
 Place a video inside `video/manual_uploads/` and run:

--- a/analysis/assignments.py
+++ b/analysis/assignments.py
@@ -3,44 +3,162 @@
 from __future__ import annotations
 
 import json
-from typing import Dict, List, Any
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
 
 from . import assignments_schema
 
 
-def load_playbook(path: str | None) -> Dict[str, Any]:
+@dataclass
+class OffensePlay:
+    """Representation of an offensive play."""
+
+    name: str
+    formation: str
+    motion: str | None = None
+    roles: Dict[str, Any] | None = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a dictionary representation for recogniser consumption."""
+
+        data = {"name": self.name, "formation": self.formation}
+        if self.motion is not None:
+            data["motion"] = self.motion
+        if self.roles is not None:
+            data["roles"] = self.roles
+        return data
+
+
+@dataclass
+class DefensePosition:
+    """Representation of a defensive position and responsibilities."""
+
+    name: str
+    tech: str | None = None
+    gap: str | None = None
+    responsibilities: List[str] = field(default_factory=list)
+
+
+@dataclass
+class Playbook:
+    """Normalised playbook structure used throughout the pipeline."""
+
+    offense_plays: List[OffensePlay] = field(default_factory=list)
+    defense_positions: List[DefensePosition] = field(default_factory=list)
+    calls: Dict[str, str] = field(default_factory=dict)
+    schema: str = "minimal"
+
+
+def _load_default() -> Playbook:
+    canon = assignments_schema.CANONICAL_TEMPLATE
+    return Playbook()
+
+
+def load_playbook(path: str | None) -> Playbook:
     """Load and normalise a playbook file.
 
-    The loader accepts a variety of JSON layouts and converts them into a
-    canonical in-memory representation.  Unknown keys are ignored with a
-    warning while missing required fields trigger :class:`ValueError` with a
-    helpful message.
+    Supports legacy flat formats and the new ``split_sections`` schema.  The
+    returned :class:`Playbook` exposes offensive plays, defensive positions and
+    optional defensive calls in a single dataclass.
     """
 
     if not path:
-        return assignments_schema.CANONICAL_TEMPLATE.copy()
+        return _load_default()
 
     with open(path, "r", encoding="utf8") as f:
         data = json.load(f)
 
     schema = assignments_schema.detect_schema(data)
-    playbook = assignments_schema.normalise(data)
+
+    offense_plays_raw: List[Dict[str, Any]] = []
+    defense_positions_raw: Any = []
+    calls_raw: Any = {}
+
+    if schema == "split_sections":
+        offense = data.get("offense", {})
+        defense = data.get("defense", {})
+        offense_plays_raw = offense.get("plays", [])
+        defense_positions_raw = defense.get("positions", []) or defense.get("base", {}).get("alignment", {})
+        calls_raw = defense.get("calls", {})
+        if not defense_positions_raw:
+            raise ValueError("Playbook missing defense.positions")
+    elif schema == "flat_lists":
+        offense_plays_raw = data.get("plays") or data.get("offense_plays", [])
+        defense_positions_raw = data.get("defense_positions", [])
+        calls_raw = data.get("calls", {})
+    else:  # minimal
+        for name, details in data.items():
+            if not isinstance(details, dict):
+                continue
+            formation = details.get("formation")
+            if formation:
+                offense_plays_raw.append(
+                    {"name": name, "formation": formation, "motion": details.get("motion")}
+                )
+        defense_positions_raw = data.get("defense_positions", [])
+        calls_raw = data.get("calls", {})
+
+    offense_plays = [
+        OffensePlay(
+            name=p.get("name", ""),
+            formation=p.get("formation", ""),
+            motion=p.get("motion"),
+            roles=p.get("roles") or p.get("assignments"),
+        )
+        for p in offense_plays_raw
+        if p.get("name") and p.get("formation")
+    ]
+
+    defense_positions: List[DefensePosition] = []
+    if isinstance(defense_positions_raw, dict):
+        for name, info in defense_positions_raw.items():
+            if not isinstance(info, dict):
+                continue
+            defense_positions.append(
+                DefensePosition(
+                    name=name,
+                    tech=info.get("tech"),
+                    gap=info.get("gap"),
+                    responsibilities=info.get("responsibilities", []),
+                )
+            )
+    else:
+        for pos in defense_positions_raw:
+            if not isinstance(pos, dict):
+                continue
+            defense_positions.append(
+                DefensePosition(
+                    name=pos.get("name", ""),
+                    tech=pos.get("tech"),
+                    gap=pos.get("gap"),
+                    responsibilities=pos.get("responsibilities", []),
+                )
+            )
+
+    if isinstance(calls_raw, list):
+        calls = {c.get("cue"): c.get("trigger") for c in calls_raw if c.get("cue")}
+    else:
+        calls = {str(k): str(v) for k, v in calls_raw.items()}
+
+    playbook = Playbook(
+        offense_plays=offense_plays,
+        defense_positions=defense_positions,
+        calls=calls,
+        schema=schema,
+    )
 
     # Emit helpful logging for tests / CLI users
     print(
         f"Detected playbook schema: {schema}\n"
-        f"Loaded offense plays: {len(playbook['offense']['plays'])}, "
-        f"defense positions: {len(playbook['defense']['positions'])}"
+        f"Loaded offense plays: {len(offense_plays)}, defense positions: {len(defense_positions)}"
     )
     return playbook
 
 
-def assignments_for_play(play_name: str, playbook: Dict[str, Any]) -> Dict[str, Any]:
+def assignments_for_play(play_name: str, playbook: Playbook) -> Dict[str, Any]:
     """Return assignment mapping for ``play_name`` if present."""
 
-    plays = playbook.get("offense", {}).get("plays", [])
-    for play in plays:
-        if play.get("name") == play_name:
-            # Prefer new ``roles`` section but fall back to ``assignments``
-            return play.get("roles") or play.get("assignments", {})
+    for play in playbook.offense_plays:
+        if play.name == play_name:
+            return play.roles or {}
     return {}

--- a/analysis/configs/grading_weights_defense.yaml
+++ b/analysis/configs/grading_weights_defense.yaml
@@ -1,0 +1,21 @@
+EDGE:
+  contain: 1.0
+  leverage: 1.0
+  depth_control: 0.5
+  pursuit: 0.5
+  assignment: 1.0
+DT:
+  gap_fill: 1.2
+  knockback: 1.0
+  shed: 0.6
+  assignment: 1.2
+LB:
+  read_first: 1.0
+  correct_fill_or_drop: 1.0
+  pursuit_angle: 0.6
+  assignment: 1.0
+DB:
+  cushion_depth: 1.0
+  leverage: 0.6
+  break_on_ball: 0.6
+  assignment: 0.8

--- a/analysis/grading.py
+++ b/analysis/grading.py
@@ -1,41 +1,153 @@
-"""Simplified player grading utilities.
-
-The production system applies a rich set of coaching rubrics to evaluate
-player performance.  For unit testing we only need a lightweight stub
-that produces deterministic output so downstream reporting and clipping
-logic can be exercised.
-"""
+"""Simplified player grading utilities with defensive rubric."""
 
 from __future__ import annotations
 
+import os
 from typing import Any, Dict, Iterable, List
+
+from .assignments import Playbook
+
+# ---------------------------------------------------------------------------
+# Weight handling
+# ---------------------------------------------------------------------------
+
+
+DEFAULT_WEIGHTS: Dict[str, Dict[str, float]] = {
+    "EDGE": {
+        "contain": 1.0,
+        "leverage": 1.0,
+        "depth_control": 0.5,
+        "pursuit": 0.5,
+        "assignment": 1.0,
+    },
+    "DT": {
+        "gap_fill": 1.2,
+        "knockback": 1.0,
+        "shed": 0.6,
+        "assignment": 1.2,
+    },
+    "LB": {
+        "read_first": 1.0,
+        "correct_fill_or_drop": 1.0,
+        "pursuit_angle": 0.6,
+        "assignment": 1.0,
+    },
+    "DB": {
+        "cushion_depth": 1.0,
+        "leverage": 0.6,
+        "break_on_ball": 0.6,
+        "assignment": 0.8,
+    },
+}
+
+
+DEFAULT_WEIGHTS_PATH = os.path.join(
+    os.path.dirname(__file__), "configs", "grading_weights_defense.yaml"
+)
+
+POSITION_GROUP = {
+    "LE": "EDGE",
+    "RE": "EDGE",
+    "Monster": "EDGE",
+    "Blood": "EDGE",
+    "DT1": "DT",
+    "DT3": "DT",
+    "Mike": "LB",
+    "Will": "LB",
+    "FS": "DB",
+    "LCB": "DB",
+    "RCB": "DB",
+}
+
+FAIL_SIGNALS = {
+    "EDGE": {
+        "contain": "lost_edge",
+        "leverage": "lost_leverage",
+        "depth_control": "depth_violation",
+        "pursuit": "pursuit_miss",
+        "assignment": "assignment_error",
+    },
+    "DT": {
+        "gap_fill": "wrong_gap",
+        "knockback": "no_knockback",
+        "shed": "no_shed",
+        "assignment": "assignment_error",
+    },
+    "LB": {
+        "read_first": "late_read",
+        "correct_fill_or_drop": "wrong_gap",
+        "pursuit_angle": "bad_angle",
+        "assignment": "assignment_error",
+    },
+    "DB": {
+        "cushion_depth": "depth_violation",
+        "leverage": "lost_leverage",
+        "break_on_ball": "late_break",
+        "assignment": "assignment_error",
+    },
+}
+
+
+def _load_weights(path: str | None) -> Dict[str, Dict[str, float]]:
+    target = path or DEFAULT_WEIGHTS_PATH
+    weights = DEFAULT_WEIGHTS
+    if os.path.exists(target):
+        try:
+            import yaml  # type: ignore
+
+            with open(target, "r", encoding="utf8") as f:
+                data = yaml.safe_load(f)
+            if isinstance(data, dict):
+                weights = data  # type: ignore[assignment]
+        except Exception:
+            pass
+    return weights
+
+
+def _grade_player(group: str, signals: Dict[str, Any], weights: Dict[str, Dict[str, float]]):
+    metrics = weights.get(group, {})
+    total = sum(metrics.values()) or 1.0
+    score = 0.0
+    mistakes: List[str] = []
+    positives: List[str] = []
+    for metric, weight in metrics.items():
+        failure_key = FAIL_SIGNALS.get(group, {}).get(metric, "")
+        failed = signals.get(failure_key, False)
+        if failed:
+            mistakes.append(metric)
+        else:
+            positives.append(metric)
+            score += weight
+    grade = round((score / total) * 4, 2)
+    return grade, mistakes, positives
 
 
 def grade(
     predictions: Iterable[Dict[str, Any]],
     tracks: Iterable[Any],
     identity_map: Dict[str, str],
-    playbook: Dict[str, Any] | None = None,
+    playbook: Playbook | None = None,
     weights_path: str | None = None,
 ) -> List[Dict[str, Any]]:
-    """Return placeholder grades for each play.
+    """Return grades for each play with defensive evaluation."""
 
-    Each player starts at 100 points and no mistakes are recorded.  The
-    structure mirrors the shape expected by :mod:`analysis.report` and
-    :mod:`analysis.clipping`.
-    """
-
+    weights = _load_weights(weights_path)
     results: List[Dict[str, Any]] = []
     for pred in predictions:
-        players = {
-            identity_map.get(t.player_id, t.player_id): {
-                "grade": 100,
+        players: Dict[str, Dict[str, Any]] = {}
+        for t in tracks:
+            pid = identity_map.get(t.player_id, t.player_id)
+            role = getattr(t, "role_hint", None)
+            group = POSITION_GROUP.get(role, "DB")
+            signals = getattr(t, "signals", {}) or {}
+            grade_score, mistakes, positives = _grade_player(group, signals, weights)
+            players[pid] = {
+                "grade": grade_score,
                 "notes": [],
-                "mistakes": [],
-                "positives": [],
+                "mistakes": mistakes,
+                "positives": positives,
+                "position": role,
             }
-            for t in tracks
-        }
         results.append(
             {
                 "play_id": pred["play_id"],
@@ -48,3 +160,4 @@ def grade(
             }
         )
     return results
+

--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -64,8 +64,14 @@ def run_pipeline(
     _write_jsonl([p.as_dict() for p in plays], os.path.join(out_dir, "plays.jsonl"))
 
     playbook = assignments.load_playbook(playbook_path)
+    print(
+        f"Loaded offense plays: {len(playbook.offense_plays)}, defense positions: {len(playbook.defense_positions)}"
+    )
+    if playbook.schema == "split_sections" and not playbook.defense_positions:
+        raise SystemExit("Playbook missing defense.positions")
+
     preds = play_recognizer.recognize(
-        [p.as_dict() for p in plays], playbook["offense"]["plays"]
+        [p.as_dict() for p in plays], [pl.to_dict() for pl in playbook.offense_plays]
     )
     _write_jsonl(preds, os.path.join(out_dir, "play_predictions.jsonl"))
 

--- a/analysis/report.py
+++ b/analysis/report.py
@@ -39,6 +39,47 @@ def generate(grades: Iterable[Dict[str, Any]], out_dir: str) -> None:
             lines.append(f"- {player}: {g['grade']}")
         lines.append("")
 
+    # ------------------------------------------------------------------
+    # Simple defence summary
+    # ------------------------------------------------------------------
+    edge_total = gap_total = read_total = 0
+    edge_mistakes = gap_mistakes = read_mistakes = 0
+    explosive = 0
+    pos_grades: Dict[str, list[float]] = {}
+    pos_corrections: Dict[str, list[str]] = {}
+    for play in grades:
+        for player, g in play["players"].items():
+            pos = g.get("position") or "Unknown"
+            pos_grades.setdefault(pos, []).append(g["grade"])
+            pos_corrections.setdefault(pos, []).extend(g["mistakes"])
+            edge_total += 1
+            gap_total += 1
+            read_total += 1
+            if "contain" in g["mistakes"]:
+                edge_mistakes += 1
+            if "gap_fill" in g["mistakes"]:
+                gap_mistakes += 1
+            if "read_first" in g["mistakes"]:
+                read_mistakes += 1
+            if "explosive_play" in g["mistakes"]:
+                explosive += 1
+
+    lines.extend(["## Defense", ""])
+    if edge_total:
+        lines.append(f"Edge-set rate: {1 - edge_mistakes / edge_total:.2f}")
+    if gap_total:
+        lines.append(f"Correct-gap rate: {1 - gap_mistakes / gap_total:.2f}")
+    if read_total:
+        lines.append(f"Read correctness: {1 - read_mistakes / read_total:.2f}")
+    lines.append(f"Explosive plays allowed: {explosive}")
+    lines.append("")
+    lines.append("### Position Groups")
+    for pos, grades_list in pos_grades.items():
+        avg = sum(grades_list) / len(grades_list)
+        corr = ", ".join(pos_corrections.get(pos, [])[:3])
+        lines.append(f"- {pos}: avg {avg:.2f} | corrections: {corr}")
+    lines.append("")
+
     with open(md_path, "w", encoding="utf8") as f:
         f.write("\n".join(lines))
 

--- a/tests/fixtures/sample_playbook_split.json
+++ b/tests/fixtures/sample_playbook_split.json
@@ -1,0 +1,14 @@
+{
+  "schema": "split_sections",
+  "offense": { "plays": [ {"name": "Rit Dive", "formation": "Rit"} ] },
+  "defense": {
+    "positions": [
+      {"name":"DT1","tech":"1","gap":"A (weak)","responsibilities":["anchor"]},
+      {"name":"DT3","tech":"3","gap":"B (strong)","responsibilities":["penetrate"]}
+    ],
+    "calls": [
+      {"cue":"RUN","trigger":"downfield blocking"},
+      {"cue":"PASS","trigger":"pass set"}
+    ]
+  }
+}

--- a/tests/test_defense_grading_basics.py
+++ b/tests/test_defense_grading_basics.py
@@ -1,0 +1,27 @@
+from types import SimpleNamespace
+from analysis import grading
+
+
+def _track(pid, role, signals=None):
+    return SimpleNamespace(player_id=pid, role_hint=role, signals=signals or {})
+
+
+def test_defense_grading_basics():
+    preds = [{"play_id": 1, "predicted_play": "UNKNOWN", "confidence": 0.0}]
+    base_tracks = [
+        _track("1", "LE"),
+        _track("2", "DT1"),
+        _track("3", "Mike"),
+        _track("4", "FS"),
+    ]
+    base = grading.grade(preds, base_tracks, {}, None)[0]["players"]
+
+    edge_grade = grading.grade(preds, [_track("1", "LE", {"lost_edge": True})], {}, None)[0]["players"]["1"]["grade"]
+    dt_grade = grading.grade(preds, [_track("2", "DT1", {"wrong_gap": True})], {}, None)[0]["players"]["2"]["grade"]
+    lb_grade = grading.grade(preds, [_track("3", "Mike", {"late_read": True})], {}, None)[0]["players"]["3"]["grade"]
+    db_grade = grading.grade(preds, [_track("4", "FS", {"depth_violation": True})], {}, None)[0]["players"]["4"]["grade"]
+
+    assert edge_grade < base["1"]["grade"]
+    assert dt_grade < base["2"]["grade"]
+    assert lb_grade < base["3"]["grade"]
+    assert db_grade < base["4"]["grade"]

--- a/tests/test_playbook_loader.py
+++ b/tests/test_playbook_loader.py
@@ -28,6 +28,7 @@ def test_normalise_variants(minimal, split_sections, flat_lists):
 def test_real_playbooks_same_structure():
     pb1 = assignments.load_playbook("mca_full_playbook_final.json")
     pb2 = assignments.load_playbook("mca_playbook.json")
-    assert set(pb1.keys()) == set(pb2.keys())
-    assert set(pb1["offense"].keys()) == set(pb2["offense"].keys())
-    assert set(pb1["defense"].keys()) == set(pb2["defense"].keys())
+    assert isinstance(pb1.offense_plays, list)
+    assert isinstance(pb2.offense_plays, list)
+    assert isinstance(pb1.defense_positions, list)
+    assert isinstance(pb2.defense_positions, list)

--- a/tests/test_playbook_loader_split_sections.py
+++ b/tests/test_playbook_loader_split_sections.py
@@ -1,0 +1,8 @@
+from analysis import assignments
+
+
+def test_split_sections_loader():
+    pb = assignments.load_playbook("tests/fixtures/sample_playbook_split.json")
+    assert len(pb.defense_positions) > 0
+    names = [p.name for p in pb.defense_positions]
+    assert "DT1" in names and "DT3" in names


### PR DESCRIPTION
## Summary
- Introduce `Playbook` dataclass handling offense plays, defense positions and calls
- Add defensive grading rubric with configurable weights and position signal mapping
- Extend pipeline and reporting to validate defensive data and summarise defensive performance

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68983241af3c832da4b5cda7883a070a