### PR TITLE
Add debug video overlay with segment details

### DIFF
--- a/analysis/debug_overlay.py
+++ b/analysis/debug_overlay.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+import json, math, subprocess, shutil
+from pathlib import Path
+from typing import List, Dict, Any
+
+
+def _sec_from_frame(f: int, fps: float) -> float:
+    return max(0.0, float(f) / float(fps or 30.0))
+
+
+def _fmt_ass_time(t: float) -> str:
+    # ASS wants H:MM:SS.cs (centiseconds)
+    h = int(t // 3600)
+    m = int((t % 3600) // 60)
+    s = int(t % 60)
+    cs = int(round((t - int(t)) * 100))
+    if cs == 100:
+        s += 1
+        cs = 0
+    return f"{h}:{m:02d}:{s:02d}.{cs:02d}"
+
+
+def _load_grades(grades_path: Path, n_segments: int) -> Dict[int, Dict[str, Any]]:
+    """Returns map: index -> {"overall": float, "mode": "full"|"fallback"}
+
+    Accepts either {"play_index": i, "overall_defense": x, "grading_mode": "..."} or
+    sequential lines. Falls back to index order if play_index missing.
+    """
+    out: Dict[int, Dict[str, Any]] = {}
+    if not grades_path.exists():
+        return out
+    lines = [ln for ln in grades_path.read_text().splitlines() if ln.strip()]
+    for i, ln in enumerate(lines[:n_segments]):
+        try:
+            o = json.loads(ln)
+        except Exception:
+            continue
+        idx = o.get("play_index")
+        if isinstance(idx, int) and 0 <= idx < n_segments:
+            k = idx
+        else:
+            k = i
+        out[k] = {
+            "overall": float(o.get("overall_defense", 0.0)),
+            "mode": str(
+                o.get("grading_mode", "full" if "overall_defense" in o else "fallback")
+            ),
+        }
+    return out
+
+
+def build_debug_video(
+    video_path: Path,
+    out_dir: Path,
+    segments: List[Dict[str, Any]],
+    fps: float,
+    formations: List[str],
+    play_matches: List[Dict[str, Any]],
+    grades_path: Path,
+) -> Path:
+    """Writes:
+      out_dir/debug/debug.ass
+      out_dir/debug/debug.mp4  (source video with ASS burned-in)
+    """
+    dbg_dir = out_dir / "debug"
+    dbg_dir.mkdir(parents=True, exist_ok=True)
+    ass_path = dbg_dir / "debug.ass"
+    out_vid = dbg_dir / "debug.mp4"
+
+    grades = _load_grades(grades_path, len(segments))
+
+    # ASS header with readable style (top-left)
+    header = (
+        "[Script Info]\n"
+        "ScriptType: v4.00+\n"
+        "PlayResX: 1280\n"
+        "PlayResY: 720\n"
+        "ScaledBorderAndShadow: yes\n"
+        "\n"
+        "[V4+ Styles]\n"
+        "Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, "
+        "Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, "
+        "Alignment, MarginL, MarginR, MarginV, Encoding\n"
+        "Style: DBG,DejaVu Sans,28,&H00FFFFFF,&H000000FF,&H80000000,&H80000000,"\
+        "-1,0,0,0,100,100,0,0,1,2,0,7,20,20,20,0\n"
+        "\n"
+        "[Events]\n"
+        "Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text\n"
+    )
+
+    lines = [header]
+
+    for i, seg in enumerate(segments):
+        sf = int(seg["start_frame"]) if "start_frame" in seg else int(seg.get("start", 0))
+        ef = int(seg["end_frame"]) if "end_frame" in seg else int(seg.get("end", sf))
+        t0 = _sec_from_frame(sf, fps)
+        t1 = _sec_from_frame(ef, fps)
+        if t1 <= t0 + 0.05:  # skip zero-length
+            continue
+
+        form = formations[i] if i < len(formations) else "Unknown"
+        pm = play_matches[i] if i < len(play_matches) else {"name": "Unknown", "confidence": 0.0}
+        pname = pm.get("name", "Unknown") or "Unknown"
+        pconf = float(pm.get("confidence", 0.0))
+        gr = grades.get(i, {"overall": 0.0, "mode": "fallback"})
+        gtxt = f"{gr['overall']:.2f}"
+        gmode = gr.get("mode", "fallback")
+
+        label = (
+            f"# {i+1}  {form}  {pname} (conf={pconf:.2f})  "
+            f"Def={gtxt} (mode:{gmode})"
+        )
+        # \N makes a new line in ASS; add time range too
+        timerange = f"{_fmt_ass_time(t0)} → {_fmt_ass_time(t1)}"
+        text = label + r"\N" + timerange
+
+        lines.append(
+            "Dialogue: 0,"\
+            f"{_fmt_ass_time(t0)},"\
+            f"{_fmt_ass_time(t1)},"\
+            "DBG,,0000,0000,0000,,"\
+            f"{text}\n"
+        )
+
+    ass_path.write_text("".join(lines), encoding="utf-8")
+
+    # Burn subtitles; prefer ffmpeg if present
+    if not shutil.which("ffmpeg"):
+        raise RuntimeError("ffmpeg not found; can't render debug video")
+    cmd = [
+        "ffmpeg",
+        "-y",
+        "-i",
+        str(video_path),
+        "-vf",
+        f"ass={ass_path}",
+        "-c:v",
+        "libx264",
+        "-preset",
+        "veryfast",
+        "-crf",
+        "20",
+        "-c:a",
+        "copy",
+        str(out_vid),
+    ]
+    subprocess.run(cmd, check=True)
+    return out_vid

--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -170,6 +170,23 @@ def run_pipeline(
             grades_path=Path(out_dir) / "grades.jsonl",
         )
 
+    if args and getattr(args, "debug_vid", False):
+        from . import debug_overlay
+
+        seg_dicts = [
+            {"start_frame": int(seg.start_ts * fps), "end_frame": int(seg.end_ts * fps)}
+            for seg in segments
+        ]
+        debug_overlay.build_debug_video(
+            video_path=Path(video),
+            out_dir=Path(out_dir),
+            segments=seg_dicts,
+            fps=fps,
+            formations=formations,
+            play_matches=play_matches,
+            grades_path=Path(out_dir) / "grades.jsonl",
+        )
+
     if generate_report and not (clip_corrections or clip_wins or clip_highlights):
         clip_corrections = clip_wins = clip_highlights = True
 
@@ -227,7 +244,11 @@ def main(argv: List[str] | None = None) -> None:
     parser.add_argument("--generate-highlights", action=argparse.BooleanOptionalAction, default=True)
     parser.add_argument("--min-play-gap", type=float, default=7.0)
     parser.add_argument("--min-play-length", type=float, default=4.0)
-    parser.add_argument("--debug-vid", action="store_true")
+    parser.add_argument(
+        "--debug-vid",
+        action="store_true",
+        help="Render a debug video with overlays",
+    )
     parser.add_argument("--player-ids")
     parser.add_argument("--id-overrides")
     parser.add_argument("--team-color")


### PR DESCRIPTION
## Summary
- add debug overlay module to build ASS subtitles and burn debug video
- extend pipeline with `--debug-vid` flag and integration of overlay builder

## Testing
- `pytest`
- `python -m analysis.pipeline --help | rg "debug-vid" -n`

------
https://chatgpt.com/codex/tasks/task_e_689b4f8b21c4832da614f677d0e4ce40