### PR TITLE
Enforce jersey OCR API and add segmentation tests

### DIFF
--- a/assignment_analyzer.py
+++ b/assignment_analyzer.py
@@ -6,7 +6,7 @@ import argparse
 import csv
 import json
 import os
-from typing import Dict, List, Tuple, Optional
+from typing import Dict, List, Tuple
 
 import cv2
 import logging
@@ -71,9 +71,17 @@ def detect_players(frame) -> List[Box]:
         return []
 
 
-def detect_jerseys(frame, boxes: Optional[List[Box]] = None):
-    if boxes is None:
-        boxes = detect_players(frame)
+def detect_jerseys(frame, boxes: List[Box]) -> List[int]:
+    """Return jersey numbers detected within ``boxes`` on ``frame``.
+
+    The previous implementation allowed ``boxes`` to be omitted which
+    resulted in ``TypeError`` whenever :func:`ai_detector.detect_jerseys`
+    was invoked without the required argument.  Enforce the explicit
+    ``boxes`` parameter so call sites must provide the current detection
+    boxes.  This mirrors the signature of
+    :func:`ai_detector.detect_jerseys` and prevents silent mis-use.
+    """
+
     return _detect_jerseys(frame, boxes)
 
 def load_assignments(path: str) -> Dict[int, str]:

--- a/tests/test_detect_jerseys_api.py
+++ b/tests/test_detect_jerseys_api.py
@@ -1,0 +1,40 @@
+import numpy as np
+import pytest
+
+# ``ai_detector`` depends on OpenCV which may be missing in the test
+# environment.  Provide a lightweight stub to satisfy the import if the
+# real module is unavailable.
+import types
+import sys
+import importlib
+
+
+def test_detect_jerseys_requires_boxes():
+    frame = np.zeros((10, 10, 3), dtype=np.uint8)
+
+    # Temporarily stub cv2 so ``ai_detector`` can be imported even when
+    # OpenCV is missing.  Restore the original state afterwards so other
+    # modules see the expected environment.
+    original_cv2 = sys.modules.get("cv2")
+    if original_cv2 is None:
+        sys.modules["cv2"] = types.SimpleNamespace()
+    ai_detector = importlib.import_module("ai_detector")
+    if original_cv2 is None:
+        del sys.modules["cv2"]
+
+    with pytest.raises(TypeError):
+        ai_detector.detect_jerseys(frame)  # type: ignore[arg-type]
+
+    # Patch extract_jersey_number to return a known value so the
+    # detection path returns a non-empty list when boxes are provided.
+    def fake_extract(frame, box, *, video_name=None, frame_id=None, bbox_id=None, timestamp=None, play_id=None):
+        return "12", 99.0
+
+    orig = ai_detector.extract_jersey_number
+    ai_detector.extract_jersey_number = fake_extract
+    try:
+        result = ai_detector.detect_jerseys(frame, [(0, 0, 5, 5)])
+    finally:
+        ai_detector.extract_jersey_number = orig
+
+    assert result == ["12"]

--- a/tests/test_segmentation_synthetic.py
+++ b/tests/test_segmentation_synthetic.py
@@ -1,0 +1,25 @@
+import numpy as np
+
+from analysis import segmentation
+
+
+def _make_frames(num_segments: int = 5, seg_len: int = 60, gap_len: int = 70):
+    """Generate synthetic video frames with alternating motion and gaps."""
+    frames = []
+    silent = np.zeros((32, 32, 3), dtype=np.uint8)
+    for _ in range(num_segments):
+        for _ in range(gap_len):
+            frames.append(silent.copy())
+        for _ in range(seg_len):
+            frames.append(np.random.randint(0, 255, (32, 32, 3), dtype=np.uint8))
+    # trailing gap so the final segment closes cleanly
+    for _ in range(gap_len):
+        frames.append(silent.copy())
+    return frames
+
+
+def test_segmentation_detects_multiple_segments():
+    fps = 30
+    frames = _make_frames()
+    segs = segmentation.segment_video(frames, fps, min_play_gap=1.0, min_play_length=1.0)
+    assert len(segs) >= 3


### PR DESCRIPTION
## Summary
- require bounding-box argument for `detect_jerseys` and document reasoning
- add unit test covering jersey OCR API, including missing boxes and successful detection
- add synthetic motion segmentation test ensuring multiple play segments

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b625e32f4832d91722262734aa844