### PR TITLE
Add overlay and debugging flags to analysis pipeline

### DIFF
--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -8,6 +8,16 @@ import os
 from pathlib import Path
 from typing import Any, Dict, List
 
+try:
+    from overlays.debug_overlay import render_overlays_for_out_dir
+except Exception as _e:  # pragma: no cover - optional dependency
+    render_overlays_for_out_dir = None
+
+try:
+    from reporting.debug_summary import print_debug_summary
+except Exception as _e:  # pragma: no cover - optional dependency
+    print_debug_summary = None
+
 from . import (
     detect_track,
     play_recognizer,
@@ -256,6 +266,23 @@ def main(argv: List[str] | None = None) -> None:
     parser.add_argument("--clip-corrections", action="store_true")
     parser.add_argument("--clip-wins", action="store_true")
     parser.add_argument("--clip-highlights", action="store_true")
+    parser.add_argument(
+        "--make-overlay",
+        action="store_true",
+        help="Generate debug overlay videos per play (and optionally a stitched full overlay)",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Fail if suspicious output (e.g., too few plays for clip length, zero matches, etc.)",
+    )
+    parser.add_argument(
+        "--debug-summary",
+        "--debug_summary",
+        dest="debug_summary",
+        action="store_true",
+        help="Print counts of plays, formations, matches, and average grades at the end",
+    )
     args = parser.parse_args(argv)
 
     run_pipeline(
@@ -279,6 +306,75 @@ def main(argv: List[str] | None = None) -> None:
         clip_highlights=args.clip_highlights,
         args=args,
     )
+
+    # ---- Strict checks & overlays & summary ----
+    out_dir = Path(args.out) if args.out else Path("output")
+    plays_fp = out_dir / "plays.jsonl"
+    predictions_fp = out_dir / "play_predictions.jsonl"
+    grades_fp = out_dir / "grades.jsonl"
+    tracking_fp = out_dir / "tracking.jsonl"
+    metadata_fp = out_dir / "metadata.json"
+
+    def _safe_load_jsonl(fp: Path) -> List[Dict[str, Any]]:
+        if not fp.exists():
+            return []
+        return [json.loads(line) for line in fp.read_text().splitlines() if line.strip()]
+
+    def _safe_load_json(fp: Path) -> Dict[str, Any]:
+        if not fp.exists():
+            return {}
+        return json.loads(fp.read_text())
+
+    plays = _safe_load_jsonl(plays_fp)
+    predictions = _safe_load_jsonl(predictions_fp)
+    grades = _safe_load_jsonl(grades_fp)
+    tracking_rows = _safe_load_jsonl(tracking_fp)
+    meta = _safe_load_json(metadata_fp)
+
+    video_len_s = float(meta.get("video_length_sec", 0.0)) or float(
+        meta.get("duration_sec", 0.0) or 0.0
+    )
+
+    # STRICT: basic sanity checks
+    if args.strict:
+        # if the clip is long but we got almost no segments, something is wrong with the segmenter thresholds
+        if video_len_s >= 45 and len(plays) < 3:
+            raise SystemExit(
+                f"Strict mode: too few plays ({len(plays)}) for video length {video_len_s:.1f}s"
+            )
+        # if tracking never populated, flag it
+        if len(tracking_rows) == 0:
+            raise SystemExit("Strict mode: no tracking.jsonl rows found (tracking likely failed)")
+        # if classifier/predictions are empty, flag it
+        if len(predictions) == 0:
+            raise SystemExit(
+                "Strict mode: no play_predictions.jsonl produced (classification likely failed)"
+            )
+
+    # Overlays
+    if args.make_overlay:
+        if render_overlays_for_out_dir is None:
+            print(
+                "[WARN] --make-overlay requested but overlays.debug_overlay not importable; skipping overlays."
+            )
+        else:
+            try:
+                render_overlays_for_out_dir(out_dir)
+            except Exception as e:  # pragma: no cover - best effort
+                print(f"[WARN] Overlay rendering failed: {e}")
+
+    # Debug summary
+    if getattr(args, "debug-summary", False) or getattr(args, "debug_summary", False):  # allow either spelling if someone typed the dash
+        if print_debug_summary is None:
+            print(
+                "[WARN] --debug-summary requested but reporting.debug_summary not importable; skipping summary."
+            )
+            
+        else:
+            try:
+                print_debug_summary(out_dir, plays, predictions, grades)
+            except Exception as e:  # pragma: no cover - best effort
+                print(f"[WARN] Debug summary failed: {e}")
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry

--- a/overlays/__init__.py
+++ b/overlays/__init__.py
@@ -1,0 +1,1 @@
+# Package for debug overlay helpers

--- a/overlays/debug_overlay.py
+++ b/overlays/debug_overlay.py
@@ -1,0 +1,75 @@
+from pathlib import Path
+import json, cv2
+
+
+def _load_jsonl(fp: Path):
+    if not fp.exists():
+        return []
+    return [json.loads(l) for l in fp.read_text().splitlines() if l.strip()]
+
+
+def render_overlays_for_out_dir(out_dir: Path):
+    """
+    Minimal overlay renderer:
+    - For each play in plays.jsonl, re-open the source video from metadata.json
+    - Seek to play start, iterate frames until play end
+    - Draw bbox + jersey_number for any tracking rows matching play_id and time window
+    - Write mp4s to out_dir/overlay/PLAY_{id:03d}.mp4
+    """
+    plays = _load_jsonl(out_dir / "plays.jsonl")
+    tracking = _load_jsonl(out_dir / "tracking.jsonl")
+    meta = json.loads((out_dir / "metadata.json").read_text()) if (out_dir / "metadata.json").exists() else {}
+    video_path = meta.get("video_path") or meta.get("input_video")
+
+    if not video_path or not Path(video_path).exists():
+        print("[overlay] No video_path in metadata or file missing; skipping overlays.")
+        return
+
+    overlay_dir = out_dir / "overlay"
+    overlay_dir.mkdir(parents=True, exist_ok=True)
+
+    cap = cv2.VideoCapture(video_path)
+    fps = cap.get(cv2.CAP_PROP_FPS) or 30
+    w = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH) or 1280)
+    h = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT) or 720)
+
+    # Group tracking rows by play_id for fast lookup
+    by_play = {}
+    for r in tracking:
+        by_play.setdefault(r.get("play_id"), []).append(r)
+
+    for p in plays:
+        pid = p.get("play_id")
+        start_s = float(p.get("start_s", 0.0))
+        end_s = float(p.get("end_s", 0.0))
+        if end_s <= start_s:
+            continue
+        out_fp = str((overlay_dir / f"PLAY_{int(pid):03d}.mp4"))
+
+        fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+        writer = cv2.VideoWriter(out_fp, fourcc, fps, (w, h))
+
+        # seek to start
+        cap.set(cv2.CAP_PROP_POS_MSEC, start_s * 1000.0)
+        t = start_s
+        rows = by_play.get(pid, [])
+
+        while t <= end_s:
+            ret, frame = cap.read()
+            if not ret:
+                break
+
+            t_rows = [r for r in rows if abs(float(r.get("time_s", 0.0)) - t) <= (1.0 / fps) * 1.1]
+            for r in t_rows:
+                x1, y1, x2, y2 = [int(v) for v in r.get("bbox", [0, 0, 0, 0])]
+                cv2.rectangle(frame, (x1, y1), (x2, y2), (0, 255, 0), 2)
+                label = f"#{r.get('jersey_number', '?')} id:{r.get('track_id', '?')}"
+                cv2.putText(frame, label, (x1, max(20, y1 - 6)), cv2.FONT_HERSHEY_SIMPLEX, 0.6, (255, 255, 255), 2)
+
+            writer.write(frame)
+            t += 1.0 / fps
+
+        writer.release()
+
+    cap.release()
+    print(f"[overlay] Wrote overlays to: {overlay_dir}")

--- a/reporting/__init__.py
+++ b/reporting/__init__.py
@@ -1,0 +1,1 @@
+# Package for reporting helpers

--- a/reporting/debug_summary.py
+++ b/reporting/debug_summary.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+import statistics as stats
+
+
+def print_debug_summary(out_dir: Path, plays, predictions, grades):
+    total_plays = len(plays)
+    known_preds = sum(
+        1 for p in predictions if p.get("predicted_play") and p.get("predicted_play") != "UNKNOWN"
+    )
+    top_match_rate = 0.0
+    if total_plays:
+        top_match_rate = known_preds / total_plays
+
+    gvals = [g.get("overall_defense") for g in grades if isinstance(g.get("overall_defense"), (int, float))]
+    avg_grade = (sum(gvals) / len(gvals)) if gvals else None
+
+    formations = [(p.get("formation") or p.get("topk", [{}])[0].get("formation")) for p in predictions]
+    unknown_form = sum(1 for f in formations if not f or str(f).lower().startswith("unknown"))
+
+    print("\n==== Debug Summary ====")
+    print(f"Output dir: {out_dir}")
+    print(f"Plays detected: {total_plays}")
+    print(f"Predicted (known): {known_preds} | Unknown formations: {unknown_form}")
+    print(f"Playbook/known rate: {top_match_rate:.2f}")
+    if avg_grade is not None:
+        print(f"Avg defensive grade: {avg_grade:.2f}")
+    else:
+        print("Avg defensive grade: N/A")
+    print("=======================\n")


### PR DESCRIPTION
## Summary
- Allow pipeline to optionally generate per-play debug overlays and end-of-run summaries
- Add `--strict` mode for basic artifact sanity checks
- Provide minimal overlay renderer and debug summary utilities

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b68e50dd4832db7eaccd7cf7d1be4