### PR TITLE
Improve metadata handling, segmentation fallback, and overlays

### DIFF
--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -29,7 +29,6 @@ from . import (
     formation_classifier,
     defense_grader,
     report_builder,
-    io_utils,
     play_matcher,
 )
 
@@ -72,17 +71,24 @@ def run_pipeline(
 
     logger = logging.getLogger("pipeline")
 
-    # Detect FPS from the input video unless explicitly provided
+    # Open the video to gather metadata and detect FPS if not provided
     detected_fps = None
-    if fps in (None, 0):
-        try:  # pragma: no cover - best effort only
-            import cv2  # type: ignore
+    frame_count = 0
+    width = 0
+    height = 0
+    try:  # pragma: no cover - best effort only
+        import cv2  # type: ignore
 
-            cap = cv2.VideoCapture(video)
-            detected_fps = cap.get(cv2.CAP_PROP_FPS) or None
-            cap.release()
-        except Exception:
-            detected_fps = None
+        cap = cv2.VideoCapture(video)
+        detected_fps = cap.get(cv2.CAP_PROP_FPS) or None
+        frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT) or 0)
+        width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH) or 0)
+        height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT) or 0)
+        cap.release()
+    except Exception:
+        detected_fps = None
+
+    if fps in (None, 0):
         fps = detected_fps
     else:
         detected_fps = fps
@@ -98,6 +104,21 @@ def run_pipeline(
             )
 
     fps = fps or 30
+    duration_sec = (frame_count / fps) if (fps and frame_count) else 0.0
+
+    meta = {
+        "team": (args.team if args else team) or "",
+        "opponent": (args.opponent if args else opponent) or "",
+        "video_path": str(video),
+        "video": str(video),
+        "fps": fps,
+        "frame_count": frame_count,
+        "width": width,
+        "height": height,
+        "video_length_sec": duration_sec,
+    }
+    meta_path = Path(out_dir) / "metadata.json"
+    meta_path.write_text(json.dumps(meta, indent=2))
 
     tracks = detect_track.run(video, team=team, fps=fps)
     detect_track.write_jsonl(tracks, os.path.join(out_dir, "tracking.jsonl"))
@@ -121,16 +142,9 @@ def run_pipeline(
         logger=logger,
     )
 
-    # Write metadata early with accurate play count
-    meta_path = Path(out_dir) / "metadata.json"
-    meta = {
-        "team": (args.team if args else team) or "Metro Christian Academy",
-        "opponent": (args.opponent if args else opponent) or "UNKNOWN",
-        "video": args.video if args else video,
-        "fps": fps,
-        "play_count": len(segments),
-    }
-    io_utils.write_json(meta_path, meta)
+    # Update metadata with play count
+    meta["play_count"] = len(segments)
+    meta_path.write_text(json.dumps(meta, indent=2))
 
     playbook = assignments.load_playbook(playbook_path)
 
@@ -331,14 +345,23 @@ def main(argv: List[str] | None = None) -> None:
     tracking_rows = _safe_load_jsonl(tracking_fp)
     meta = _safe_load_json(metadata_fp)
 
-    video_len_s = float(meta.get("video_length_sec", 0.0)) or float(
-        meta.get("duration_sec", 0.0) or 0.0
-    )
+    video_len_s = float(meta.get("video_length_sec") or 0.0)
+    if (not video_len_s) and meta.get("video_path"):
+        try:  # pragma: no cover - best effort only
+            import cv2  # type: ignore
+
+            cap2 = cv2.VideoCapture(meta["video_path"])
+            fps2 = cap2.get(cv2.CAP_PROP_FPS) or 30.0
+            frames2 = cap2.get(cv2.CAP_PROP_FRAME_COUNT) or 0
+            video_len_s = (frames2 / fps2) if fps2 and frames2 else 0.0
+            cap2.release()
+        except Exception:
+            video_len_s = 0.0
 
     # STRICT: basic sanity checks
     if args.strict:
         # if the clip is long but we got almost no segments, something is wrong with the segmenter thresholds
-        if video_len_s >= 45 and len(plays) < 3:
+        if video_len_s >= 45.0 and len(plays) < 3:
             raise SystemExit(
                 f"Strict mode: too few plays ({len(plays)}) for video length {video_len_s:.1f}s"
             )

--- a/overlays/debug_overlay.py
+++ b/overlays/debug_overlay.py
@@ -19,7 +19,7 @@ def render_overlays_for_out_dir(out_dir: Path):
     plays = _load_jsonl(out_dir / "plays.jsonl")
     tracking = _load_jsonl(out_dir / "tracking.jsonl")
     meta = json.loads((out_dir / "metadata.json").read_text()) if (out_dir / "metadata.json").exists() else {}
-    video_path = meta.get("video_path") or meta.get("input_video")
+    video_path = meta.get("video_path") or meta.get("video") or meta.get("input_video")
 
     if not video_path or not Path(video_path).exists():
         print("[overlay] No video_path in metadata or file missing; skipping overlays.")

--- a/segment/play_segmenter.py
+++ b/segment/play_segmenter.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+try:  # pragma: no cover - optional dependency
+    import cv2  # type: ignore
+except Exception:  # pragma: no cover - best effort
+    cv2 = None  # type: ignore
+
+
+def _windowize(duration_sec: float, min_len: float, min_gap: float) -> List[Dict[str, float]]:
+    """Generate sliding windows as fallback segmentation."""
+    win = max(3.5, float(min_len))
+    gap = max(0.8, float(min_gap))
+    step = win + gap
+    t = 0.0
+    segments: List[Dict[str, float]] = []
+    pid = 1
+    while t + 0.75 * win < duration_sec:
+        start = t
+        end = min(t + win, duration_sec)
+        if end - start >= 0.66 * win:
+            segments.append({"play_id": pid, "start_s": float(start), "end_s": float(end)})
+            pid += 1
+        t += step
+    return segments
+
+
+def segment_video(
+    ctx: Optional[Dict[str, Any]] = None,
+    cfg: Optional[Dict[str, Any]] = None,
+    video_path: str | None = None,
+) -> List[Dict[str, float]]:
+    """Segment a video into play windows.
+
+    This function expects that a primary detection stage has populated ``ctx``
+    with a list of segments under the key ``"segments"``.  If no segments are
+    present, a sliding window fallback is used based on the minimum play
+    length and gap specified in ``cfg``.
+    """
+
+    ctx = ctx or {}
+    cfg = cfg or {}
+    segs = ctx.get("segments") or []
+
+    if not segs:
+        print("Segmentation fallback: only 0 plays found; windowizing video")
+        duration_sec = float(ctx.get("duration_sec") or ctx.get("video_length_sec") or 0.0)
+        if duration_sec <= 0.0 and video_path and cv2 is not None:
+            cap = cv2.VideoCapture(video_path)
+            fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
+            frames = cap.get(cv2.CAP_PROP_FRAME_COUNT) or 0
+            duration_sec = (frames / fps) if fps and frames else 0.0
+            cap.release()
+        segs = _windowize(
+            duration_sec,
+            cfg.get("min_play_length", 6.0),
+            cfg.get("min_play_gap", 1.5),
+        )
+    return segs


### PR DESCRIPTION
## Summary
- capture full video metadata including path, dimensions, frame count, and duration
- add sliding window fallback segmentation using play length and gap settings
- stricter pipeline checks and overlays accept legacy video fields

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b72078b54832d852386baab8136ce