### PR TITLE
Join predictions and grades for reporting

### DIFF
--- a/analysis/report_builder.py
+++ b/analysis/report_builder.py
@@ -1,19 +1,18 @@
 from __future__ import annotations
 
 import csv
-import json
 from pathlib import Path
 from typing import Dict, Sequence
+
+from reporting.generate_report import (
+    build_joined_rows,
+    summarize,
+    timeline_rows,
+)
 
 from .io_utils import ensure_dir, write_json
 from .segmentation import Segment
 from . import report as _legacy_report
-
-
-def _fmt_time(seconds: float) -> str:
-    m = int(seconds // 60)
-    s = int(seconds % 60)
-    return f"{m:02d}:{s:02d}"
 
 
 def build(
@@ -29,59 +28,24 @@ def build(
     dashboards = out_dir / "dashboards"
     ensure_dir(dashboards)
 
-    # Load grades if available
-    grade_map: Dict[int, Dict[str, object]] = {}
-    if grades_path.exists():
-        with grades_path.open("r", encoding="utf8") as gf:
-            for line in gf:
-                g = json.loads(line)
-                grade_map[int(g.get("play_index", 0))] = g
-
-    # ------------------------------------------------------------------
-    # Summary JSON
-    # ------------------------------------------------------------------
-    formation_counts: dict[str, int] = {}
-    for f in formations:
-        formation_counts[f] = formation_counts.get(f, 0) + 1
-
-    play_counts: dict[str, int] = {}
-    for m in play_matches:
-        name = m.get("name", "Unknown")
-        play_counts[name] = play_counts.get(name, 0) + 1
+    joined = build_joined_rows(out_dir)
+    formation_counts, play_counts, _, _ = summarize(joined)
 
     summary = {
-        "play_count": len(segments),
-        "formations": formation_counts,
-        "plays": play_counts,
+        "play_count": len(joined),
+        "formations": dict(formation_counts),
+        "plays": dict(play_counts),
     }
     write_json(dashboards / "summary.json", summary)
 
-    # ------------------------------------------------------------------
-    # Timeline CSV
-    # ------------------------------------------------------------------
+    rows = timeline_rows(joined)
     with (dashboards / "timeline.csv").open("w", newline="") as f:
         writer = csv.writer(f)
-        writer.writerow(["#", "Start", "End", "Dur", "Formation", "Play (conf)", "Def Grade"])
-        for idx, seg in enumerate(segments, 1):
-            formation = formations[idx - 1] if idx - 1 < len(formations) else "Unknown"
-            pm = play_matches[idx - 1] if idx - 1 < len(play_matches) else {"name": "Unknown", "confidence": 0.0}
-            grade = grade_map.get(idx - 1, {})
-            writer.writerow(
-                [
-                    idx,
-                    _fmt_time(seg.start_ts),
-                    _fmt_time(seg.end_ts),
-                    _fmt_time(seg.duration),
-                    formation,
-                    f"{pm.get('name')} ({pm.get('confidence', 0.0):.2f})",
-                    grade.get("overall_defense", ""),
-                ]
-            )
+        writer.writerow(["#", "Start", "End", "Duration", "Tag", "Note"])
+        for r in rows:
+            writer.writerow([r["num"], r["start"], r["end"], r["dur"], r["tag"], r["note"]])
 
-    # ------------------------------------------------------------------
-    # Simple markdown / PDF report
-    # ------------------------------------------------------------------
-    md_lines = ["# Game Report", "", f"Total plays: {len(segments)}", ""]
+    md_lines = ["# Game Report", "", f"Total plays: {len(joined)}", ""]
 
     md_lines.append("## Formations Used")
     for name, count in formation_counts.items():

--- a/analysis/report_emergency.py
+++ b/analysis/report_emergency.py
@@ -1,4 +1,9 @@
-import json, csv, pathlib, shutil, subprocess
+import json
+import pathlib
+import shutil
+import subprocess
+
+from reporting.generate_report import build_joined_rows, summarize, timeline_rows
 
 
 def build_emergency_report(out_dir: pathlib.Path):
@@ -10,52 +15,44 @@ def build_emergency_report(out_dir: pathlib.Path):
             meta = json.loads(pmeta.read_text())
         except Exception:
             pass
-    tl = out / "dashboards" / "timeline.csv"
-    rows = []
-    if tl.exists():
-        rows = list(csv.DictReader(tl.open()))
-    grades = []
-    g = out / "grades.jsonl"
-    if g.exists():
-        for line in g.read_text().splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                o = json.loads(line)
-                if "overall_defense" in o:
-                    grades.append(o["overall_defense"])
-            except Exception:
-                pass
 
-    def h(x):
-        return "" if x is None else str(x)
-
-    fc = {}
-    for r in rows:
-        fc[r.get("Tag", "Unknown")] = fc.get(r.get("Tag", "Unknown"), 0) + 1
+    joined = build_joined_rows(out)
+    formations, plays_detected, known_rate, avg_grade = summarize(joined)
+    rows = timeline_rows(joined)
+    grade_count = len([r for r in joined if isinstance(r.get("grade_overall"), (int, float))])
 
     md = out / "report_emergency.md"
     with md.open("w") as f:
         f.write("# Game Report\n\n")
         f.write(
-            f"**Team:** {meta.get('team','')}  \n**Opponent:** {meta.get('opponent','')}  \n**FPS:** {meta.get('fps','')}  \n**Detected Plays:** {meta.get('play_count', len(rows))}\n\n"
+            f"**Summary:** plays={len(joined)} • known_rate={known_rate:.2f} • avg_defense={avg_grade if avg_grade is not None else 'N/A'}\n\n"
         )
-        if fc:
+        f.write(
+            f"**Team:** {meta.get('team','')}  \n**Opponent:** {meta.get('opponent','')}  \n**FPS:** {meta.get('fps','')}  \n**Detected Plays:** {len(joined)}\n\n"
+        )
+        if formations:
             f.write("## Formations Used\n")
-            for k, v in sorted(fc.items(), key=lambda x: (-x[1], x[0])):
+            for k, v in sorted(formations.items(), key=lambda x: (-x[1], x[0])):
                 f.write(f"- {k}: {v}\n")
             f.write("\n")
-        if grades:
-            avg = sum(grades) / len(grades)
+        if plays_detected:
+            f.write("## Plays Detected\n")
+            for k, v in sorted(plays_detected.items(), key=lambda x: (-x[1], x[0])):
+                f.write(f"- {k}: {v}\n")
+            f.write("\n")
+        if avg_grade is not None:
             f.write("## Defensive Summary\n")
-            f.write(f"- Plays graded: {len(grades)}\n- Avg Overall Defense: {avg:.2f}\n\n")
+            f.write(
+                f"- Plays graded: {grade_count}\n- Avg Overall Defense: {avg_grade:.2f}\n\n"
+            )
         if rows:
             f.write("## Timeline\n")
-            f.write("| # | Start | End | Duration | Tag | Note |\n|---:|:-----:|:---:|:-------:|:----|:-----|\n")
+            f.write(
+                "| # | Start | End | Duration | Tag | Note |\n|---:|:-----:|:---:|:-------:|:----|:-----|\n"
+            )
             for r in rows:
                 f.write(
-                    f"| {h(r.get('#'))} | {h(r.get('Start'))} | {h(r.get('End'))} | {h(r.get('Duration'))} | {h(r.get('Tag'))} | {h(r.get('Note'))} |\n"
+                    f"| {r['num']} | {r['start']} | {r['end']} | {r['dur']} | {r['tag']} | {r['note']} |\n"
                 )
 
     html = out / "report_emergency.html"

--- a/reporting/generate_report.py
+++ b/reporting/generate_report.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from collections import Counter
+import json
+from pathlib import Path
+from typing import List, Dict, Any
+
+
+def _load_jsonl(fp: Path) -> List[Dict[str, Any]]:
+    if not fp.exists():
+        return []
+    return [json.loads(l) for l in fp.read_text().splitlines() if l.strip()]
+
+
+def build_joined_rows(out_dir: Path) -> List[Dict[str, Any]]:
+    plays = _load_jsonl(out_dir / "plays.jsonl")
+    preds = _load_jsonl(out_dir / "play_predictions.jsonl")
+    grades = _load_jsonl(out_dir / "grades.jsonl")
+
+    by_pred = {p["play_id"]: p for p in preds if "play_id" in p}
+    by_grade = {g["play_id"]: g for g in grades if "play_id" in g}
+
+    joined: List[Dict[str, Any]] = []
+    for p in plays:
+        pid = p.get("play_id")
+        pr = by_pred.get(pid, {})
+        gr = by_grade.get(pid, {})
+        duration = (p.get("end_s", 0.0) or 0.0) - (p.get("start_s", 0.0) or 0.0)
+        formation = (
+            pr.get("formation")
+            or pr.get("topk", [{}])[0].get("formation")
+            or "Unknown"
+        )
+        pred_name = (
+            pr.get("predicted_play")
+            or pr.get("topk", [{}])[0].get("name")
+            or "UNKNOWN"
+        )
+        conf = float(pr.get("confidence") or pr.get("topk", [{}])[0].get("p") or 0.0)
+        joined.append(
+            {
+                "play_id": pid,
+                "start_s": p.get("start_s"),
+                "end_s": p.get("end_s"),
+                "duration_s": max(0.0, duration),
+                "formation": formation,
+                "predicted_play": pred_name,
+                "confidence": conf,
+                "grade_overall": gr.get("overall_defense"),
+                "source": p.get("source", "primary"),
+            }
+        )
+    return joined
+
+
+def summarize(joined: List[Dict[str, Any]]):
+    formations = Counter([r["formation"] for r in joined])
+    formations = Counter(
+        { (k if str(k).lower() != "unknown" else "Unknown"): v for k, v in formations.items() }
+    )
+
+    plays_detected: Counter[str] = Counter()
+    for r in joined:
+        name = r["predicted_play"]
+        if not name or str(name).upper() == "UNKNOWN":
+            name = "Unknown"
+        plays_detected[name] += 1
+
+    known = sum(v for k, v in plays_detected.items() if k != "Unknown")
+    total = len(joined)
+    known_rate = (known / total) if total else 0.0
+
+    grades = [r["grade_overall"] for r in joined if isinstance(r.get("grade_overall"), (int, float))]
+    avg_grade = (sum(grades) / len(grades)) if grades else None
+
+    return formations, plays_detected, known_rate, avg_grade
+
+
+def _mmss(t: Any) -> str:
+    if t is None:
+        return ""
+    t = max(0.0, float(t))
+    m = int(t // 60)
+    s = int(round(t - 60 * m))
+    return f"{m:02d}:{s:02d}"
+
+
+def timeline_rows(joined: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    for r in sorted(joined, key=lambda x: x["play_id"]):
+        rows.append(
+            {
+                "num": r["play_id"],
+                "start": _mmss(r.get("start_s")),
+                "end": _mmss(r.get("end_s")),
+                "dur": _mmss(r.get("duration_s")),
+                "tag": r["predicted_play"] if r["predicted_play"] != "UNKNOWN" else "",
+                "note": "",
+            }
+        )
+    return rows


### PR DESCRIPTION
## Summary
- Build consolidated play rows by joining segmentation, predictions, and grades
- Generate report statistics and timelines from predictions instead of raw plays
- Add summary line and proper formation/play counts to emergency report

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1)*
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689b81aa9d0c832d89b305b783084e92