### PR TITLE
Add motion blob fallback to tracking

### DIFF
--- a/analysis/detect_track.py
+++ b/analysis/detect_track.py
@@ -9,7 +9,17 @@ pipeline stages can operate on predictable structures.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Iterable, List, Dict, Any
+
+import logging
+
+try:
+    import cv2  # type: ignore
+    import numpy as np
+except Exception:  # pragma: no cover - optional
+    cv2 = None  # type: ignore
+    np = None  # type: ignore
 
 
 @dataclass
@@ -22,6 +32,7 @@ class Track:
     jersey_number: str
     bbox: List[int]
     role_hint: str | None = None
+    detection_source: str = "primary"
 
     def as_dict(self) -> Dict[str, Any]:
         return {
@@ -31,44 +42,133 @@ class Track:
             "jersey_number": self.jersey_number,
             "bbox": self.bbox,
             "role_hint": self.role_hint,
+            "detection_source": self.detection_source,
         }
 
 
 def run(
-    video_path: str, team: str = "WHITE", fps: int = 12, model_path: str | None = None
+    video_path: str,
+    team: str = "WHITE",
+    fps: int = 12,
+    model_path: str | None = None,
+    settings: Dict[str, Any] | None = None,
 ) -> List[Track]:
-    """Fake detection routine used for tests.
+    """Detect and track players in ``video_path``.
 
-    Parameters
-    ----------
-    video_path:
-        Path to the source video.  The file is **not** opened; the value is
-        only persisted in logs so the function works in environments without
-        any media files.
-    team:
-        Team colour for our side.  Tracked players are tagged with this value.
-    fps:
-        Sampling rate.  Included for API compatibility only.
-
-    Returns
-    -------
-    list of :class:`Track`
-        A minimal set of tracks representing three players.  The bounding
-        boxes are arbitrary and only exist to satisfy the tracking schema.
+    The real project would invoke a heavy detector.  For testing we use a
+    lightweight motion-energy approach with an optional motion-blob fallback
+    when the primary method fails to detect activity for several frames.
     """
 
     if model_path:
         print(f"[detect_track] using model: {model_path}")
 
-    # Generate a couple of dummy tracks so downstream modules have something
-    # to work with.  In a real implementation these would be derived from
-    # model predictions. ``model_path`` is accepted to mirror the real API and
-    # allow callers to explicitly provide detector weights.
-    tracks = [
-        Track(frame=0, player_id="1", team=team, jersey_number="10", bbox=[0, 0, 10, 10]),
-        Track(frame=0, player_id="2", team=team, jersey_number="20", bbox=[20, 0, 30, 10]),
-        Track(frame=0, player_id="3", team=team, jersey_number="30", bbox=[40, 0, 50, 10]),
-    ]
+    if cv2 is None or np is None or not Path(video_path).exists():
+        # Generate dummy tracks when video or CV dependencies are missing so
+        # downstream code still has data to work with.
+        return [
+            Track(frame=0, player_id="1", team=team, jersey_number="10", bbox=[0, 0, 10, 10]),
+            Track(frame=0, player_id="2", team=team, jersey_number="20", bbox=[20, 0, 30, 10]),
+            Track(frame=0, player_id="3", team=team, jersey_number="30", bbox=[40, 0, 50, 10]),
+        ]
+
+    frames: List[np.ndarray] = []
+    cap = cv2.VideoCapture(video_path)
+    while True:
+        ret, frame = cap.read()
+        if not ret:
+            break
+        frames.append(frame)
+    cap.release()
+    return track_from_frames(frames, team=team, settings=settings)
+
+
+def _motion_blob_fallback(prev: np.ndarray, cur: np.ndarray, min_area: int) -> tuple[List[List[int]], float]:
+    diff = cv2.absdiff(prev, cur)
+    _, thresh = cv2.threshold(diff, 25, 255, cv2.THRESH_BINARY)
+    cnts, _ = cv2.findContours(thresh, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+    boxes: List[List[int]] = []
+    max_area = 0.0
+    for c in cnts:
+        area = cv2.contourArea(c)
+        if area >= min_area:
+            x, y, w, h = cv2.boundingRect(c)
+            boxes.append([int(x), int(y), int(x + w), int(y + h)])
+            max_area = max(max_area, area)
+    return boxes, max_area
+
+
+def track_from_frames(
+    frames: Iterable[np.ndarray],
+    *,
+    team: str = "WHITE",
+    settings: Dict[str, Any] | None = None,
+) -> List[Track]:
+    """Return tracks from in-memory ``frames`` using motion detection.
+
+    Parameters in ``settings`` control the fallback behaviour:
+
+    - ``enable_motion_blob_fallback`` (bool)
+    - ``motion_blob_min_area`` (int)
+    - ``motion_blob_confidence`` (float)
+    - ``motion_blob_n_frames`` (int)
+    """
+
+    if cv2 is None or np is None:
+        return []
+
+    settings = settings or {}
+    enable_fb = bool(settings.get("enable_motion_blob_fallback", True))
+    min_area = int(settings.get("motion_blob_min_area", 150))
+    conf_thresh = float(settings.get("motion_blob_confidence", 0.4))
+    n_frames = int(settings.get("motion_blob_n_frames", 5))
+
+    logger = logging.getLogger("detect_track")
+
+    tracks: List[Track] = []
+    prev_gray: np.ndarray | None = None
+    no_motion = 0
+    frame_id = 0
+    next_id = 1
+
+    for frame in frames:
+        gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+        blur = cv2.GaussianBlur(gray, (5, 5), 0)
+        if prev_gray is None:
+            prev_gray = blur
+            frame_id += 1
+            continue
+
+        diff = cv2.absdiff(prev_gray, blur)
+        score = float(diff.mean()) / 255.0
+
+        if score >= conf_thresh:
+            no_motion = 0
+        else:
+            no_motion += 1
+            if enable_fb and no_motion >= n_frames:
+                boxes, max_area = _motion_blob_fallback(prev_gray, blur, min_area)
+                if boxes:
+                    logger.debug(
+                        f"Motion-blob fallback triggered: {len(boxes)} blobs detected, largest area={max_area:.0f}px²"
+                    )
+                    for box in boxes:
+                        tracks.append(
+                            Track(
+                                frame=frame_id,
+                                player_id=f"fb{next_id}",
+                                team=team,
+                                jersey_number="",
+                                bbox=box,
+                                detection_source="motion_blob_fallback",
+                            )
+                        )
+                        next_id += 1
+                no_motion = 0
+
+        prev_gray = blur
+        frame_id += 1
+
     return tracks
 
 

--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -37,6 +37,10 @@ from . import (
 from .segmentation import Segment
 from segment.play_segmenter import segment_video
 
+try:  # pragma: no cover - optional dependency
+    import yaml
+except Exception:  # pragma: no cover - optional dependency
+    yaml = None  # type: ignore
 
 DEFAULT_MIN_PLAY_LEN = 6.0
 DEFAULT_MIN_PLAY_GAP = 1.5
@@ -233,7 +237,19 @@ def run_pipeline(
     meta["play_count"] = len(plays)
     meta_path.write_text(json.dumps(meta, indent=2))
 
-    tracks = detect_track.run(video, team=team, fps=fps, model_path=detect_model)
+    settings_data: Dict[str, Any] = {}
+    settings_fp = Path("config/settings.yaml")
+    if settings_fp.exists() and yaml:
+        try:
+            loaded = yaml.safe_load(settings_fp.read_text()) or {}
+            if isinstance(loaded, dict):
+                settings_data = loaded
+        except Exception:
+            settings_data = {}
+
+    tracks = detect_track.run(
+        video, team=team, fps=fps, model_path=detect_model, settings=settings_data
+    )
 
     tracking_rows = [t.as_dict() for t in tracks]
 

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -15,3 +15,6 @@ grading:
 export:
   pre_snap_pad_sec: 3.0
   post_whistle_pad_sec: 2.0
+enable_motion_blob_fallback: true
+motion_blob_min_area: 150
+motion_blob_confidence: 0.4

--- a/overlays/debug_overlay.py
+++ b/overlays/debug_overlay.py
@@ -62,8 +62,13 @@ def render_overlays_for_out_dir(out_dir: Path):
             t_rows = [r for r in rows if abs(float(r.get("time_s", 0.0)) - t) <= (1.0 / fps) * 1.1]
             for r in t_rows:
                 x1, y1, x2, y2 = [int(v) for v in r.get("bbox", [0, 0, 0, 0])]
-                cv2.rectangle(frame, (x1, y1), (x2, y2), (0, 255, 0), 2)
-                label = f"#{r.get('jersey_number', '?')} id:{r.get('track_id', '?')}"
+                color = (0, 255, 0)
+                prefix = ""
+                if r.get("detection_source") == "motion_blob_fallback":
+                    color = (0, 255, 255)
+                    prefix = "FB "
+                cv2.rectangle(frame, (x1, y1), (x2, y2), color, 2)
+                label = f"{prefix}#{r.get('jersey_number', '?')} id:{r.get('track_id', '?')}"
                 cv2.putText(frame, label, (x1, max(20, y1 - 6)), cv2.FONT_HERSHEY_SIMPLEX, 0.6, (255, 255, 255), 2)
 
             writer.write(frame)

--- a/tests/test_motion_blob_fallback.py
+++ b/tests/test_motion_blob_fallback.py
@@ -1,0 +1,31 @@
+import numpy as np
+import pytest
+
+cv2 = pytest.importorskip("cv2")
+from analysis import detect_track
+
+
+def _gen_frames():
+    frames = []
+    base = np.zeros((100, 100), dtype=np.uint8)
+    for i in range(6):
+        frame = base.copy()
+        cv2.rectangle(frame, (10 + i, 10), (30 + i, 30), 255, -1)
+        frames.append(cv2.cvtColor(frame, cv2.COLOR_GRAY2BGR))
+    return frames
+
+
+def test_motion_blob_fallback_triggers():
+    frames = _gen_frames()
+    settings = {
+        "enable_motion_blob_fallback": True,
+        "motion_blob_min_area": 50,
+        "motion_blob_confidence": 0.9,  # high so primary fails
+        "motion_blob_n_frames": 5,
+    }
+    tracks = detect_track.track_from_frames(frames, settings=settings, team="WHITE")
+    fb_tracks = [t for t in tracks if t.detection_source == "motion_blob_fallback"]
+    assert fb_tracks, "fallback should produce tracks"
+    for t in fb_tracks:
+        x1, y1, x2, y2 = t.bbox
+        assert x2 > x1 and y2 > y1


### PR DESCRIPTION
## Summary
- add motion-blob fallback when primary motion detection fails for several frames
- expose motion blob configuration flags and log fallback events
- render fallback detections in yellow overlays and test fallback logic

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689de3b7e270832dab5ca0a1e6556371