### PR TITLE
feat: add detector probe and loader

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,5 +29,5 @@ run-pipeline:
 >  --debug-summary \
 >  --debug-detections \
 >  --max-debug-frames 12 \
->  --conf-thresh 0.22 \
->  --nms-thresh 0.55
+>  --conf-thresh $${MCA_DET_CONF:-0.22} \
+>  --nms-thresh $${MCA_DET_NMS:-0.55}

--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -1,1 +1,1 @@
-# Marks analysis as a package.
+# analysis package

--- a/analysis/detectors/__init__.py
+++ b/analysis/detectors/__init__.py
@@ -1,1 +1,1 @@
-# Marks detectors as a subpackage.
+# detectors subpackage

--- a/analysis/detectors/player_detector.py
+++ b/analysis/detectors/player_detector.py
@@ -1,31 +1,53 @@
-import os
-import os.path as osp
+"""
+Alias loader for the actual player detector implementation.
 
-DEFAULT_CONF = float(os.environ.get("MCA_DET_CONF", "0.25"))
-DEFAULT_NMS = float(os.environ.get("MCA_DET_NMS", "0.50"))
-EXPECTS_RGB = True
-INPUT_SIZE = (960, 540)  # (w, h)
-WEIGHTS_PATH = os.environ.get("MCA_DET_WEIGHTS", "models/player_detector/best.onnx")
+This module looks for another module under `analysis.detectors.*`
+that exposes a `detect(...)` function (and optionally DEFAULT_CONF,
+DEFAULT_NMS, EXPECTS_RGB, INPUT_SIZE, WEIGHTS_PATH) and then
+re-exports its public symbols so existing imports keep working:
 
-def _ensure_weights():
-    if not osp.exists(WEIGHTS_PATH):
-        raise FileNotFoundError(f"Detector weights missing: {WEIGHTS_PATH}")
+    from analysis.detectors import player_detector
+    boxes, scores, classes = player_detector.detect(...)
 
-def detect(frame, conf_thresh=None, nms_thresh=None):
-    """
-    Args:
-      frame: np.ndarray (H, W, 3) BGR by OpenCV; we convert to RGB if EXPECTS_RGB.
-    Returns:
-      boxes (List[xyxy]), scores (List[float]), classes (List[int])
-      Return []/[]/[] on no detections, never None.
-    """
-    _ensure_weights()
-    conf = DEFAULT_CONF if conf_thresh is None else conf_thresh
-    nms = DEFAULT_NMS if nms_thresh is None else nms_thresh
-    try:
-        # existing inference code should go here
-        # ensure resize & color ordering are correct
-        # boxes, scores, classes = your_infer(frame_rgb_resized, conf, nms)
-        return [], [], []  # placeholder
-    except Exception:
-        return [], [], []
+If you know the exact file (e.g., yolo_player.py), you can replace
+this module with:
+    from .yolo_player import *
+"""
+import pkgutil, importlib
+from types import ModuleType
+
+PKG_PREFIX = __name__.rsplit('.', 1)[0]  # 'analysis.detectors'
+
+
+def _load_impl() -> ModuleType:
+    preferred = ["yolo_player", "yolo_detector", "players", "detector", "people_detector"]
+    for base in preferred:
+        try:
+            return importlib.import_module(f"{PKG_PREFIX}.{base}")
+        except Exception:
+            pass
+
+    # Fallback: discover any module with a detect() function
+    import analysis.detectors as _pkg
+    for mod in pkgutil.walk_packages(_pkg.__path__, prefix=_pkg.__name__ + "."):
+        name_l = mod.name.lower()
+        if name_l.endswith("__init__"):
+            continue
+        if ("player" in name_l or "detect" in name_l) and "player_detector" not in name_l:
+            try:
+                m = importlib.import_module(mod.name)
+                if hasattr(m, "detect"):
+                    return m
+            except Exception:
+                continue
+    raise ImportError("No detector implementation with detect() found under analysis.detectors.*")
+
+
+_impl = _load_impl()
+
+# Re-export everything public from the impl module
+for k in dir(_impl):
+    if not k.startswith("_"):
+        globals()[k] = getattr(_impl, k)
+__all__ = [k for k in globals().keys() if not k.startswith("_")]
+

--- a/tools/probe_detector.py
+++ b/tools/probe_detector.py
@@ -1,32 +1,74 @@
-import json
-import cv2  # type: ignore
+import os, sys, json, pkgutil, importlib
 from pathlib import Path
 
-# Ensure repo root on sys.path if running as `PYTHONPATH=. python3 tools/probe_detector.py`
-from analysis.detectors import player_detector as det
+# Ensure repo root on sys.path
+repo_root = Path(__file__).resolve().parents[1]
+if str(repo_root) not in sys.path:
+    sys.path.insert(0, str(repo_root))
+
+
+def discover_detector():
+    """
+    Try to import the same detector the pipeline expects:
+      from analysis.detectors import player_detector
+    If that import works, return it. Otherwise, auto-discover a module with detect().
+    """
+    # First try the alias
+    try:
+        from analysis.detectors import player_detector as det
+        if hasattr(det, "detect"):
+            return det
+    except Exception:
+        pass
+
+    # Fallback: walk analysis.* to find any detect()
+    import analysis
+    for m in pkgutil.walk_packages(analysis.__path__, prefix=analysis.__name__ + "."):
+        name = m.name.lower()
+        if ("detector" in name or "player" in name) and not name.endswith("__init__"):
+            mod = importlib.import_module(m.name)
+            if hasattr(mod, "detect"):
+                return mod
+    raise ImportError("Could not find a detector module with a detect() function under analysis.*")
 
 
 def main(video="video/manual_uploads/IMG_4129.MP4"):
+    import cv2
+    det = discover_detector()
+    conf = float(getattr(det, "DEFAULT_CONF", float(os.getenv("MCA_DET_CONF", "0.25"))))
+    nms  = float(getattr(det, "DEFAULT_NMS", float(os.getenv("MCA_DET_NMS", "0.50"))))
+    expects_rgb = bool(getattr(det, "EXPECTS_RGB", True))
+
     cap = cv2.VideoCapture(video)
     ok, frame = cap.read()
     Path("debug").mkdir(exist_ok=True)
-    if ok:
-        cv2.imwrite("debug/first_frame.jpg", frame)
-    img = frame[..., ::-1] if (ok and getattr(det, "EXPECTS_RGB", True)) else frame
-    boxes, scores, classes = det.detect(
-        img,
-        conf_thresh=det.DEFAULT_CONF,
-        nms_thresh=det.DEFAULT_NMS,
-    )
-    out = {
-        "opened": ok,
+    meta = {
+        "opened": bool(ok),
         "shape": None if not ok else list(frame.shape),
-        "detections": len(boxes) if boxes else 0,
-        "detector_module": det.__name__,
+        "detector_module": getattr(det, "__name__", "unknown"),
+        "detections": None,
+        "error": None
     }
-    Path("debug/detector_probe.json").write_text(json.dumps(out, indent=2))
-    print(json.dumps(out, indent=2))
+
+    if ok:
+        try:
+            import cv2 as _cv2
+            _cv2.imwrite("debug/first_frame.jpg", frame)
+            img = frame[..., ::-1] if expects_rgb else frame
+            boxes, scores, classes = det.detect(img, conf_thresh=conf, nms_thresh=nms)
+            meta["detections"] = 0 if boxes is None else len(boxes)
+        except Exception as e:
+            meta["detections"] = -1
+            meta["error"] = f"{type(e).__name__}: {e}"
+    else:
+        meta["detections"] = -2
+        meta["error"] = "Failed to read first frame"
+
+    Path("debug/detector_probe.json").write_text(json.dumps(meta, indent=2))
+    print(json.dumps(meta, indent=2))
 
 
 if __name__ == "__main__":
-    main()
+    vid = sys.argv[1] if len(sys.argv) > 1 else "video/manual_uploads/IMG_4129.MP4"
+    main(vid)
+


### PR DESCRIPTION
## Summary
- add package markers for analysis and detectors
- use dynamic alias for player detector implementations
- add robust detector probing tool
- support env-configurable thresholds in run-pipeline Makefile target

## Testing
- `PYTHONPATH=. python3 tools/probe_detector.py` *(fails: ImportError: libGL.so.1: cannot open shared object file)*
- `make run-pipeline` *(fails: ImportError: libGL.so.1: cannot open shared object file)*
- `pytest tests/test_detect_jerseys_api.py -q`
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_689e1b766160832da3eada94895ed0d6