### PR TITLE
Handle null clinic_id before unique constraint on facility_patient_counts

### DIFF
--- a/alter_facility_patient_counts_add_clinic_snapshot_unique.sql
+++ b/alter_facility_patient_counts_add_clinic_snapshot_unique.sql
@@ -1,0 +1,22 @@
+BEGIN;
+
+-- Populate missing clinic_id values from the clinics table based on facility_id
+UPDATE facility_patient_counts fpc
+SET clinic_id = c.id
+FROM clinics c
+WHERE fpc.clinic_id IS NULL
+  AND fpc.facility_id = c.facility_id;
+
+-- Remove any remaining rows without a clinic_id
+DELETE FROM facility_patient_counts
+WHERE clinic_id IS NULL;
+
+-- Enforce NOT NULL constraint on clinic_id
+ALTER TABLE facility_patient_counts
+  ALTER COLUMN clinic_id SET NOT NULL;
+
+-- Ensure uniqueness of clinic and snapshot_date pairs
+CREATE UNIQUE INDEX IF NOT EXISTS facility_patient_counts_clinic_snapshot_unique
+  ON facility_patient_counts (clinic_id, snapshot_date);
+
+COMMIT;


### PR DESCRIPTION
## Summary
- Add migration script to populate missing clinic_id values, remove remaining null rows, enforce NOT NULL, and create unique index on clinic_id and snapshot_date

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_689e1e35c850832d91bca3297166ca75