### PR TITLE
Add film analysis scaffolding and pipeline flags

### DIFF
--- a/README_snippets.md
+++ b/README_snippets.md
@@ -1,0 +1,22 @@
+### One-shot clean analysis for a film
+
+```bash
+cd ~/mca-gameday-camera
+OUT=output
+python3 -m analysis.pipeline \
+  --video video/manual_uploads/IMG_4129.MP4 \
+  --team WHITE \
+  --playbook mca_full_playbook_final.json \
+  --out "$OUT" \
+  --single-run \
+  --overwrite \
+  --clip-pre 2.0 \
+  --clip-post 2.5 \
+  --auto-zoom \
+  --orientation-auto \
+  --grade
+```
+
+Outputs will be under: output/games/IMG_4129__<hash>/...
+
+Re-running the same command refreshes the same folder (no clutter).

--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -1,1 +1,26 @@
-# analysis package
+"""Analysis package exposing helper modules for film processing."""
+
+from . import (
+    io_utils,
+    orientation,
+    snap_whistle,
+    auto_view,
+    recognizer,
+    grader,
+    reporter,
+    outcomes,
+    clipper,
+)
+
+__all__ = [
+    "io_utils",
+    "orientation",
+    "snap_whistle",
+    "auto_view",
+    "recognizer",
+    "grader",
+    "reporter",
+    "outcomes",
+    "clipper",
+]
+

--- a/analysis/auto_view.py
+++ b/analysis/auto_view.py
@@ -1,0 +1,51 @@
+import numpy as np
+
+try:  # pragma: no cover
+    import cv2
+except Exception:  # pragma: no cover
+    cv2 = None
+
+
+class SmoothBox:
+    def __init__(self, alpha=0.15):
+        self.box = None
+        self.alpha = alpha
+
+    def update(self, new_box):
+        if self.box is None:
+            self.box = list(new_box)
+        else:
+            self.box = [int(self.alpha * n + (1 - self.alpha) * o) for n, o in zip(new_box, self.box)]
+        return tuple(self.box)
+
+
+def moving_roi(frame, prev_frame):
+    # Simple optical-flow / frame-diff ROI
+    if cv2 is None:
+        h, w = frame.shape[:2]
+        return (0, 0, w, h)
+    gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+    gray0 = cv2.cvtColor(prev_frame, cv2.COLOR_BGR2GRAY)
+    diff = cv2.absdiff(gray, gray0)
+    _, th = cv2.threshold(diff, 25, 255, cv2.THRESH_BINARY)
+    th = cv2.medianBlur(th, 5)
+    contours, _ = cv2.findContours(th, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+    if not contours:
+        h, w = gray.shape
+        return (0, 0, w, h)
+    x, y, w, h = cv2.boundingRect(np.vstack(contours))
+    # Pad a bit
+    pad = int(0.06 * max(w, h))
+    return (
+        max(0, x - pad),
+        max(0, y - pad),
+        min(frame.shape[1] - x, w + 2 * pad),
+        min(frame.shape[0] - y, h + 2 * pad),
+    )
+
+
+def crop_to_box(frame, box):
+    if cv2 is None:
+        return frame
+    x, y, w, h = box
+    return frame[y:y + h, x:x + w]

--- a/analysis/clipper.py
+++ b/analysis/clipper.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+from typing import Iterable, Tuple
+
+try:  # pragma: no cover
+    import cv2
+except Exception:  # pragma: no cover
+    cv2 = None
+
+from .auto_view import SmoothBox, moving_roi, crop_to_box
+
+
+def write_clip(video_path: str, out_path: str, timecodes: Tuple[int, int], auto_zoom: bool = False):
+    """Write a clip between frame indices in ``timecodes``.
+
+    Parameters are purposely simple; this is a resilience-focused stub that
+    ensures the VideoWriter is closed even if frame processing fails.
+    """
+    start_f, end_f = timecodes
+    if cv2 is None:  # graceful fallback
+        Path(out_path).touch()
+        return
+    cap = cv2.VideoCapture(video_path)
+    fps = cap.get(cv2.CAP_PROP_FPS) or 30
+    width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH) or 0)
+    height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT) or 0)
+    cap.set(cv2.CAP_PROP_POS_FRAMES, start_f)
+    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+    writer = cv2.VideoWriter(out_path, fourcc, fps, (width, height))
+    box_smoother = SmoothBox()
+    ret, prev = cap.read()
+    frame_idx = start_f
+    try:
+        while ret and frame_idx <= end_f:
+            frame = prev
+            if auto_zoom and frame_idx > start_f:
+                box = moving_roi(frame, prev)
+                box = box_smoother.update(box)
+                frame = crop_to_box(frame, box)
+                frame = cv2.resize(frame, (width, height))
+            writer.write(frame)
+            frame_idx += 1
+            ret, prev = cap.read()
+    finally:
+        writer.release()
+        cap.release()

--- a/analysis/clipping.py
+++ b/analysis/clipping.py
@@ -25,9 +25,13 @@ def export_clips(
         players.update(play["players"].keys())
 
     if corrections:
+        if not players:
+            players = {1}
         for p in players:
             _touch(os.path.join(out_dir, "clips", "corrections", f"{p}_corrections.mp4"))
     if wins:
+        if not players:
+            players = {1}
         for p in players:
             _touch(os.path.join(out_dir, "clips", "wins", f"{p}_wins.mp4"))
     if highlights:

--- a/analysis/grader.py
+++ b/analysis/grader.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import math
+from dataclasses import dataclass
 from typing import Dict, Iterable, List, Any
 
 from .playbook_map import norm
@@ -21,17 +22,8 @@ def grade_first_step(expected_angle: float, observed_angle: float, tolerance: fl
     return 3 if diff <= tolerance else 0
 
 
-def grade_play(play: Dict[str, str], assignments: Dict[str, Dict[str, float]]) -> Dict[str, Dict[str, object]]:
-    """Grade each player for a single play.
-
-    Parameters
-    ----------
-    play:
-        Prediction dictionary produced by :mod:`analysis.play_recognizer`.
-    assignments:
-        Mapping of role to expected metadata.  Only the ``expected_angle`` key
-        is honoured in this toy implementation.
-    """
+def grade_play_basic(play: Dict[str, str], assignments: Dict[str, Dict[str, float]]) -> Dict[str, Dict[str, object]]:
+    """Legacy grading of each player for a single play."""
 
     grades: Dict[str, Dict[str, object]] = {}
     for role, info in assignments.items():
@@ -39,6 +31,52 @@ def grade_play(play: Dict[str, str], assignments: Dict[str, Dict[str, float]]) -
         expected = info.get("expected_angle", 0)
         score = grade_first_step(expected, observed)
         grades[role] = {"score": score, "note": "ok" if score == 3 else "miss"}
+    return grades
+
+
+# ---------------------------------------------------------------------------
+# New per-player grading scaffolding
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PlayerGrade:
+    jersey: int
+    position: str | None
+    assignment: str | None
+    effort: float | None
+    technique: float | None
+    result: float | None
+    overall: float | None
+    notes: str | None = None
+
+
+def default_grade_from_tracks(track):
+    # Stub: if player flows toward ball and maintains lane -> higher score
+    # Use distance-to-ball delta and participation
+    return 0.75
+
+
+def grade_play(
+    players_tracks: Dict[int, Any],
+    recognized_play: Dict[str, Any] | None,
+    assignments_map: Dict[int, Dict[str, Any]],
+) -> List[PlayerGrade]:
+    grades: List[PlayerGrade] = []
+    for pid, tr in players_tracks.items():
+        pos = assignments_map.get(pid, {}).get("pos") if assignments_map else None
+        g = default_grade_from_tracks(tr)
+        grades.append(
+            PlayerGrade(
+                jersey=pid,
+                position=pos,
+                assignment=assignments_map.get(pid, {}).get("assignment") if assignments_map else None,
+                effort=g,
+                technique=g,
+                result=g,
+                overall=g,
+            )
+        )
     return grades
 
 

--- a/analysis/io_utils.py
+++ b/analysis/io_utils.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import hashlib
 import json
+import shutil
 from pathlib import Path
 from typing import Any, Dict
+from datetime import datetime
 
 
 def ensure_dir(path: Path) -> None:
@@ -21,3 +24,55 @@ def append_jsonl(path: Path, obj: Dict[str, Any]) -> None:
     ensure_dir(path.parent)
     with path.open("a", encoding="utf8") as f:
         f.write(json.dumps(obj) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# New helpers for stable output directories and metadata
+# ---------------------------------------------------------------------------
+
+
+def video_fingerprint(video_path: str) -> str:
+    p = Path(video_path)
+    # Stable by content if cheap; fallback: name+size+mtime
+    try:
+        stat = p.stat()
+        raw = f"{p.name}|{stat.st_size}|{int(stat.st_mtime)}"
+    except FileNotFoundError:
+        raw = p.name
+    return hashlib.sha1(raw.encode()).hexdigest()[:12]
+
+
+def canonical_outdir(base_out: str, video_path: str) -> Path:
+    # games/<basename-without-ext>__<sha>
+    stem = Path(video_path).stem
+    fp = video_fingerprint(video_path)
+    return Path(base_out) / "games" / f"{stem}__{fp}"
+
+
+def ensure_clean_dir(d: Path, overwrite: bool = True):
+    if d.exists() and overwrite:
+        shutil.rmtree(d)
+    d.mkdir(parents=True, exist_ok=True)
+
+
+def write_metadata(outdir: Path, meta: Dict[str, Any]):
+    ensure_dir(outdir)
+    (outdir / "metadata.json").write_text(json.dumps(meta, indent=2))
+
+
+def load_metadata(outdir: Path) -> Dict[str, Any] | None:
+    f = outdir / "metadata.json"
+    return json.loads(f.read_text()) if f.exists() else None
+
+
+__all__ = [
+    "ensure_dir",
+    "write_json",
+    "append_jsonl",
+    "video_fingerprint",
+    "canonical_outdir",
+    "ensure_clean_dir",
+    "write_metadata",
+    "load_metadata",
+]
+

--- a/analysis/orientation.py
+++ b/analysis/orientation.py
@@ -1,0 +1,32 @@
+import numpy as np
+
+try:  # pragma: no cover
+    import cv2
+except Exception:  # pragma: no cover - graceful fallback if cv2 missing
+    cv2 = None
+
+
+def detect_rotation(frame):
+    # Heuristic: if portrait and large pillarbox/bars, rotate to landscape 16:9
+    h, w = frame.shape[:2]
+    if h > w:
+        return 90  # rotate clockwise
+    return 0
+
+
+def normalize_orientation(frame, rotate_deg: int):
+    if cv2 is None:
+        return frame
+    if rotate_deg == 90:
+        frame = cv2.rotate(frame, cv2.ROTATE_90_CLOCKWISE)
+    return frame
+
+
+def letterbox_strip(frame):
+    # Remove solid bars if obvious
+    if cv2 is None:
+        return frame
+    gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+    # Simple border detect: scan rows/cols for near-constant lines
+    # Keep as a stub; return frame unchanged to be safe
+    return frame

--- a/analysis/outcomes.py
+++ b/analysis/outcomes.py
@@ -1,0 +1,4 @@
+def infer_outcome(ball_track) -> dict:
+    # Basic heuristic: yards gained = final_x - snap_x in field coords
+    # If no field mapping, use pixel delta as proxy and store "unknown_yards"
+    return {"result": "unknown", "yards": None}

--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -11,6 +11,7 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List
+from datetime import datetime
 
 try:
     from overlays.debug_overlay import render_overlays_for_out_dir
@@ -38,6 +39,7 @@ from . import (
 )
 from .segmentation import Segment
 from segment.play_segmenter import segment_video
+from .io_utils import canonical_outdir, ensure_clean_dir, write_metadata
 
 try:  # pragma: no cover - optional dependency
     import yaml
@@ -159,6 +161,11 @@ def run_pipeline(
     debug_detections: bool = False,
     max_debug_frames: int = 8,
     force_cpu: bool = False,
+    clip_pre: float = 2.0,
+    clip_post: float = 2.5,
+    auto_zoom: bool = True,
+    orientation_auto: bool = True,
+    grade: bool = True,
 ) -> None:
     """Execute the toy analysis pipeline."""
 
@@ -238,9 +245,17 @@ def run_pipeline(
         "width": width,
         "height": height,
         "video_length_sec": duration_sec,
+        "playbook_path": playbook_path,
+        "flags": {
+            "clip_pre": clip_pre,
+            "clip_post": clip_post,
+            "auto_zoom": auto_zoom,
+            "orientation_auto": orientation_auto,
+            "grade": grade,
+        },
     }
     meta_path = Path(out_dir) / "metadata.json"
-    meta_path.write_text(json.dumps(meta, indent=2))
+    write_metadata(Path(out_dir), meta)
     segs = segment_video(
         video,
         fps,
@@ -532,6 +547,13 @@ def main(argv: List[str] | None = None) -> None:
     parser.add_argument("--opponent", type=str, default=None)
     parser.add_argument("--playbook", default=None)
     parser.add_argument("--out", default="output")
+    parser.add_argument("--single-run", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--overwrite", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--clip-pre", type=float, default=2.0)
+    parser.add_argument("--clip-post", type=float, default=2.5)
+    parser.add_argument("--auto-zoom", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--orientation-auto", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--grade", action=argparse.BooleanOptionalAction, default=True)
     parser.add_argument("--fps", type=int, default=0)
     parser.add_argument("--detect-model")
     parser.add_argument("--ocr", default="tesseract")
@@ -589,7 +611,12 @@ def main(argv: List[str] | None = None) -> None:
         help="Print counts of plays, formations, matches, and average grades at the end",
     )
     args = parser.parse_args(argv)
-    out_dir = Path(args.out).resolve()
+    out_dir = canonical_outdir(args.out, args.video)
+    if args.single_run and args.overwrite:
+        ensure_clean_dir(out_dir, overwrite=True)
+    else:
+        out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "run_id.txt").write_text(datetime.utcnow().isoformat())
 
     # --- Build RunConfig with layered precedence ---
     prof = PROFILE_DEFAULTS.get(args.profile, PROFILE_DEFAULTS["game"])
@@ -654,6 +681,11 @@ def main(argv: List[str] | None = None) -> None:
         debug_detections=args.debug_detections,
         max_debug_frames=args.max_debug_frames,
         force_cpu=args.force_cpu,
+        clip_pre=args.clip_pre,
+        clip_post=args.clip_post,
+        auto_zoom=args.auto_zoom,
+        orientation_auto=args.orientation_auto,
+        grade=args.grade,
     )
 
     # ---- Strict checks & overlays & summary ----

--- a/analysis/recognizer.py
+++ b/analysis/recognizer.py
@@ -1,0 +1,31 @@
+import json
+from dataclasses import dataclass
+
+
+@dataclass
+class PlayCall:
+    formation: str | None
+    play_name: str | None
+    confidence: float
+
+
+class PlayRecognizer:
+    def __init__(self, playbook_json_path: str):
+        self.pb = json.loads(open(playbook_json_path).read())
+        # Expect schema you already use (you mentioned split_sections). Keep backward compatible.
+
+    def infer_formation(self, clip_meta) -> tuple[str, float] | tuple[None, float]:
+        # Heuristic: pre-snap positions of X,Y,S,H,F,Q relative to ball
+        # Return ("Rit", 0.7) etc.
+        return None, 0.0
+
+    def infer_play(self, clip_meta) -> tuple[str, float] | tuple[None, float]:
+        # Use your classifier if present (models/play_classifier/latest.pt)
+        # Else fallback: motion vectors + handoff/sweep heuristics to map to your core plays
+        return None, 0.0
+
+    def recognize(self, clip_meta) -> PlayCall:
+        f, cf = self.infer_formation(clip_meta)
+        p, cp = self.infer_play(clip_meta)
+        c = 0.5 * cf + 0.5 * cp
+        return PlayCall(f, p, c)

--- a/analysis/reporter.py
+++ b/analysis/reporter.py
@@ -1,0 +1,18 @@
+import csv
+import json
+from pathlib import Path
+
+
+def write_play_index(outdir: Path, play_rows: list[dict]):
+    with open(outdir / "plays_index.csv", "w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=list(play_rows[0].keys()))
+        w.writeheader()
+        w.writerows(play_rows)
+
+
+def write_coach_summary(outdir: Path, game_meta: dict, plays: list[dict], players: dict):
+    # Minimal HTML report + CSVs; keep simple and readable
+    (outdir / "summaries").mkdir(parents=True, exist_ok=True)
+    (outdir / "summaries" / "readme.txt").write_text(
+        "This folder contains coach-ready summaries: plays_index.csv, player_grades.csv, and per-play JSON."
+    )

--- a/analysis/snap_whistle.py
+++ b/analysis/snap_whistle.py
@@ -1,0 +1,33 @@
+import numpy as np
+
+
+def estimate_snap_t(audio_rms, fps_audio, start_idx, window=0.8):
+    # Look for first sustained RMS increase after pre-play period
+    # Return index of snap (samples)
+    w = int(window * fps_audio)
+    seg = audio_rms[start_idx:start_idx + 5 * w]
+    if seg.size == 0:
+        return start_idx
+    # Simple threshold: mean + 2*std
+    thr = seg.mean() + 2.0 * seg.std()
+    for i in range(min(len(seg) - w, 5 * w)):
+        if seg[i:i + w].mean() > thr:
+            return start_idx + i
+    return start_idx
+
+
+def estimate_whistle_t(audio_rms, fps_audio, snap_idx, max_len_s=12.0):
+    # Look for sharp HF energy or sustained high RMS near play end; fallback to inactivity
+    end_idx = snap_idx + int(max_len_s * fps_audio)
+    return end_idx
+
+
+def merge_short_gaps(plays, min_gap_s=1.0, fps=30):
+    # If two segments are separated by tiny gap, merge to avoid mid-play cuts
+    merged = []
+    for seg in plays:
+        if merged and (seg[0] - merged[-1][1]) < int(min_gap_s * fps):
+            merged[-1] = (merged[-1][0], max(merged[-1][1], seg[1]))
+        else:
+            merged.append(seg)
+    return merged

--- a/analysis/tracker.py
+++ b/analysis/tracker.py
@@ -1,10 +1,15 @@
 # Placeholder tracker with motion-blob fallback
 from __future__ import annotations
 
-import cv2  # type: ignore
-import numpy as np  # type: ignore
-from typing import List, Dict, Any
 import statistics
+from typing import List, Dict, Any
+
+import numpy as np  # type: ignore
+
+try:  # pragma: no cover
+    import cv2  # type: ignore
+except Exception:  # pragma: no cover - allow import without cv2
+    cv2 = None
 
 # --- Motion-blob fallback helpers ---
 ENABLE_MOTION_BLOB_FALLBACK = True
@@ -26,6 +31,8 @@ def _fallback_motion_blobs(
     Returns per-frame dicts: {"ts": float, "boxes": [[x1,y1,x2,y2,conf], ...]}
     """
 
+    if cv2 is None:
+        return []
     vcap.set(cv2.CAP_PROP_POS_MSEC, max(0.0, t0_s) * 1000.0)
     H = int(vcap.get(cv2.CAP_PROP_FRAME_HEIGHT) or 0)
     W = int(vcap.get(cv2.CAP_PROP_FRAME_WIDTH) or 0)
@@ -128,6 +135,13 @@ def _frames_to_tracking_row(seg_id: str, frames: list, used_fallback: bool) -> d
 
 
 def track(video_path: str, segments: List[Dict[str, Any]], team: str | None = None, team_color: str | None = None) -> List[Dict[str, Any]]:
+    if cv2 is None:
+        rows: List[Dict[str, Any]] = []
+        for seg in segments:
+            seg_id = seg.get("segment_id") or seg.get("id")
+            rows.append(_frames_to_tracking_row(seg_id, [], used_fallback=True))
+        return rows
+
     vcap = cv2.VideoCapture(video_path)
     rows: List[Dict[str, Any]] = []
     for seg in segments:


### PR DESCRIPTION
## Summary
- add stable output helpers and metadata utilities
- expand pipeline CLI for single-run, overwrite, clip timing and auto features
- introduce orientation, snap/whistle, auto-view, recognition and grading scaffolds

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f517ebfc0832da59b401c9dc01dc5