### PR TITLE
Fix DEFAULT_MIN_PLAY_GAP import in pipeline

### DIFF
--- a/analysis/config.py
+++ b/analysis/config.py
@@ -1,0 +1,3 @@
+"""Configuration constants for analysis modules."""
+
+DEFAULT_MIN_PLAY_GAP = 1.5  # seconds between plays

--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -42,6 +42,7 @@ from .video_reader import VideoReader
 from .snap_whistle_seg import SegParams, SnapWhistleFinder, PlayWindow
 from segment.play_segmenter import segment_video
 from .io_utils import canonical_outdir, ensure_clean_dir, write_metadata
+from analysis.config import DEFAULT_MIN_PLAY_GAP
 
 
 try:  # pragma: no cover - optional dependency
@@ -50,10 +51,9 @@ except Exception:  # pragma: no cover - optional dependency
     yaml = None  # type: ignore
 
 DEFAULT_MIN_PLAY_LEN = 6.0
-DEFAULT_MIN_PLAY_GAP = 1.5
 
 PROFILE_DEFAULTS = {
-    "game": {"min_play_length": 6.0, "min_play_gap": 1.5},
+    "game": {"min_play_length": 6.0, "min_play_gap": DEFAULT_MIN_PLAY_GAP},
     "practice": {"min_play_length": 5.0, "min_play_gap": 1.0},
     "clinic": {"min_play_length": 4.0, "min_play_gap": 0.8},
 }


### PR DESCRIPTION
## Summary
- Define `DEFAULT_MIN_PLAY_GAP` in `analysis/config.py`
- Import the constant in `analysis/pipeline.py` and remove duplicate local definition

## Testing
- `pytest` *(fails: duplicate argument 'clip_pre' in function definition)*

------
https://chatgpt.com/codex/tasks/task_e_689f6bb0abd8832dabb7bbb8d6931db0