### PR TITLE
feat: support alias for YouTube RTMP URL

### DIFF
--- a/env_loader.py
+++ b/env_loader.py
@@ -1,18 +1,47 @@
 import os
 from pathlib import Path
 
+
 def load_env(dotenv_path: str = ".env") -> None:
     p = Path(dotenv_path)
     if p.exists():
         for line in p.read_text().splitlines():
-            line=line.strip()
-            if not line or line.startswith("#") or "=" not in line: 
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
                 continue
-            k,v = line.split("=",1)
+            k, v = line.split("=", 1)
             os.environ.setdefault(k.strip(), v.strip())
 
-def require(name: str) -> str:
-    val = os.environ.get(name, "")
-    if not val:
-        raise RuntimeError(f"Required environment variable {name} is not set. Add it in .env or export it.")
-    return val
+
+def require(names):
+    """Return the first set environment variable among ``names``.
+
+    ``names`` may be a single variable name or an iterable of aliases. The
+    first value found in the environment is returned. If none are set, the
+    user is prompted for a value which is used for the current process only.
+    """
+
+    if isinstance(names, str):
+        names = [names]
+
+    for name in names:
+        val = os.environ.get(name)
+        if val:
+            return val
+
+    msg = (
+        f"Required environment variable(s) {', '.join(names)} not set. "
+        "Check your .env file."
+    )
+    print(msg)
+
+    prompt = (
+        "Enter YouTube RTMP URL: "
+        if any(n in ("YT_RTMP_URL", "YOUTUBE_RTMP_URL") for n in names)
+        else f"Enter value for {names[0]}: "
+    )
+    user_val = input(prompt).strip()
+    if user_val:
+        return user_val
+
+    raise RuntimeError(msg + " Add it in .env or export it.")

--- a/stream_to_youtube.py
+++ b/stream_to_youtube.py
@@ -41,7 +41,12 @@ from config import StreamConfig, load_config
 load_env()
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
 
-YOUTUBE_URL = os.environ.get("YT_RTMP_URL") or require("YT_RTMP_URL")
+# Try both the old and new env var names
+YOUTUBE_URL = (
+    os.environ.get("YT_RTMP_URL")
+    or os.environ.get("YOUTUBE_RTMP_URL")
+    or require(["YT_RTMP_URL", "YOUTUBE_RTMP_URL"])
+)
 
 
 def ffmpeg_has_encoder(name: str) -> bool:


### PR DESCRIPTION
## Summary
- Support both YT_RTMP_URL and YOUTUBE_RTMP_URL in stream_to_youtube
- Allow env_loader.require to accept multiple names, prompt user if missing

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*
- `python - <<'PY' ...` *(missing env vars prompts and accepts input)*

------
https://chatgpt.com/codex/tasks/task_e_689fc9969dc0832dabca269a98bb7868