### PR TITLE
Handle corrupt MJPEG startup

### DIFF
--- a/stream_to_youtube.py
+++ b/stream_to_youtube.py
@@ -144,7 +144,7 @@ def build_ffmpeg_cmd(
     ]
     if use_wallclock_ts:
         video_in += ["-use_wallclock_as_timestamps", "1"]
-    video_in += ["-i", dev]
+    video_in += ["-fflags", "+discardcorrupt", "-i", dev]
     audio_in = [
         "-f",
         "alsa",
@@ -215,6 +215,28 @@ def build_ffmpeg_cmd(
     ] + video_in + audio_in + ["-vf", vf] + v_opts + a_opts + common + [rtmp_url]
 
 
+def _ffmpeg_started_ok(proc, timeout_s=5):
+    """Return True if ffmpeg prints 'Output #0' within timeout."""
+    import time, select, os, fcntl
+
+    fd = proc.stderr.fileno()
+    fl = fcntl.fcntl(fd, fcntl.F_GETFL)
+    fcntl.fcntl(fd, fcntl.F_SETFL, fl | os.O_NONBLOCK)
+    buf = ""
+    t0 = time.time()
+    while time.time() - t0 < timeout_s:
+        r, _, _ = select.select([fd], [], [], 0.1)
+        if r:
+            try:
+                chunk = proc.stderr.read().decode("utf-8", "ignore")
+            except Exception:
+                chunk = ""
+            buf += chunk
+            if "Output #0" in buf:
+                return True
+    return False
+
+
 def run_with_retries(
     rtmp_url: str,
     dev: str = "/dev/video0",
@@ -231,6 +253,7 @@ def run_with_retries(
         {"encoder": "libx264", "input_format": "yuyv422", "use_ts": True},
         {"encoder": "libx264", "input_format": "yuyv422", "use_ts": False},
     ]
+    fallback_tried = False
 
     for i, cfg in enumerate(attempts, 1):
         cmd = build_ffmpeg_cmd(
@@ -253,21 +276,48 @@ def run_with_retries(
         proc = subprocess.Popen(
             cmd,
             stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-            bufsize=1,
-            universal_newlines=True,
+            stderr=subprocess.PIPE,
         )
+        if not _ffmpeg_started_ok(proc, timeout_s=6):
+            logging.warning("FFmpeg didn't announce output quickly; considering v4l2 fallback...")
+            try:
+                proc.terminate()
+            except Exception:
+                pass
+            if not fallback_tried:
+                fallback_tried = True
+                logging.info("Retrying with V4L2 input_format=yuyv422")
+                try:
+                    v4l2_index = cmd.index("-input_format") + 1
+                    cmd[v4l2_index] = "yuyv422"
+                except Exception:
+                    pass
+                proc = subprocess.Popen(
+                    cmd,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                )
+                if not _ffmpeg_started_ok(proc, timeout_s=6):
+                    logging.error("FFmpeg still didn't start after yuyv422 fallback.")
+
+        import fcntl, os
+        try:
+            fd = proc.stderr.fileno()
+            flags = fcntl.fcntl(fd, fcntl.F_GETFL)
+            fcntl.fcntl(fd, fcntl.F_SETFL, flags & ~os.O_NONBLOCK)
+        except Exception:
+            pass
 
         saw_v4l2_corrupt = False
         saw_pts_drop = False
         rc = None
         try:
-            for line in proc.stdout:
-                sys.stdout.write(line)
-                if "Dequeued v4l2 buffer contains corrupted data (0 bytes)" in line:
+            for line in proc.stderr:
+                text = line.decode(errors="replace")
+                sys.stdout.write(text)
+                if "Dequeued v4l2 buffer contains corrupted data (0 bytes)" in text:
                     saw_v4l2_corrupt = True
-                if "invalid dropping" in line and "PTS" in line:
+                if "invalid dropping" in text and "PTS" in text:
                     saw_pts_drop = True
         finally:
             rc = proc.wait()


### PR DESCRIPTION
## Summary
- discard corrupt V4L2 buffers during FFmpeg startup
- add startup watchdog that falls back to yuyv422 if MJPEG is unstable

## Testing
- `pytest` *(fails: ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_689fee70ed98832daa3db26024fea2da