### PR TITLE
Auto encoder fallback and safe schedule import

### DIFF
--- a/gameday
+++ b/gameday
@@ -1,11 +1,70 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ "${1-}" == "--self-test" ]]; then
-  echo "🔎 Probing encoders..."
-  tools/encoder_detect.py "${PREFERRED_ENCODERS-}" || { echo "❌ No encoder works"; exit 1; }
-  echo "✅ Selected: $(tools/encoder_detect.py "${PREFERRED_ENCODERS-}")"
-  exit 0
+# --- Config / defaults ---
+WIDTH="${WIDTH:-1280}"
+HEIGHT="${HEIGHT:-720}"
+FPS="${FPS:-30}"
+
+VIDEO_DEV="${VIDEO_DEV:-/dev/video0}"
+AUDIO_DEV="${AUDIO_DEV:-hw:1,0}"
+
+VIDEO_BITRATE="${VIDEO_BITRATE:-3500k}"
+VIDEO_MAXRATE="${VIDEO_MAXRATE:-4000k}"
+VIDEO_BUFSIZE="${VIDEO_BUFSIZE:-6000k}"
+
+RECORD_DIR="${RECORD_DIR:-recordings}"
+LOG_DIR="${LOG_DIR:-livestream_logs}"
+mkdir -p "$RECORD_DIR" "$LOG_DIR"
+
+TS="$(date +%Y%m%d_%H%M%S)"
+REC_PATH="${RECORD_DIR}/${TS}_raw.mkv"
+LOG_PATH="${LOG_DIR}/${TS}.log"
+
+RTMP_URL="${YT_RTMP_URL:-}"
+if [[ -z "${RTMP_URL}" ]]; then
+  echo "❌ YT_RTMP_URL not set. Export it or put it in .env"
+  exit 1
 fi
 
-exec "$(dirname "$0")/scripts/gameday_launcher.sh"
+# --- Encoder auto-pick ---
+if [[ "${USE_SW_ENC:-0}" == "1" ]]; then
+  PREFERRED_ENCODERS="libx264"
+fi
+ENC_FLAG="$(tools/encoder_detect.py "${PREFERRED_ENCODERS-}" || true)"
+if [[ -z "$ENC_FLAG" ]]; then
+  echo "❌ No working H.264 encoder found."
+  exit 1
+fi
+
+echo "📡 Streaming to: ${RTMP_URL}"
+echo "🎥 Using video device: ${VIDEO_DEV}"
+echo "🎤 Using mic: ${AUDIO_DEV}"
+echo "🗂  Recording file: ${REC_PATH}"
+echo "📜 Log: ${LOG_PATH}"
+
+# --- Build FFmpeg command ---
+# Notes:
+# - Force MJPEG input for USB cams, then normalize to yuv420p
+# - Add -fflags +genpts to smooth DTS/PTS during warmup
+# - Use tee to stream to YT and record locally
+set -x
+ffmpeg -hide_banner -nostdin -fflags +genpts \
+  -f v4l2 -input_format mjpeg -framerate "${FPS}" -video_size "${WIDTH}x${HEIGHT}" -thread_queue_size 512 -i "${VIDEO_DEV}" \
+  -f alsa -ar 48000 -ac 1 -thread_queue_size 512 -i "${AUDIO_DEV}" \
+  -map 0:v:0 -map 1:a:0 \
+  ${ENC_FLAG} -pix_fmt yuv420p -vf "scale=${WIDTH}:${HEIGHT},format=yuv420p" \
+  -g "$((FPS*2))" -bf 0 -b:v "${VIDEO_BITRATE}" -maxrate "${VIDEO_MAXRATE}" -bufsize "${VIDEO_BUFSIZE}" \
+  -preset "${X264_PRESET:-veryfast}" -tune "${X264_TUNE:-zerolatency}" \
+  -c:a aac -b:a 128k -flags +global_header \
+  -f tee "[f=flv]${RTMP_URL}|[f=matroska]${REC_PATH}" \
+  2> "${LOG_PATH}" || {
+    set +x
+    echo
+    echo "⚠️  FFmpeg exited non-zero. Hints:" | tee -a "${LOG_PATH}"
+    echo " • HW encoder failed? Try: USE_SW_ENC=1 ./gameday" | tee -a "${LOG_PATH}"
+    echo " • Check devices: v4l2-ctl --list-devices ; arecord -l" | tee -a "${LOG_PATH}"
+    echo " • See log: ${LOG_PATH}" | tee -a "${LOG_PATH}"
+    exit 1
+  }
+

--- a/play_count_tracker.py
+++ b/play_count_tracker.py
@@ -2,13 +2,21 @@
 
 from __future__ import annotations
 
+import sys
+
+try:
+    import schedule  # pip install schedule
+    SCHEDULE_AVAILABLE = True
+except ModuleNotFoundError:
+    print("[play_count_tracker] 'schedule' not installed; tracker disabled. Run: pip install schedule", file=sys.stderr)
+    SCHEDULE_AVAILABLE = False
+
 import argparse
 import csv
 import os
 import time
 from typing import Dict, Iterable, List
 
-import schedule
 from colorama import Fore, Style, init as colorama_init
 
 from email_alerts import load_env, send_email
@@ -155,6 +163,9 @@ def parse_args() -> argparse.Namespace:
 
 
 def main() -> None:
+    if not SCHEDULE_AVAILABLE:
+        # Don't crash the whole app if optional dependency is missing
+        return
     args = parse_args()
     colorama_init()
     env = load_env()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ deep_sort_realtime
 easyocr
 opencv-python
 torch
+schedule>=1.2.0

--- a/tools/encoder_detect.py
+++ b/tools/encoder_detect.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import subprocess, re, sys, shlex
 
-# Preference order: Jetson V4L2 → NVENC (desktop/laptop NVIDIA) → software x264
+# Preference: Jetson V4L2 → NVENC → software x264
 CANDIDATES = [
     ("h264_v4l2m2m", "-c:v h264_v4l2m2m"),
     ("h264_nvenc",   "-c:v h264_nvenc"),
@@ -11,15 +11,14 @@ CANDIDATES = [
 
 def has_encoder(name: str) -> bool:
     try:
-        out = subprocess.check_output(["ffmpeg", "-hide_banner", "-encoders"],
-                                      text=True, stderr=subprocess.STDOUT)
+        out = subprocess.check_output(["ffmpeg","-hide_banner","-encoders"], text=True, stderr=subprocess.STDOUT)
         return re.search(rf"\b{name}\b", out) is not None
     except Exception:
         return False
 
 
 def sanity_probe(flag: str) -> bool:
-    # Try a 1s null encode to verify the encoder actually opens.
+    # 1-sec null encode to verify the encoder really opens
     cmd = f"ffmpeg -hide_banner -loglevel error -f lavfi -i testsrc2=size=1280x720:rate=30 -t 1 {flag} -f null -"
     try:
         subprocess.check_call(shlex.split(cmd))
@@ -28,20 +27,16 @@ def sanity_probe(flag: str) -> bool:
         return False
 
 
-def pick(preferred_csv: str | None = None) -> str:
+def pick(preferred_csv: str|None=None) -> str:
     order = CANDIDATES[:]
     if preferred_csv:
         want = [x.strip() for x in preferred_csv.split(",") if x.strip()]
         order = [x for x in CANDIDATES if x[0] in want] + [x for x in CANDIDATES if x[0] not in want]
-
     for name, flag in order:
         if has_encoder(name) and sanity_probe(flag):
             return flag
-
-    # Last-ditch: try software x264 even if FFmpeg encoders list is odd
     if sanity_probe("-c:v libx264"):
         return "-c:v libx264"
-
     raise SystemExit("No working H.264 encoder found (tried h264_v4l2m2m, h264_nvenc, libx264).")
 
 


### PR DESCRIPTION
## Summary
- add encoder detection script and auto-fallback gameday wrapper
- guard `schedule` import in `play_count_tracker` and mark as optional dependency

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f1345af8832d8083a875c2a18817