### PR TITLE
feat: add silent encoder detector and skip-hw option

### DIFF
--- a/gameday
+++ b/gameday
@@ -62,11 +62,16 @@ TS="$(date +%Y%m%d_%H%M%S)"
 REC_PATH="${RECORD_DIR}/${TS}_raw.mkv"
 LOG_PATH="${LOG_DIR}/${TS}.log"
 
-# --- Encoder auto-pick (force SW if USE_SW_ENC=1) ---
-if [[ "${USE_SW_ENC:-0}" == "1" ]]; then
-  PREFERRED_ENCODERS="libx264"
+# --- Encoder auto-pick ---
+# Force software if requested, or allow user to skip HW encoders entirely.
+DET_ARGS=( "--silent" )
+if [[ "${USE_SW_ENC:-0}" == "1" || "${SKIP_HW_ENC:-0}" == "1" ]]; then
+  DET_ARGS+=( "--skip-hw" )
 fi
-ENC_FLAG="$(tools/encoder_detect.py "${PREFERRED_ENCODERS-}" || true)"
+if [[ -n "${PREFERRED_ENCODERS-}" ]]; then
+  DET_ARGS+=( "--preferred" "${PREFERRED_ENCODERS}" )
+fi
+ENC_FLAG="$(tools/encoder_detect.py "${DET_ARGS[@]}" || true)"
 if [[ -z "$ENC_FLAG" ]]; then
   echo "❌ No working H.264 encoder found."
   exit 1

--- a/tools/encoder_detect.py
+++ b/tools/encoder_detect.py
@@ -1,46 +1,69 @@
 #!/usr/bin/env python3
-import subprocess, re, sys, shlex
+import subprocess, re, sys, shlex, argparse
 
-# Preference: Jetson V4L2 → NVENC → software x264
-CANDIDATES = [
+# Preference order
+BASE_CANDIDATES = [
     ("h264_v4l2m2m", "-c:v h264_v4l2m2m"),
     ("h264_nvenc",   "-c:v h264_nvenc"),
     ("libx264",      "-c:v libx264"),
 ]
 
-
 def has_encoder(name: str) -> bool:
     try:
-        out = subprocess.check_output(["ffmpeg","-hide_banner","-encoders"], text=True, stderr=subprocess.STDOUT)
+        out = subprocess.check_output(
+            ["ffmpeg", "-hide_banner", "-encoders"],
+            text=True, stderr=subprocess.STDOUT
+        )
         return re.search(rf"\b{name}\b", out) is not None
     except Exception:
         return False
 
-
-def sanity_probe(flag: str) -> bool:
-    # 1-sec null encode to verify the encoder really opens
+def sanity_probe(flag: str, silent: bool) -> bool:
+    # 1s null encode to verify the encoder opens.
     cmd = f"ffmpeg -hide_banner -loglevel error -f lavfi -i testsrc2=size=1280x720:rate=30 -t 1 {flag} -f null -"
     try:
-        subprocess.check_call(shlex.split(cmd))
+        # Capture ALL output so failures don't print to console
+        subprocess.run(shlex.split(cmd), check=True, capture_output=silent, text=True)
         return True
-    except Exception:
+    except subprocess.CalledProcessError:
         return False
 
+def pick(preferred_csv: str|None, skip_hw: bool, silent: bool) -> str:
+    candidates = BASE_CANDIDATES[:]
+    if skip_hw:
+        # Drop hardware encoders
+        candidates = [c for c in candidates if c[0] not in ("h264_v4l2m2m", "h264_nvenc")]
 
-def pick(preferred_csv: str|None=None) -> str:
-    order = CANDIDATES[:]
     if preferred_csv:
         want = [x.strip() for x in preferred_csv.split(",") if x.strip()]
-        order = [x for x in CANDIDATES if x[0] in want] + [x for x in CANDIDATES if x[0] not in want]
-    for name, flag in order:
-        if has_encoder(name) and sanity_probe(flag):
-            return flag
-    if sanity_probe("-c:v libx264"):
-        return "-c:v libx264"
-    raise SystemExit("No working H.264 encoder found (tried h264_v4l2m2m, h264_nvenc, libx264).")
+        # Reorder by user preference while keeping only available base candidates
+        order = []
+        base = dict(candidates)
+        for n in want:
+            if n in base:
+                order.append((n, base[n]))
+        for n, f in candidates:
+            if n not in [x[0] for x in order]:
+                order.append((n, f))
+        candidates = order
 
+    for name, flag in candidates:
+        if has_encoder(name) and sanity_probe(flag, silent=silent):
+            return flag
+
+    # Last-ditch: try software x264 even if not listed
+    if sanity_probe("-c:v libx264", silent=silent):
+        return "-c:v libx264"
+
+    raise SystemExit("No working H.264 encoder found.")
+
+def main():
+    ap = argparse.ArgumentParser(description="Pick a working H.264 encoder.")
+    ap.add_argument("--preferred", help="Comma-separated encoders by preference", default=None)
+    ap.add_argument("--skip-hw", action="store_true", help="Skip hardware encoders")
+    ap.add_argument("--silent", action="store_true", help="Silence probe errors")
+    args = ap.parse_args()
+    print(pick(args.preferred, args.skip_hw, args.silent))
 
 if __name__ == "__main__":
-    pref = sys.argv[1] if len(sys.argv) > 1 else None
-    print(pick(pref))
-
+    main()


### PR DESCRIPTION
## Summary
- make encoder detection quiet, allow skipping hardware encoders
- call detector in silent mode and respect SKIP_HW_ENC in gameday

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*
- `./gameday --check-env`
- `tools/encoder_detect.py --silent --skip-hw` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'ffmpeg')*


------
https://chatgpt.com/codex/tasks/task_e_68a0f7255228832db32a9ec02d5ca2ae