### PR TITLE
Add first-pass telestration auto draw for review clips

### DIFF
--- a/analysis/review_draw.py
+++ b/analysis/review_draw.py
@@ -1,0 +1,46 @@
+import cv2, json, subprocess
+from pathlib import Path
+from typing import Dict, Any, List
+
+
+def _read_topk(out: Path, k: int) -> List[Dict[str, Any]]:
+    rows = []
+    rp = out / "review" / "review_rankings.jsonl"
+    if not rp.exists():
+        return rows
+    for i, line in enumerate(rp.open()):
+        if i >= k:
+            break
+        rows.append(json.loads(line))
+    return rows
+
+
+def _annotate_clip(src: Path, dst: Path, label: str):
+    # quick ffmpeg drawtext overlay (fast path) to avoid re-encoding in Python loops
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        "ffmpeg",
+        "-y",
+        "-i",
+        str(src),
+        "-vf",
+        f"drawtext=text='{label}':x=20:y=40:fontsize=36:box=1:boxcolor=black@0.4:fontcolor=white",
+        "-c:a",
+        "copy",
+        str(dst),
+    ]
+    subprocess.run(cmd, check=True)
+
+
+def draw_topk(out_dir: str, pb, top_k: int = 10):
+    out = Path(out_dir)
+    top = _read_topk(out, top_k)
+    for row in top:
+        clip = out / row["clip"]
+        if not clip.exists():
+            print(f"[review_draw] missing clip {clip}")
+            continue
+        reasons = "; ".join(row.get("reasons", [])[:2]) or "Coach Review"
+        dst = out / "review" / "auto_annotated" / (Path(row["clip"]).stem + "_ann.mp4")
+        _annotate_clip(clip, dst, reasons)
+    print(f"[review_draw] wrote annotated clips to {out/'review'/'auto_annotated'}")

--- a/tools/review_batch.py
+++ b/tools/review_batch.py
@@ -1,0 +1,21 @@
+import argparse, json
+from pathlib import Path
+from analysis.playbook_loader import load_playbook
+from analysis.review_draw import draw_topk
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--in", dest="out_dir", required=True)
+    ap.add_argument("--playbook", required=True)
+    ap.add_argument("--top-k", type=int, default=10)
+    ap.add_argument("--auto-draw", action="store_true")
+    args = ap.parse_args()
+    pb = load_playbook(args.playbook)
+    if args.auto_draw:
+        draw_topk(args.out_dir, pb, top_k=args.top_k)
+    print("[review_batch] done")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add review_draw utility to overlay top-ranked clips with textual cues
- Provide review_batch tool to load playbook and optionally auto-annotate clips

## Testing
- `PYTHONDONTWRITEBYTECODE=1 pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ffe0f450832daaae626f31fd7432