### PR TITLE
Make env loading in gameday tolerant of invalid lines

### DIFF
--- a/gameday
+++ b/gameday
@@ -1,9 +1,24 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# --- load .env if present ---
+# --- load .env if present (ignore malformed lines) ---
+load_env_file() {
+  local file="$1"
+  local line key value
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    # skip blanks and comments
+    [[ -z "$line" || "${line:0:1}" == "#" ]] && continue
+    if [[ "$line" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; then
+      key="${line%%=*}"
+      value="${line#*=}"
+      export "$key=$value"
+    else
+      echo "Ignoring malformed env line in $file: $line" >&2
+    fi
+  done < "$file"
+}
 for f in ".env" ".env.local" ".env.production"; do
-  [[ -f "$f" ]] && { set -a; source "$f"; set +a; }
+  [[ -f "$f" ]] && load_env_file "$f"
 done
 
 mask(){ local s="${1:-}"; [[ -n "$s" ]] && echo "${s:0:8}****" || echo ""; }


### PR DESCRIPTION
## Summary
- avoid crashing when `.env` contains stray text such as `your-camera`

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a212a10d34832db9beeac6fa690e87