### PR TITLE
Add review ranking and auto-draw hooks in pipeline

### DIFF
--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -1028,6 +1028,21 @@ def main(argv: List[str] | None = None) -> None:
         grade=args.grade,
       )
 
+    if args.review_rank or args.review_topk or args.auto_draw:
+        from analysis.playbook_loader import load_playbook
+        pb = load_playbook(args.playbook)
+        print(f"[pipeline] Playbook loaded: {args.playbook}")
+    if args.review_rank:
+        from analysis.review_ranker import rank_all
+        rank_all(args.out, pb)
+        print("[pipeline] Review rankings complete. Next:")
+        print(f"  python3 tools/review_batch.py --in \"{args.out}\" --playbook {args.playbook} --top-k 10 --auto-draw")
+    if args.review_topk and args.auto_draw:
+        from analysis.review_draw import draw_topk
+        draw_topk(args.out, pb, top_k=args.review_topk)
+        print("[pipeline] Auto-draw complete. Next:")
+        print(f"  python3 tools/review_record.py --in \"{args.out}/review/auto_annotated\"")
+
     # ---- Strict checks & overlays & summary ----
     game_dir = _game_dir(str(out_dir), run_cfg.video)
     plays_fp = game_dir / "plays.jsonl"

--- a/analysis/playbook_loader.py
+++ b/analysis/playbook_loader.py
@@ -1,0 +1,4 @@
+from analysis.playbook.loader import load_playbook
+
+__all__ = ["load_playbook"]
+


### PR DESCRIPTION
## Summary
- wire up review ranking and auto-drawing options in analysis pipeline
- expose `load_playbook` via new `analysis.playbook_loader` helper

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68a2153c0f10832db926a201b4ef68f6