### PR TITLE
fix: ensure default compressor threshold

### DIFF
--- a/gameday
+++ b/gameday
@@ -83,7 +83,7 @@ fi
 : "${DYN_PERCENTILE:=0.95}"         # 0.0..1.0; higher = protect peaks
 
 # compressor fallback tuning
-: "${COMP_THRESHOLD_DB:--22}"       # start compressing around -22 dBFS
+: "${COMP_THRESHOLD_DB:=-22}"       # start compressing around -22 dBFS
 : "${COMP_RATIO:=3.5}"              # 3.5:1 ratio
 : "${COMP_ATTACK_MS:=12}"
 : "${COMP_RELEASE_MS:=250}"


### PR DESCRIPTION
## Summary
- prevent unbound COMP_THRESHOLD_DB by assigning default -22 dB

## Testing
- `pytest` *(fails: NameError: name 'Sequence' is not defined)*
- `STREAM_URL=fake ./gameday --print-audio-chain`


------
https://chatgpt.com/codex/tasks/task_e_68a24f2046b0832db0e6b330e3e90574