### PR TITLE
Harden playbook loader and pipeline logging

### DIFF
--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -51,7 +51,8 @@ except Exception:  # pragma: no cover
 from .segmentation import segment_video
 from . import detect_track, features, orientation, zoom
 from formation_detector import detect_formation
-from .playbook.loader import load_playbook
+from analysis.playbook_loader import load_playbook
+from .playbook.schema import validate_playbook
 from .match.play_matcher import match_play
 
 
@@ -148,16 +149,26 @@ def _run_pipeline(args: argparse.Namespace) -> None:
     (run_dir / "metadata.json").write_text(json.dumps(meta, indent=2))
 
     # load playbook for playcall matching if available
-    try:
-        pb = load_playbook(args.playbook) if getattr(args, "playbook", None) else None
-    except Exception:
-        pb = None
-    if pb:
-        print(f"[pipeline] playbook loaded with {len(pb.plays)} plays")
+    raw_pb: Dict[str, Any]
+    plays: List[Dict[str, Any]]
+    raw_pb, plays = (load_playbook(args.playbook) if getattr(args, "playbook", None) else ({}, []))
+    pb = None
+    if plays:
+        try:
+            canonical_pb = {"plays": plays, "formations": raw_pb.get("formations", [])}
+            pb = validate_playbook(canonical_pb)
+        except Exception:
+            pb = None
+    print(f"[pipeline] playbook loaded with {len(plays)} plays")
+    if len(plays) == 0:
+        print("[pipeline] NOTE: classifier will degrade with 0 plays; continuing with formation-only heuristics.")
 
     # 1) segmentation
     segs = segment_video(args.video, min_play_gap=args.min_play_gap, min_play_length=args.min_play_length)
     print(f"[pipeline] segments detected: {len(segs)}")
+    skip_play_match = len(plays) == 0
+    if skip_play_match:
+        print("[pipeline] INFO: skipping play matching (no plays in playbook). Formation-only pass will run.")
 
     features_rows: List[Dict[str, Any]] = []
     prediction_rows: List[Dict[str, Any]] = []
@@ -229,7 +240,7 @@ def _run_pipeline(args: argparse.Namespace) -> None:
         play_name: Optional[str] = None
         play_conf = 0.0
         play_family = ""
-        if pb and formation_name != "Unknown":
+        if not skip_play_match and pb and formation_name != "Unknown":
             try:
                 play_candidates = match_play(pb, formation_name, {})
             except Exception:
@@ -244,7 +255,10 @@ def _run_pipeline(args: argparse.Namespace) -> None:
             "confidence": float(play_conf),
             "candidates": [{"name": n, "score": s} for n, s in play_candidates],
         }
-        print(f"[play_classifier] {seg_id}: {play_name} conf={play_conf:.2f}")
+        if not play_name:
+            print(f"[play_classifier] {seg_id}: Unknown conf={play_conf:.2f}")
+        else:
+            print(f"[play_classifier] {seg_id}: {play_name} conf={play_conf:.2f}")
 
         formation_dict = {
             "name": formation_name if formation_name != "Unknown" else None,

--- a/analysis/play_classifier.py
+++ b/analysis/play_classifier.py
@@ -1,0 +1,40 @@
+"""Minimal play classifier helper.
+
+This module provides a thin wrapper around an internal ``_infer`` function,
+ensuring that callers always receive a deterministic `(name, confidence)` tuple
+and never ``None``.  The actual inference logic is intentionally minimal here as
+it is primarily used for tests and lightweight heuristics.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Tuple
+
+
+def _infer(segment: Any, model: Any, plays_index: Any) -> Tuple[Any, float]:
+    """Placeholder inference function.
+
+    Real implementations should replace this with logic that uses ``model`` and
+    ``plays_index``.  For now we simply return ``(None, 0.0)`` so the classifier
+    falls back to ``"Unknown"``.
+    """
+
+    return None, 0.0
+
+
+def classify_play(segment: Any, model: Any, plays_index: Any) -> Tuple[str, float]:
+    pred, conf = _infer(segment, model, plays_index)
+    # Harden output: never return None
+    if pred is None:
+        return "Unknown", 0.0
+    # also coerce unexpected types
+    if isinstance(pred, dict):
+        name = pred.get("name") or pred.get("id") or "Unknown"
+        return name, float(conf or 0.0)
+    if not isinstance(pred, str):
+        return "Unknown", float(conf or 0.0)
+    return pred, float(conf or 0.0)
+
+
+__all__ = ["classify_play"]
+

--- a/analysis/playbook_loader.py
+++ b/analysis/playbook_loader.py
@@ -1,36 +1,65 @@
-import json
+"""Robust playbook loader accepting multiple schemas and paths."""
+
+from __future__ import annotations
+
 from pathlib import Path
-from typing import Any, Dict, Optional
+import json
+from typing import Dict, Any, List, Tuple
 
 
-class Playbook:
-    """Lightweight playbook wrapper with convenience lookups."""
-
-    def __init__(self, data: Dict[str, Any]):
-        self.data = data
-        self.offense = data.get("offense", {})
-        self.defense = data.get("defense", {})
-        self.off_plays = {p["id"]: p for p in self.offense.get("plays", []) if "id" in p}
-        self.off_plays_by_name = {
-            p.get("name", "").lower(): p
-            for p in self.offense.get("plays", [])
-            if p.get("name")
-        }
-
-    def get_offense_play_by_id(self, pid: str) -> Optional[Dict[str, Any]]:
-        return self.off_plays.get(pid)
-
-    def get_offense_play_by_name(self, name: str) -> Optional[Dict[str, Any]]:
-        return self.off_plays_by_name.get((name or "").lower())
+def _try_paths(p: str) -> List[Path]:
+    cand = [Path(p)]
+    # common fallbacks
+    cand.append(Path("playbooks") / p)
+    cand.append(Path("playbooks") / Path(p).name)
+    return [c for c in cand if c.exists()]
 
 
-def load_playbook(path: str) -> Playbook:
-    """Load a playbook JSON file into a Playbook wrapper."""
+def load_playbook(playbook_path: str) -> Tuple[Dict[str, Any], List[Dict[str, Any]]]:
+    """Load a playbook from disk.
 
-    p = Path(path)
-    data = json.loads(p.read_text())
-    return Playbook(data)
+    Returns a tuple of ``(raw_playbook, plays_list)`` and prints a helpful log
+    message describing what was loaded.  Supports a few common JSON schemas:
+
+    ``{"plays": [...]}``
+        Flat list at top-level.
+    ``{"offense": {"plays": [...]}, "defense": {...}}``
+        Split offense/defense sections.
+    ``{"sections": {"offense": {"plays": [...]}}}``
+        Nested sections variant.
+    """
+
+    candidates = _try_paths(playbook_path)
+    if not candidates:
+        print(f"[playbook] ERROR: not found: {playbook_path} (also tried playbooks/ variants)")
+        return {}, []
+    pb_path = candidates[0]
+    try:
+        raw = json.loads(pb_path.read_text())
+    except Exception as e:  # pragma: no cover - defensive
+        print(f"[playbook] ERROR: failed to parse JSON at {pb_path}: {e}")
+        return {}, []
+
+    plays: List[Dict[str, Any]] = []
+    if isinstance(raw, dict) and isinstance(raw.get("plays"), list):
+        # schema 1
+        plays = raw["plays"]
+    elif isinstance(raw.get("offense"), dict) and isinstance(raw["offense"].get("plays"), list):
+        # schema 2
+        plays = raw["offense"]["plays"]
+    elif isinstance(raw.get("sections"), dict):
+        # schema 3 (split sections)
+        off = raw["sections"].get("offense") or raw["sections"].get("Offense")
+        if isinstance(off, dict) and isinstance(off.get("plays"), list):
+            plays = off["plays"]
+
+    if not plays:
+        keys = list(raw.keys()) if isinstance(raw, dict) else type(raw)
+        print(f"[playbook] WARNING: 0 plays parsed from {pb_path}. Top-level keys: {keys}")
+    else:
+        print(f"[playbook] OK: loaded {len(plays)} plays from {pb_path.name}")
+    return raw, plays
 
 
-__all__ = ["Playbook", "load_playbook"]
+__all__ = ["load_playbook"]
 

--- a/tools/backfill_from_clips.py
+++ b/tools/backfill_from_clips.py
@@ -3,6 +3,14 @@ from __future__ import annotations
 import csv, json, subprocess, sys
 from pathlib import Path
 
+def as_str(x, key: str = "name") -> str:
+    if isinstance(x, str):
+        return x
+    if isinstance(x, dict):
+        return x.get(key) or x.get("id") or ""
+    return ""
+
+
 def ffprobe_duration(mp4: Path) -> float | None:
     try:
         out = subprocess.check_output(
@@ -120,6 +128,18 @@ def backfill(run_dir: Path) -> int:
             }
             jf.write(json.dumps(row_json) + "\n")
 
+            def _formation_name(f):
+                if isinstance(f, dict):
+                    return f.get("name") or f.get("id") or ""
+                if isinstance(f, str):
+                    return f
+                return ""
+
+            f_name = _formation_name(formation)
+            p_name = as_str(playcall)
+            f_conf = float(formation.get("confidence", 0.0)) if isinstance(formation, dict) else 0.0
+            p_conf = float(playcall.get("confidence", 0.0)) if isinstance(playcall, dict) else 0.0
+
             w.writerow(
                 {
                     "play_id": pid,
@@ -128,15 +148,15 @@ def backfill(run_dir: Path) -> int:
                     "snap": existing.get("snap", ""),
                     "whistle": existing.get("whistle", ""),
                     "clip_path": str(mp4),
-                    "formation": formation.get("name") or "",
+                    "formation": f_name,
                     "play_family": play_family or "",
                     "outcome": existing.get("outcome", ""),
                     "clip_duration": row_json["clip_duration"],
                 }
             )
             print(
-                f"[backfill] play {pid}: formation={formation.get('name')} conf={formation.get('confidence')} "
-                f"playcall={playcall.get('name')} conf={playcall.get('confidence')}"
+                f"[backfill] play {pid}: formation={f_name} conf={f_conf} "
+                f"playcall={p_name} conf={p_conf}"
             )
             total += 1
 

--- a/tools/review_batch.py
+++ b/tools/review_batch.py
@@ -12,9 +12,9 @@ def main() -> None:
     ap.add_argument("--auto-draw", action="store_true")
     args = ap.parse_args()
 
-    pb = load_playbook(args.playbook)
+    raw_pb, _ = load_playbook(args.playbook)
     if args.auto_draw:
-        draw_topk(args.out_dir, pb, top_k=args.top_k)
+        draw_topk(args.out_dir, raw_pb, top_k=args.top_k)
     print("[review_batch] done")
 
 


### PR DESCRIPTION
## Summary
- add robust playbook loader that searches common paths and supports several schemas, logging when no plays are found
- integrate new loader into analysis pipeline with clearer logs and ability to skip play matching when playbook is empty
- ensure classifier wrapper always returns a name ("Unknown") and confidence
- allow backfill_from_clips to handle formation metadata stored as string or dict

## Testing
- `pytest -q`
- `python -m analysis.pipeline --video dummy.mp4 --team WHITE --playbook mca_full_playbook_final.json --out /tmp/out_pipeline`
- `python tools/backfill_from_clips.py /tmp/run`


------
https://chatgpt.com/codex/tasks/task_e_68a48e52960c832dbce11e5dd7b1d797