### PR TITLE
feat: robust playbook loading

### DIFF
--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -150,7 +150,17 @@ def _run_pipeline(args: argparse.Namespace) -> None:
 
     # load playbook for playcall matching if available
     raw_pb: Dict[str, Any] = load_offense_playbook(getattr(args, "playbook", None))
-    plays: List[Dict[str, Any]] = raw_pb.get("plays", [])
+    plays = []
+    # Extract plays from multiple known schemas
+    if isinstance(raw_pb, dict):
+        if isinstance(raw_pb.get("plays"), list):
+            plays = raw_pb["plays"]
+        elif isinstance(raw_pb.get("offense"), dict) and isinstance(raw_pb["offense"].get("plays"), list):
+            plays = raw_pb["offense"]["plays"]
+        elif isinstance(raw_pb.get("sections"), dict):
+            off = raw_pb["sections"].get("offense") or raw_pb["sections"].get("Offense")
+            if isinstance(off, dict) and isinstance(off.get("plays"), list):
+                plays = off["plays"]
     pb = None
     if plays:
         try:
@@ -158,9 +168,13 @@ def _run_pipeline(args: argparse.Namespace) -> None:
             pb = validate_playbook(canonical_pb)
         except Exception:
             pb = None
+    print(
+        f"[config] min_play_length={args.min_play_length} min_play_gap={args.min_play_gap} "
+        f"report={args.generate_report} clips={args.generate_clips} highlights={args.generate_highlights} overlay={getattr(args, 'make_overlay', getattr(args, 'overlay', False))}"
+    )
     print(f"[pipeline] playbook loaded with {len(plays)} plays")
     if len(plays) == 0:
-        print("[pipeline] NOTE: classifier will degrade with 0 plays; continuing with formation-only heuristics.")
+        print("[pipeline] NOTE: proceeding without play names (formation-only classification).")
 
     # 1) segmentation
     segs = segment_video(args.video, min_play_gap=args.min_play_gap, min_play_length=args.min_play_length)
@@ -352,6 +366,7 @@ def run_pipeline(*, args: argparse.Namespace | None = None, **kwargs) -> None:
             "generate_report": False,
             "generate_clips": False,
             "generate_highlights": False,
+            "make_overlay": False,
             "clip_pre": 1.0,
             "clip_post": 1.0,
             "orientation_auto": False,

--- a/playbooks/__init__.py
+++ b/playbooks/__init__.py
@@ -1,7 +1,64 @@
+import json
 from pathlib import Path
-import json, functools
-@functools.lru_cache(maxsize=1)
-def load_offense_playbook(path: str|None=None):
-    p = Path(path or "playbooks/mca_5th_playbook.json")
-    return json.loads(p.read_text())
+from typing import Optional, Tuple, Dict, Any, List
+
+
+DEFAULT_PLAYBOOK_CANDIDATES = [
+    "playbooks/mca_5th_v2.json",
+    "playbooks/mca_full_playbook_final.json",
+    "mca_5th_v2.json",
+    "mca_full_playbook_final.json",
+    "playbooks/mca_5th_playbook.json",
+    "mca_5th_playbook.json",
+]
+
+
+def _candidate_paths(p: Optional[str]) -> List[Path]:
+    cands: List[Path] = []
+    if p:
+        pp = Path(p)
+        # exact path if exists
+        cands.append(pp)
+        # try relative to ./playbooks
+        cands.append(Path("playbooks") / pp)
+        # try basename under playbooks
+        cands.append(Path("playbooks") / pp.name)
+    # defaults last (lowest priority)
+    cands.extend(Path(x) for x in DEFAULT_PLAYBOOK_CANDIDATES)
+    # de-dupe while preserving order
+    seen = set()
+    uniq = []
+    for c in cands:
+        if str(c) not in seen:
+            uniq.append(c)
+            seen.add(str(c))
+    return uniq
+
+
+def _first_existing(cands: List[Path]) -> Optional[Path]:
+    for c in cands:
+        if c.exists():
+            return c
+    return None
+
+
+def load_offense_playbook(playbook_arg: Optional[str] = None) -> Dict[str, Any]:
+    """
+    Loads offense playbook JSON from a robust set of candidate paths.
+    Returns {} if nothing is found (caller may still run formation-only).
+    """
+    cands = _candidate_paths(playbook_arg)
+    chosen = _first_existing(cands)
+    if not chosen:
+        print(f"[playbook] ERROR: could not find playbook. Tried:")
+        for c in cands:
+            print(f"  - {c}")
+        return {}
+    try:
+        data = json.loads(chosen.read_text())
+        print(f"[playbook] OK: loaded playbook from {chosen}")
+        return data
+    except Exception as e:
+        print(f"[playbook] ERROR: failed to parse JSON at {chosen}: {e}")
+        return {}
 

--- a/tools/run_and_backfill.sh
+++ b/tools/run_and_backfill.sh
@@ -2,6 +2,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# If user passes a bare filename that doesn't exist in CWD,
+# pipeline will still try playbooks/<name> and defaults.
+# Here we only forward what the user gave us.
 # Pass all args to the pipeline
 python3 -m analysis.pipeline "$@"
 


### PR DESCRIPTION
## Summary
- load offense playbooks from multiple candidate paths with fallback and logging
- handle diverse playbook JSON structures and report play count
- clarify run_and_backfill playbook comment

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log || tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68a4ecfaac0c832db0b7db435d07c5d4