### PR TITLE
Improve playbook discovery and backfill robustness

### DIFF
--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -149,7 +149,11 @@ def _run_pipeline(args: argparse.Namespace) -> None:
     (run_dir / "metadata.json").write_text(json.dumps(meta, indent=2))
 
     # load playbook for playcall matching if available
-    raw_pb: Dict[str, Any] = load_offense_playbook(getattr(args, "playbook", None))
+    try:
+        raw_pb: Dict[str, Any] = load_offense_playbook(getattr(args, "playbook", None))
+    except FileNotFoundError as e:
+        print(f"[playbook] {e}")
+        raw_pb = {}
     plays = []
     # Extract plays from multiple known schemas
     if isinstance(raw_pb, dict):
@@ -172,9 +176,10 @@ def _run_pipeline(args: argparse.Namespace) -> None:
         f"[config] min_play_length={args.min_play_length} min_play_gap={args.min_play_gap} "
         f"report={args.generate_report} clips={args.generate_clips} highlights={args.generate_highlights} overlay={getattr(args, 'make_overlay', getattr(args, 'overlay', False))}"
     )
+    print(f"[playbook] source={raw_pb.get('_source_path', '<none>')}")
     print(f"[pipeline] playbook loaded with {len(plays)} plays")
     if len(plays) == 0:
-        print("[pipeline] NOTE: proceeding without play names (formation-only classification).")
+        print("[pipeline] WARNING: proceeding without play names (formation-only classification).")
 
     # 1) segmentation
     segs = segment_video(args.video, min_play_gap=args.min_play_gap, min_play_length=args.min_play_length)
@@ -304,6 +309,7 @@ def _run_pipeline(args: argparse.Namespace) -> None:
         clip_out.parent.mkdir(parents=True, exist_ok=True)
         export_clip(args.video, clip_start, clip_end, clip_out, rotation)
 
+        clip_duration = float(t1 - t0)
         plays_index.append(
             {
                 "play_id": seg_id,
@@ -313,8 +319,11 @@ def _run_pipeline(args: argparse.Namespace) -> None:
                 "whistle": t1,
                 "clip_path": str(clip_out),
                 "formation": formation_name,
+                "formation_confidence": formation_conf,
                 "play_family": play_family,
+                "playcall_confidence": float(play_conf),
                 "outcome": "",
+                "clip_duration": clip_duration,
             }
         )
 
@@ -329,7 +338,20 @@ def _run_pipeline(args: argparse.Namespace) -> None:
     with (run_dir / "plays_index.csv").open("w", newline="", encoding="utf8") as f:
         writer = csv.DictWriter(
             f,
-            fieldnames=["play_id", "t0", "t1", "snap", "whistle", "clip_path", "formation", "play_family", "outcome"],
+            fieldnames=[
+                "play_id",
+                "t0",
+                "t1",
+                "snap",
+                "whistle",
+                "clip_path",
+                "formation",
+                "formation_confidence",
+                "play_family",
+                "playcall_confidence",
+                "outcome",
+                "clip_duration",
+            ],
         )
         writer.writeheader()
         writer.writerows(plays_index)

--- a/playbooks/__init__.py
+++ b/playbooks/__init__.py
@@ -1,64 +1,60 @@
-import json
 from pathlib import Path
-from typing import Optional, Tuple, Dict, Any, List
+import json
+from typing import Any, Dict, List
 
-
-DEFAULT_PLAYBOOK_CANDIDATES = [
+# Keep old names for backward compatibility, but prefer the current file first.
+DEFAULT_PLAYBOOK_CANDIDATES: List[str] = [
+    "playbooks/mca_5th_playbook.json",
+    "mca_5th_playbook.json",
     "playbooks/mca_5th_v2.json",
     "playbooks/mca_full_playbook_final.json",
     "mca_5th_v2.json",
     "mca_full_playbook_final.json",
-    "playbooks/mca_5th_playbook.json",
-    "mca_5th_playbook.json",
 ]
 
 
-def _candidate_paths(p: Optional[str]) -> List[Path]:
-    cands: List[Path] = []
-    if p:
-        pp = Path(p)
-        # exact path if exists
-        cands.append(pp)
-        # try relative to ./playbooks
-        cands.append(Path("playbooks") / pp)
-        # try basename under playbooks
-        cands.append(Path("playbooks") / pp.name)
-    # defaults last (lowest priority)
-    cands.extend(Path(x) for x in DEFAULT_PLAYBOOK_CANDIDATES)
-    # de-dupe while preserving order
-    seen = set()
-    uniq = []
-    for c in cands:
-        if str(c) not in seen:
-            uniq.append(c)
-            seen.add(str(c))
-    return uniq
-
-
-def _first_existing(cands: List[Path]) -> Optional[Path]:
-    for c in cands:
-        if c.exists():
-            return c
+def _try_paths(rel_or_base: str) -> Path | None:
+    """Resolve a file by trying as-is, repo-root joined, and playbooks/ joined (if arg is bare name)."""
+    p = Path(rel_or_base)
+    if p.exists():
+        return p
+    root = Path(__file__).resolve().parents[1]
+    p2 = root / rel_or_base
+    if p2.exists():
+        return p2
+    if "/" not in rel_or_base and "\\" not in rel_or_base:
+        p3 = root / "playbooks" / rel_or_base
+        if p3.exists():
+            return p3
     return None
 
 
-def load_offense_playbook(playbook_arg: Optional[str] = None) -> Dict[str, Any]:
-    """
-    Loads offense playbook JSON from a robust set of candidate paths.
-    Returns {} if nothing is found (caller may still run formation-only).
-    """
-    cands = _candidate_paths(playbook_arg)
-    chosen = _first_existing(cands)
-    if not chosen:
-        print(f"[playbook] ERROR: could not find playbook. Tried:")
-        for c in cands:
-            print(f"  - {c}")
-        return {}
+def _load_json(path: Path) -> Dict[str, Any]:
     try:
-        data = json.loads(chosen.read_text())
-        print(f"[playbook] OK: loaded playbook from {chosen}")
-        return data
-    except Exception as e:
-        print(f"[playbook] ERROR: failed to parse JSON at {chosen}: {e}")
-        return {}
+        return json.loads(path.read_text())
+    except Exception as e:  # pragma: no cover - diagnostics
+        raise RuntimeError(f"Failed to parse playbook at {path}: {e}") from e
 
+
+def load_offense_playbook(arg: str | None = None) -> Dict[str, Any]:
+    """Load an offense playbook from an explicit path or fallback candidates."""
+    if arg:
+        r = _try_paths(arg)
+        if r:
+            pb = _load_json(r)
+            pb["_source_path"] = str(r)
+            return pb
+        raise FileNotFoundError(
+            f"Playbook not found for arg='{arg}'. Tried as-is, repo-relative, and playbooks/. "
+            f"Known defaults: {', '.join(DEFAULT_PLAYBOOK_CANDIDATES)}"
+        )
+    for cand in DEFAULT_PLAYBOOK_CANDIDATES:
+        r = _try_paths(cand)
+        if r:
+            pb = _load_json(r)
+            pb["_source_path"] = str(r)
+            return pb
+    raise FileNotFoundError(
+        "No offense playbook found. Pass --playbook or create one of: "
+        + ", ".join(DEFAULT_PLAYBOOK_CANDIDATES)
+    )

--- a/tools/backfill_from_clips.py
+++ b/tools/backfill_from_clips.py
@@ -2,13 +2,22 @@
 from __future__ import annotations
 import csv, json, subprocess, sys
 from pathlib import Path
+from typing import Any, Dict
 
-def as_str(x, key: str = "name") -> str:
+
+def _as_name(x: Any) -> str:
     if isinstance(x, str):
         return x
     if isinstance(x, dict):
-        return x.get(key) or x.get("id") or ""
+        return (x.get("name") or x.get("id") or "").strip()
     return ""
+
+
+def _as_float(x: Any, default: float = 0.0) -> float:
+    try:
+        return float(x)
+    except Exception:
+        return default
 
 
 def ffprobe_duration(mp4: Path) -> float | None:
@@ -91,7 +100,9 @@ def backfill(run_dir: Path) -> int:
             "whistle",
             "clip_path",
             "formation",
+            "formation_confidence",
             "play_family",
+            "playcall_confidence",
             "outcome",
             "clip_duration",
         ]
@@ -128,17 +139,10 @@ def backfill(run_dir: Path) -> int:
             }
             jf.write(json.dumps(row_json) + "\n")
 
-            def _formation_name(f):
-                if isinstance(f, dict):
-                    return f.get("name") or f.get("id") or ""
-                if isinstance(f, str):
-                    return f
-                return ""
-
-            f_name = _formation_name(formation)
-            p_name = as_str(playcall)
-            f_conf = float(formation.get("confidence", 0.0)) if isinstance(formation, dict) else 0.0
-            p_conf = float(playcall.get("confidence", 0.0)) if isinstance(playcall, dict) else 0.0
+            formation_name = _as_name(formation)
+            playcall_name = _as_name(playcall)
+            formation_conf = _as_float(formation.get("confidence") if isinstance(formation, dict) else 0.0)
+            playcall_conf = _as_float(playcall.get("confidence") if isinstance(playcall, dict) else 0.0)
 
             w.writerow(
                 {
@@ -148,15 +152,17 @@ def backfill(run_dir: Path) -> int:
                     "snap": existing.get("snap", ""),
                     "whistle": existing.get("whistle", ""),
                     "clip_path": str(mp4),
-                    "formation": f_name,
-                    "play_family": play_family or "",
+                    "formation": formation_name,
+                    "formation_confidence": formation_conf,
+                    "play_family": playcall_name or "",
+                    "playcall_confidence": playcall_conf,
                     "outcome": existing.get("outcome", ""),
                     "clip_duration": row_json["clip_duration"],
                 }
             )
             print(
-                f"[backfill] play {pid}: formation={f_name} conf={f_conf} "
-                f"playcall={p_name} conf={p_conf}"
+                f"[backfill] play {pid}: formation={formation_name} conf={formation_conf} "
+                f"playcall={playcall_name} conf={playcall_conf}"
             )
             total += 1
 

--- a/tools/run_and_backfill.sh
+++ b/tools/run_and_backfill.sh
@@ -8,6 +8,23 @@ set -euo pipefail
 # Pass all args to the pipeline
 python3 -m analysis.pipeline "$@"
 
+# Determine playbook argument for messaging
+PLAYBOOK=""
+prev=""
+for arg in "$@"; do
+  if [[ "$prev" == "--playbook" ]]; then
+    PLAYBOOK="$arg"
+    break
+  fi
+  prev="$arg"
+done
+
+if [[ -n "$PLAYBOOK" ]]; then
+  echo "[playbook] OK: requested playbook: $PLAYBOOK"
+else
+  echo "[playbook] using default candidate resolution (see playbooks/__init__.py)"
+fi
+
 OUT_DIR="output"
 RUN_DIR="$(ls -td "${OUT_DIR}/games/"* | head -n1 || true)"
 if [[ -z "${RUN_DIR}" || ! -d "${RUN_DIR}" ]]; then


### PR DESCRIPTION
## Summary
- Allow playbook loader to resolve basenames or repo-relative paths and report source
- Carry formation name and confidences through pipeline and plays_index
- Harden backfill_from_clips for dict/string inputs and emit confidence columns
- Echo playbook resolution in run_and_backfill.sh

## Testing
- `pytest`
- `python tools/backfill_from_clips.py nonexistent_dir`

------
https://chatgpt.com/codex/tasks/task_e_68a4f58eb0dc832daf7dd645f2b332ac