### PR TITLE
Improve playbook resolution and backfill logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,3 +441,11 @@ Tune at runtime:
 MCA_DET_CONF=0.20 MCA_DET_NMS=0.55 MCA_DET_WEIGHTS=models/player_detector/best.onnx make run-pipeline
 ```
 Use `--force-cpu` if GPU runtime is misconfigured.
+
+## Development
+
+For quick lint checks, install Pyflakes:
+
+```
+pip install pyflakes
+```

--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -51,7 +51,7 @@ except Exception:  # pragma: no cover
 from .segmentation import segment_video
 from . import detect_track, features, orientation, zoom
 from formation_detector import detect_formation
-from playbooks import load_offense_playbook
+from playbooks import DEFAULT_PLAYBOOK_CANDIDATES, load_offense_playbook
 from .playbook.schema import validate_playbook
 from .match.play_matcher import match_play
 
@@ -149,11 +149,10 @@ def _run_pipeline(args: argparse.Namespace) -> None:
     (run_dir / "metadata.json").write_text(json.dumps(meta, indent=2))
 
     # load playbook for playcall matching if available
-    try:
-        raw_pb: Dict[str, Any] = load_offense_playbook(getattr(args, "playbook", None))
-    except FileNotFoundError as e:
-        print(f"[playbook] {e}")
-        raw_pb = {}
+    raw_pb: Dict[str, Any] = load_offense_playbook(getattr(args, "playbook", None))
+    print(
+        f"[playbook] OK: requested playbook: {getattr(args, 'playbook', None) if getattr(args, 'playbook', None) else '<auto>'}"
+    )
     plays = []
     # Extract plays from multiple known schemas
     if isinstance(raw_pb, dict):
@@ -176,7 +175,6 @@ def _run_pipeline(args: argparse.Namespace) -> None:
         f"[config] min_play_length={args.min_play_length} min_play_gap={args.min_play_gap} "
         f"report={args.generate_report} clips={args.generate_clips} highlights={args.generate_highlights} overlay={getattr(args, 'make_overlay', getattr(args, 'overlay', False))}"
     )
-    print(f"[playbook] source={raw_pb.get('_source_path', '<none>')}")
     print(f"[pipeline] playbook loaded with {len(plays)} plays")
     if len(plays) == 0:
         print("[pipeline] WARNING: proceeding without play names (formation-only classification).")
@@ -511,7 +509,12 @@ def main(argv: Sequence[str] | None = None) -> None:
         f"report={generate_report} clips={generate_clips} highlights={generate_highlights} overlay={make_overlay}"
     )
 
-    run_pipeline(args=args)
+    try:
+        run_pipeline(args=args)
+    except FileNotFoundError:
+        tried = ", ".join(DEFAULT_PLAYBOOK_CANDIDATES)
+        print(f"[playbook] ERROR: could not locate a playbook. Tried: {tried}")
+        raise
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/playbooks/__init__.py
+++ b/playbooks/__init__.py
@@ -36,25 +36,22 @@ def _load_json(path: Path) -> Dict[str, Any]:
         raise RuntimeError(f"Failed to parse playbook at {path}: {e}") from e
 
 
-def load_offense_playbook(arg: str | None = None) -> Dict[str, Any]:
+def load_offense_playbook(playbook_path: str | None = None) -> Dict[str, Any]:
     """Load an offense playbook from an explicit path or fallback candidates."""
-    if arg:
-        r = _try_paths(arg)
-        if r:
-            pb = _load_json(r)
-            pb["_source_path"] = str(r)
+    if playbook_path:
+        resolved = _try_paths(playbook_path)
+        if resolved:
+            print(f"[playbook] source={resolved}")
+            pb = _load_json(resolved)
+            pb["_source_path"] = str(resolved)
+            print(f"[playbook] OK: loaded playbook from {resolved}")
             return pb
-        raise FileNotFoundError(
-            f"Playbook not found for arg='{arg}'. Tried as-is, repo-relative, and playbooks/. "
-            f"Known defaults: {', '.join(DEFAULT_PLAYBOOK_CANDIDATES)}"
-        )
     for cand in DEFAULT_PLAYBOOK_CANDIDATES:
-        r = _try_paths(cand)
-        if r:
-            pb = _load_json(r)
-            pb["_source_path"] = str(r)
+        resolved = _try_paths(cand)
+        if resolved:
+            pb = _load_json(resolved)
+            pb["_source_path"] = str(resolved)
+            print(f"[playbook] OK: loaded playbook from {resolved}")
             return pb
-    raise FileNotFoundError(
-        "No offense playbook found. Pass --playbook or create one of: "
-        + ", ".join(DEFAULT_PLAYBOOK_CANDIDATES)
-    )
+    tried = ", ".join(DEFAULT_PLAYBOOK_CANDIDATES)
+    raise FileNotFoundError(f"could not locate a playbook. Tried: {tried}")

--- a/tools/backfill_from_clips.py
+++ b/tools/backfill_from_clips.py
@@ -2,22 +2,25 @@
 from __future__ import annotations
 import csv, json, subprocess, sys
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 
 
 def _as_name(x: Any) -> str:
     if isinstance(x, str):
         return x
     if isinstance(x, dict):
-        return (x.get("name") or x.get("id") or "").strip()
+        return x.get("name") or x.get("id") or ""
     return ""
 
 
-def _as_float(x: Any, default: float = 0.0) -> float:
-    try:
-        return float(x)
-    except Exception:
-        return default
+def _as_conf(x: Any) -> float:
+    if isinstance(x, dict):
+        c = x.get("confidence")
+        try:
+            return float(c) if c is not None else 0.0
+        except Exception:
+            return 0.0
+    return 0.0
 
 
 def ffprobe_duration(mp4: Path) -> float | None:
@@ -112,21 +115,29 @@ def backfill(run_dir: Path) -> int:
             dur = ffprobe_duration(mp4)
             pred = pred_map.get(pid, {})
             existing = existing_index.get(pid, {})
-            formation = pred.get(
-                "formation", {"name": None, "confidence": 0.0, "candidates": []}
-            )
-            playcall = pred.get(
-                "playcall", {"name": None, "confidence": 0.0, "candidates": []}
-            )
+            formation = pred.get("formation", "")
+            playcall = pred.get("playcall", {})
             play_family = pred.get("play_family", "")
+
+            formation_name = _as_name(formation)
+            formation_conf = _as_conf(formation)
+            playcall_name = _as_name(playcall)
+            playcall_conf = _as_conf(playcall)
+
+            t0 = existing.get("t0")
+            t1 = existing.get("t1")
 
             row_json = {
                 "play_id": pid,
                 "clip_path": str(mp4),
-                "t0": existing.get("t0"),
-                "t1": existing.get("t1"),
-                "formation": formation,
-                "playcall": playcall,
+                "t0": t0 if t0 is not None else "",
+                "t1": t1 if t1 is not None else "",
+                "formation": formation_name,
+                "playcall": {
+                    "name": playcall_name if playcall_name else None,
+                    "confidence": playcall_conf,
+                    "candidates": (playcall.get("candidates") if isinstance(playcall, dict) else []) or [],
+                },
                 "outcome": {
                     "yards": 0,
                     "success": False,
@@ -139,22 +150,17 @@ def backfill(run_dir: Path) -> int:
             }
             jf.write(json.dumps(row_json) + "\n")
 
-            formation_name = _as_name(formation)
-            playcall_name = _as_name(playcall)
-            formation_conf = _as_float(formation.get("confidence") if isinstance(formation, dict) else 0.0)
-            playcall_conf = _as_float(playcall.get("confidence") if isinstance(playcall, dict) else 0.0)
-
             w.writerow(
                 {
                     "play_id": pid,
-                    "t0": existing.get("t0", ""),
-                    "t1": existing.get("t1", ""),
+                    "t0": t0 if t0 is not None else "",
+                    "t1": t1 if t1 is not None else "",
                     "snap": existing.get("snap", ""),
                     "whistle": existing.get("whistle", ""),
                     "clip_path": str(mp4),
                     "formation": formation_name,
                     "formation_confidence": formation_conf,
-                    "play_family": playcall_name or "",
+                    "play_family": play_family or "",
                     "playcall_confidence": playcall_conf,
                     "outcome": existing.get("outcome", ""),
                     "clip_duration": row_json["clip_duration"],
@@ -162,7 +168,7 @@ def backfill(run_dir: Path) -> int:
             )
             print(
                 f"[backfill] play {pid}: formation={formation_name} conf={formation_conf} "
-                f"playcall={playcall_name} conf={playcall_conf}"
+                f"playcall={playcall_name or ''} conf={playcall_conf}"
             )
             total += 1
 

--- a/tools/run_and_backfill.sh
+++ b/tools/run_and_backfill.sh
@@ -2,12 +2,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# If user passes a bare filename that doesn't exist in CWD,
-# pipeline will still try playbooks/<name> and defaults.
-# Here we only forward what the user gave us.
-# Pass all args to the pipeline
-python3 -m analysis.pipeline "$@"
-
 # Determine playbook argument for messaging
 PLAYBOOK=""
 prev=""
@@ -20,10 +14,14 @@ for arg in "$@"; do
 done
 
 if [[ -n "$PLAYBOOK" ]]; then
-  echo "[playbook] OK: requested playbook: $PLAYBOOK"
-else
-  echo "[playbook] using default candidate resolution (see playbooks/__init__.py)"
+  echo "[playbook] source=$PLAYBOOK"
 fi
+
+# If user passes a bare filename that doesn't exist in CWD,
+# pipeline will still try playbooks/<name> and defaults.
+# Here we only forward what the user gave us.
+# Pass all args to the pipeline
+python3 -m analysis.pipeline "$@"
 
 OUT_DIR="output"
 RUN_DIR="$(ls -td "${OUT_DIR}/games/"* | head -n1 || true)"


### PR DESCRIPTION
## Summary
- Enhance default playbook search and logging, raising clear errors when none found
- Harden clip backfill to handle dict or string formations, emit confidence values, and clean t0/t1
- Echo chosen playbook in run scripts and pipeline; document Pyflakes installation

## Testing
- `pip install pyflakes` *(failed: Tunnel connection failed: 403 Forbidden)*
- `python -m pyflakes playbooks tools analysis` *(failed: No module named pyflakes)*

------
https://chatgpt.com/codex/tasks/task_e_68a53f701e00832d9c23659e67bbfd72