### PR TITLE
Add basic diagnostics utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,3 +495,7 @@ For quick lint checks, install Pyflakes:
 ```
 pip install pyflakes
 ```
+
+# Add to ~/.bashrc
+alias gameday_rode='USE_LOUDNORM=true EXTRA_GAIN_DB=4 ./gameday --audio-source pulse'
+

--- a/env_loader.py
+++ b/env_loader.py
@@ -54,3 +54,18 @@ def require_or_default(name: str, default: str) -> str:
     if val is None or val == "":
         return default
     return val
+
+def get_env(name, default=None):
+    val = os.environ.get(name)
+    if val is None:
+        return default
+    val = val.strip().strip('"').strip("'")
+    return val if val else default
+
+
+def resolve_stream_url():
+    for key in ("STREAM_URL", "YT_RTMP_URL", "RTMP_URL"):
+        val = get_env(key)
+        if val:
+            return val
+    return None

--- a/tools/preflight.py
+++ b/tools/preflight.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+import os, json, subprocess, shutil, sys
+from env_loader import resolve_stream_url, get_env
+from tools.audio_devices import pick_audio_source
+from tools.audio_probe import probe_pulse, probe_alsa
+from tools.video_probe import ffprobe_encoders, list_v4l2, probe_format
+
+
+def run(cmd):
+    try:
+        out = subprocess.check_output(cmd, text=True, stderr=subprocess.STDOUT)
+        return 0, out.strip()
+    except subprocess.CalledProcessError as e:
+        return e.returncode, e.output.strip()
+    except Exception as e:
+        return 1, str(e)
+
+
+def main():
+    info = {}
+    rc, out = run([sys.executable, "--version"])
+    info["python_version"] = out
+    if rc != 0:
+        print(json.dumps({"error": "python missing", **info}))
+        sys.exit(1)
+
+    rc, out = run(["ffmpeg", "-version"])
+    info["ffmpeg_version"] = out.splitlines()[0] if out else ""
+    if rc != 0:
+        print(json.dumps({"error": "ffmpeg missing", **info}))
+        sys.exit(1)
+
+    stream_url = resolve_stream_url()
+    info["stream_url"] = stream_url
+    if not stream_url or not stream_url.startswith(("rtmp://","rtmps://")):
+        print(json.dumps({"error": "STREAM_URL missing or invalid", **info}))
+        sys.exit(1)
+
+    video_dev = get_env("VIDEO_DEVICE", "/dev/video0")
+    video_fmt = get_env("VIDEO_INPUT_FORMAT", "mjpeg")
+    info["video_device"] = video_dev
+    info["video_format"] = video_fmt
+    if not os.path.exists(video_dev):
+        print(json.dumps({"error": f"No video device at {video_dev}", **info}))
+        sys.exit(1)
+
+    probe = probe_format(video_dev)
+    info["video_probe"] = probe
+    if probe.get("rc",1) != 0 and video_fmt == "mjpeg":
+        info["video_format_hint"] = "yuyv422"
+
+    enc = ffprobe_encoders()
+    info["encoders"] = enc
+    chosen = None
+    if enc.get("h264_nvenc"):
+        chosen = "h264_nvenc"
+    elif enc.get("h264_v4l2m2m"):
+        chosen = "h264_v4l2m2m"
+    elif enc.get("libx264"):
+        chosen = "libx264"
+    info["chosen_encoder"] = chosen
+    if not chosen:
+        print(json.dumps({"error": "No H.264 encoder found", **info}))
+        sys.exit(1)
+
+    backend = get_env("MIC_BACKEND", "auto")
+    pulse = get_env("MIC_PULSE_NAME")
+    alsa = get_env("MIC_ALSA_DEVICE")
+    backend, name = pick_audio_source(backend, pulse, alsa)
+    info["audio_backend"] = backend
+    info["audio_device"] = name
+    if not backend or not name:
+        print(json.dumps({"error": "No audio device selected", **info}))
+        sys.exit(1)
+
+    if backend == "alsa":
+        probe_audio = probe_alsa(name)
+    else:
+        probe_audio = probe_pulse(name)
+    info["audio_probe"] = probe_audio
+    mean = probe_audio.get("mean_db")
+    if mean is None:
+        print(json.dumps({"error": "Audio level probe failed", **info}))
+        sys.exit(1)
+
+    rc, out = run(["getent", "hosts", "a.rtmps.youtube.com"])
+    info["dns"] = out
+    if rc != 0:
+        print(json.dumps({"error": "DNS resolution failed", **info}))
+        sys.exit(1)
+
+    rc, out = run(["lsof", video_dev]) if shutil.which("lsof") else (0, "")
+    info["device_lock"] = out
+
+    print(json.dumps(info))
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        print(json.dumps({"error": str(e)}))
+        sys.exit(1)

--- a/tools/video_probe.py
+++ b/tools/video_probe.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+import os, subprocess, json, sys, shlex, re
+
+def ffprobe_encoders():
+    try:
+        out = subprocess.check_output(["ffmpeg","-hide_banner","-encoders"], text=True, stderr=subprocess.STDOUT)
+        have = lambda k: (k in out)
+        return {
+            "h264_nvenc": have("h264_nvenc"),
+            "h264_vaapi": have("h264_vaapi"),
+            "h264_v4l2m2m": have("h264_v4l2m2m"),
+            "libx264": have("libx264"),
+        }
+    except Exception as e:
+        return {"error": str(e)}
+
+def list_v4l2():
+    devs = []
+    for d in ["/dev/video0","/dev/video1","/dev/video2"]:
+        if os.path.exists(d):
+            devs.append(d)
+    return devs
+
+def probe_format(dev="/dev/video0"):
+    cmd = f'ffmpeg -hide_banner -f video4linux2 -list_formats all -i {shlex.quote(dev)}'
+    p = subprocess.run(cmd, shell=True, text=True, capture_output=True)
+    return {"rc": p.returncode, "stderr": p.stderr[-4000:]}
+
+if __name__ == "__main__":
+    info = {
+        "v4l2_devices": list_v4l2(),
+        "encoders": ffprobe_encoders(),
+        "probe": probe_format(os.environ.get("VIDEO_DEVICE","/dev/video0")),
+    }
+    print(json.dumps(info))


### PR DESCRIPTION
## Summary
- add helpers to load env variables and resolve stream URL
- add video and system preflight probes for gameday streaming
- document handy `gameday_rode` alias

## Testing
- `PYTHONPATH=. python3 -m tools.list_audio`
- `PYTHONPATH=. python3 tools/preflight.py` *(fails: ffmpeg missing)*
- `STREAM_URL=rtmp://example ./gameday --probe-only` *(fails: No Pulse source found)*
- `STREAM_URL=rtmp://example ./gameday --local-preview` *(fails: No Pulse source found)*
- `STREAM_URL=rtmp://example ./gameday --dry-run` *(fails: No Pulse source found)*
- `STREAM_URL=rtmp://example ./gameday` *(fails: No Pulse source found)*

------
https://chatgpt.com/codex/tasks/task_e_68a62bfdb670832db3b1010ccaf58009