### PR TITLE
Add smoke test script and changelog for v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,54 @@
+# Changelog
+
+All notable changes to **mca-gameday-camera** will be documented in this file.
+
+## [v0.3.0] — 2025-08-21
+
+### Added
+- **Optional Google Drive uploads**: Drive sync is disabled by default and can be enabled with `GOOGLE_DRIVE_SYNC=1`. When disabled, the pipeline skips Drive imports and continues cleanly.
+- **Robust backfill for legacy/new JSONL**:
+  - Accepts `formation` as either a dict (`{"name": "...", "confidence": ...}`) or a scalar string (`"Reo"`).
+  - Helper `_as_name(x)` normalizes formation names from mixed shapes.
+- **Classifier outputs plumbed through**:
+  - Pipeline writes `"playcall": {"name": ..., "confidence": ...}` to JSONL.
+  - Backfill surfaces `play_family` and `playcall_confidence` in CSV.
+
+### Changed
+- **CSV schema unified** (order matters):
+
+
+play_id,t0,t1,snap,whistle,clip_path,formation,formation_confidence,play_family,playcall_confidence,outcome,clip_duration
+
+- `formation` is always a scalar name in CSV, `formation_confidence` is numeric (defaults to `0.0`).
+- `t0`/`t1` are written as blank fields when missing; JSONL uses `null`.
+- **Playbook logging**:
+- Logs at start: `[playbook] source=<arg or path>`
+- After resolution: `[playbook] OK: loaded playbook from <resolved_path>`
+- Echo requested: `[playbook] OK: requested playbook: <original_arg>`
+
+### Fixed
+- **Drive query f-string crash** in `tools/gdrive_sync.py`:
+- Replaced fragile nested-quote f-string with safe escaping/formatting.
+- Removed import-time side effects so importing the module can never crash the run.
+- **Storage cleanup** resilience:
+- Lazy import of Drive uploader; errors are logged as warnings and the pipeline proceeds.
+
+### Notes
+- Audio diagnostics & capture remain unchanged; existing Pulse/ALSA probing and env-driven audio settings still apply.
+
+### Upgrade Guide
+1. Deploy the code.
+2. (Optional) Enable Drive uploads by setting:
+ ```bash
+ export GOOGLE_DRIVE_SYNC=1
+
+
+Ensure credentials are configured before enabling.
+3. Validate with the provided smoke test:
+
+```
+tools/smoke_test.sh
+
+```
+
+---

--- a/tools/smoke_test.sh
+++ b/tools/smoke_test.sh
@@ -1,24 +1,162 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# mca-gameday-camera smoke test:
+# - Validates playbook logging, backfill schema, and at least one generated clip
+# - Confirms Drive upload is optional (no crash when disabled)
+# - Exercises fallback playbook path (bad path) without crashing
+# - Emits a concise PASS/FAIL summary at the end
+
 VIDEO=${1:-video/manual_uploads/IMG_4129.MP4}
+TEAM=${TEAM:-WHITE}
+EXPLICIT_PLAYBOOK=${EXPLICIT_PLAYBOOK:-playbooks/mca_5th_playbook.json}
+BAD_PLAYBOOK=${BAD_PLAYBOOK:-does_not_exist.json}
 
-echo "[SMOKE] explicit playbook"
-tools/run_and_backfill.sh --video "$VIDEO" --team WHITE \
-  --playbook playbooks/mca_5th_playbook.json --out output \
-  --min-play-gap 1.5 --min-play-length 6.0 \
-  --generate-report --generate-clips --generate-highlights | tee /tmp/mca_smoke1.log
+EXPECTED_HEADER="play_id,t0,t1,snap,whistle,clip_path,formation,formation_confidence,play_family,playcall_confidence,outcome,clip_duration"
 
-# Extract run dir from summary
-RUN_DIR=$(grep -A3 "== Summary ==" /tmp/mca_smoke1.log | sed -n 's/^Run dir: //p' | tail -n1)
-echo "[SMOKE] check CSV header in $RUN_DIR"
-head -n1 "$RUN_DIR/plays_index.csv"
+pass_count=0
+fail_count=0
+warn_count=0
+failures=()
 
-echo "[SMOKE] fallback playbook"
-tools/run_and_backfill.sh --video "$VIDEO" --team WHITE \
-  --playbook does_not_exist.json --out output \
-  --min-play-gap 1.5 --min-play-length 6.0 \
-  --generate-report --generate-clips --generate-highlights | tee /tmp/mca_smoke2.log
+log_pass() { echo "✅  $*"; pass_count=$((pass_count+1)); }
+log_fail() { echo "❌  $*"; fail_count=$((fail_count+1)); failures+=("$*"); }
+log_warn() { echo "⚠️   $*"; warn_count=$((warn_count+1)); }
 
+find_run_dir_from_log() {
+  # Extract the "Run dir:" line after the "== Summary ==" block
+  grep -A3 "== Summary ==" "$1" | sed -n 's/^Run dir: //p' | tail -n1
+}
 
-echo "[SMOKE] done"
+# --- Test A: Explicit playbook, Drive disabled ---
+echo "[SMOKE] A: explicit playbook, Drive disabled"
+unset GOOGLE_DRIVE_SYNC
+
+TMPLOG_A=$(mktemp /tmp/mca_smokeA.XXXX.log)
+tools/run_and_backfill.sh \
+  --video "$VIDEO" \
+  --team "$TEAM" \
+  --playbook "$EXPLICIT_PLAYBOOK" \
+  --out output \
+  --min-play-gap 1.5 \
+  --min-play-length 6.0 \
+  --generate-report \
+  --generate-clips \
+  --generate-highlights | tee "$TMPLOG_A"
+
+# A1: Logs contain expected playbook lines
+if grep -qE "^\[playbook\] source=" "$TMPLOG_A"; then
+  log_pass "A1: [playbook] source= present"
+else
+  log_fail "A1: Missing '[playbook] source=' line"
+fi
+if grep -qE "^\[playbook\] OK: loaded playbook from " "$TMPLOG_A"; then
+  log_pass "A1: [playbook] OK: loaded playbook from … present"
+else
+  log_fail "A1: Missing '[playbook] OK: loaded playbook from …' line"
+fi
+if grep -qE "^\[playbook\] OK: requested playbook: " "$TMPLOG_A"; then
+  log_pass "A1: [playbook] OK: requested playbook: … present"
+else
+  log_fail "A1: Missing '[playbook] OK: requested playbook: …' line"
+fi
+
+# A2: Resolve RUN_DIR and validate CSV schema + row count
+RUN_DIR_A="$(find_run_dir_from_log "$TMPLOG_A" || true)"
+if [[ -z "${RUN_DIR_A:-}" ]] || [[ ! -d "$RUN_DIR_A" ]]; then
+  log_fail "A2: Could not resolve RUN_DIR from log"
+else
+  HEAD_A=$(head -n1 "$RUN_DIR_A/plays_index.csv" 2>/dev/null || true)
+  if [[ "$HEAD_A" == "$EXPECTED_HEADER" ]]; then
+    log_pass "A2: CSV header matches expected schema"
+  else
+    log_fail "A2: CSV header mismatch. Got: '$HEAD_A'"
+  fi
+
+  ROWS_A=$(tail -n +2 "$RUN_DIR_A/plays_index.csv" 2>/dev/null | wc -l | tr -d ' ')
+  if [[ "${ROWS_A:-0}" -ge 1 ]]; then
+    log_pass "A2: CSV contains at least one data row ($ROWS_A)"
+  else
+    log_fail "A2: CSV has no data rows"
+  fi
+
+  CLIPS_A=$(find "$RUN_DIR_A/clips" -type f -name "*.mp4" 2>/dev/null | wc -l | tr -d ' ')
+  if [[ "${CLIPS_A:-0}" -ge 1 ]]; then
+    log_pass "A2: >=1 clip generated ($CLIPS_A)"
+  else
+    log_fail "A2: No clips generated in $RUN_DIR_A/clips"
+  fi
+fi
+
+# A3: Optional: classify presence (warn if all Unknown)
+if grep -q "^\[play_classifier\].*Unknown conf=0\.00" "$TMPLOG_A"; then
+  if grep -q "^\[play_classifier\].* conf=" "$TMPLOG_A" && ! grep -q "^\[play_classifier\].*Unknown conf=0\.00$" "$TMPLOG_A"; then
+    log_pass "A3: Classifier produced named labels"
+  else
+    log_warn "A3: Classifier produced only Unknown labels"
+  fi
+else
+  # Saw classifier logs but none Unknown → good
+  if grep -q "^\[play_classifier\]" "$TMPLOG_A"; then
+    log_pass "A3: Classifier produced named labels"
+  else
+    log_warn "A3: No classifier logs found"
+  fi
+fi
+
+# --- Test B: Fallback playbook (bad path) must not crash ---
+echo "[SMOKE] B: fallback playbook (bad path) — should not crash"
+TMPLOG_B=$(mktemp /tmp/mca_smokeB.XXXX.log)
+tools/run_and_backfill.sh \
+  --video "$VIDEO" \
+  --team "$TEAM" \
+  --playbook "$BAD_PLAYBOOK" \
+  --out output \
+  --min-play-gap 1.5 \
+  --min-play-length 6.0 \
+  --generate-report \
+  --generate-clips \
+  --generate-highlights | tee "$TMPLOG_B"
+
+if grep -qE "^\[playbook\] source=${BAD_PLAYBOOK}$" "$TMPLOG_B"; then
+  log_pass "B1: Logged bad playbook source (${BAD_PLAYBOOK})"
+else
+  log_warn "B1: Did not see expected bad playbook source line"
+fi
+if grep -qE "^\[playbook\] OK: loaded playbook from " "$TMPLOG_B"; then
+  log_pass "B2: Fallback playbook loaded without crashing"
+else
+  log_fail "B2: Missing 'OK: loaded playbook from …' after bad playbook"
+fi
+
+RUN_DIR_B="$(find_run_dir_from_log "$TMPLOG_B" || true)"
+if [[ -z "${RUN_DIR_B:-}" ]] || [[ ! -d "$RUN_DIR_B" ]]; then
+  log_fail "B3: Could not resolve RUN_DIR for fallback case"
+else
+  HEAD_B=$(head -n1 "$RUN_DIR_B/plays_index.csv" 2>/dev/null || true)
+  if [[ "$HEAD_B" == "$EXPECTED_HEADER" ]]; then
+    log_pass "B3: Fallback CSV header matches expected schema"
+  else
+    log_fail "B3: Fallback CSV header mismatch. Got: '$HEAD_B'"
+  fi
+fi
+
+# --- Summary ---
+echo
+echo "=================="
+echo "SMOKE TEST SUMMARY"
+echo "=================="
+echo "Passes : $pass_count"
+echo "Fails  : $fail_count"
+echo "Warns  : $warn_count"
+if (( fail_count )); then
+  echo
+  echo "Failures:"
+  for f in "${failures[@]}"; do
+    echo " - $f"
+  done
+  exit 1
+else
+  echo
+  echo "All critical checks passed ✅"
+fi


### PR DESCRIPTION
## Summary
- Document v0.3.0 additions and fixes in new CHANGELOG
- Replace smoke test with a comprehensive script covering playbook logging and fallback scenarios

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a70b86522c832d9bbc696946c5f2a7