### PR TITLE
Add preflight schema check with column alias support

### DIFF
--- a/patient_count_ingestor.py
+++ b/patient_count_ingestor.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+"""Patient count ingestion utilities.
+
+This module provides a ``preflight_schema_check`` function that ensures required
+columns exist before ingestion. It supports field aliases so that existing
+columns with equivalent meaning can satisfy a requirement. If neither the
+expected column nor any of its aliases are present, the function will create
+that column via the provided database client.
+"""
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Mapping, MutableMapping
+
+
+class SchemaClientProtocol:
+    """Protocol for minimal database client used in preflight checks."""
+
+    def get_columns(self, table: str) -> Iterable[str]:
+        """Return an iterable of column names for ``table``."""
+
+    def create_column(self, table: str, column: str) -> None:
+        """Create ``column`` in ``table`` if it does not exist."""
+
+
+@dataclass
+class PreflightReport:
+    """Report produced by :func:`preflight_schema_check`."""
+
+    created_columns: Dict[str, List[str]] = field(default_factory=dict)
+
+    def record(self, table: str, column: str) -> None:
+        self.created_columns.setdefault(table, []).append(column)
+
+    def __bool__(self) -> bool:  # pragma: no cover - convenience method
+        return bool(self.created_columns)
+
+
+FieldAliases = Mapping[str, Mapping[str, Iterable[str]]]
+"""Type alias for field alias mapping.
+
+The mapping is ``{table: {required_column: [alias1, alias2, ...]}}``.
+"""
+
+
+def preflight_schema_check(
+    client: SchemaClientProtocol,
+    required_schema: Mapping[str, Iterable[str]],
+    field_aliases: FieldAliases | None = None,
+) -> PreflightReport:
+    """Ensure required columns exist, creating them when necessary.
+
+    Parameters
+    ----------
+    client:
+        Database client implementing :class:`SchemaClientProtocol`.
+    required_schema:
+        Mapping of table names to the columns that must be present.
+    field_aliases:
+        Optional mapping of aliases for required columns. If any alias exists
+        in the table, the column is considered satisfied.
+
+    Returns
+    -------
+    PreflightReport
+        Report describing any columns that were created.
+    """
+
+    aliases: FieldAliases = field_aliases or {}
+    report = PreflightReport()
+
+    for table, columns in required_schema.items():
+        existing = set(client.get_columns(table))
+        table_aliases = aliases.get(table, {})
+
+        for column in columns:
+            possible_names = {column}
+            possible_names.update(table_aliases.get(column, []))
+
+            if any(name in existing for name in possible_names):
+                continue
+
+            client.create_column(table, column)
+            report.record(table, column)
+            existing.add(column)
+
+    return report

--- a/tests/test_preflight_schema_check.py
+++ b/tests/test_preflight_schema_check.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import Dict, Iterable, List
+
+import patient_count_ingestor as pci
+
+
+class FakeClient(pci.SchemaClientProtocol):
+    """In-memory fake database client for testing."""
+
+    def __init__(self, schema: Dict[str, List[str]] | None = None) -> None:
+        self.schema: Dict[str, List[str]] = schema or {}
+        self.created: Dict[str, List[str]] = {}
+
+    def get_columns(self, table: str) -> Iterable[str]:
+        return list(self.schema.get(table, []))
+
+    def create_column(self, table: str, column: str) -> None:
+        self.schema.setdefault(table, []).append(column)
+        self.created.setdefault(table, []).append(column)
+
+
+def test_alias_satisfies_requirement() -> None:
+    client = FakeClient({"medicare_clinics": ["number_of_chairs"]})
+    required = {"medicare_clinics": ["clinic_chair_count"]}
+    aliases = {"medicare_clinics": {"clinic_chair_count": ["number_of_chairs"]}}
+
+    report = pci.preflight_schema_check(client, required, aliases)
+
+    assert not report.created_columns
+    assert client.schema["medicare_clinics"] == ["number_of_chairs"]
+
+
+def test_missing_column_is_created() -> None:
+    client = FakeClient({"facility_patient_counts": []})
+    required = {"facility_patient_counts": ["total_patients"]}
+
+    report = pci.preflight_schema_check(client, required)
+
+    assert report.created_columns == {"facility_patient_counts": ["total_patients"]}
+    assert client.schema["facility_patient_counts"] == ["total_patients"]


### PR DESCRIPTION
## Summary
- add `preflight_schema_check` utility that auto-creates missing columns and respects field aliases
- cover schema check behavior with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a718921cf0832da8d48da0c5a06bc8