### PR TITLE
Harden gameday launcher and JSON config handling

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -1,10 +1,11 @@
 """Streamlit dashboard for visualizing play data."""
 from __future__ import annotations
 
-import json
 from collections import Counter
 from pathlib import Path
 from typing import Any, Dict, List
+
+from tools.json_io import load_json_safe
 
 from play_recommender import recommend_play
 
@@ -25,11 +26,7 @@ def load_json(path: Path) -> Any:
     """Load JSON data if the file exists."""
     if not path.exists():
         return None
-    try:
-        with path.open('r', encoding='utf-8') as f:
-            return json.load(f)
-    except Exception:
-        return None
+    return load_json_safe(path, default=None)
 
 
 def compute_player_counts(metadata: List[Dict[str, Any]]) -> Counter:

--- a/gameday
+++ b/gameday
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 
 REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$REPO_DIR"
@@ -65,4 +65,4 @@ if [[ -f .env ]]; then set -a; . ./.env; set +a; fi
 export PULSE_SOURCE
 
 # Launch stream with auto-retry loop
-exec PYTHONPATH=. python3 -m tools.ffmpeg_stream
+exec env PYTHONPATH=. python3 -m tools.ffmpeg_stream

--- a/live_dashboard.py
+++ b/live_dashboard.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-import json
 import os
 from pathlib import Path
+
+from tools.json_io import load_json_safe, dump_json_safe
 
 from flask import Flask, jsonify, render_template, request
 
@@ -16,17 +17,13 @@ OPPONENT = os.environ.get("OPPONENT_NAME", "Victory Christian")
 
 
 def load_scouting() -> list[dict]:
-    try:
-        with SCOUTING_PATH.open("r", encoding="utf-8") as f:
-            data = json.load(f)
-            if isinstance(data, list):
-                return [d for d in data if isinstance(d, dict)]
-            if isinstance(data, dict):
-                pats = data.get("patterns", [])
-                if isinstance(pats, list):
-                    return [d for d in pats if isinstance(d, dict)]
-    except Exception:
-        pass
+    data = load_json_safe(SCOUTING_PATH, default=[])
+    if isinstance(data, list):
+        return [d for d in data if isinstance(d, dict)]
+    if isinstance(data, dict):
+        pats = data.get("patterns", [])
+        if isinstance(pats, list):
+            return [d for d in pats if isinstance(d, dict)]
     return []
 
 app = Flask(__name__)
@@ -35,29 +32,21 @@ SCOUTING_PATTERNS = load_scouting()
 
 
 def load_plays() -> list[dict]:
-    try:
-        with LOG_PATH.open("r", encoding="utf-8") as f:
-            plays = json.load(f)
-            if isinstance(plays, list):
-                return plays
-    except Exception:
-        pass
+    plays = load_json_safe(LOG_PATH, default=[])
+    if isinstance(plays, list):
+        return plays
     return []
 
 
 def load_score() -> dict:
-    try:
-        with SCORE_PATH.open("r", encoding="utf-8") as f:
-            score = json.load(f)
-            if isinstance(score, dict):
-                return {"MCA": int(score.get("MCA", 0)), "Opp": int(score.get("Opp", 0))}
-    except Exception:
-        pass
+    score = load_json_safe(SCORE_PATH, default={})
+    if isinstance(score, dict):
+        return {"MCA": int(score.get("MCA", 0)), "Opp": int(score.get("Opp", 0))}
     return {"MCA": 0, "Opp": 0}
 
 
 def save_score(score: dict) -> None:
-    SCORE_PATH.write_text(json.dumps(score), encoding="utf-8")
+    dump_json_safe(SCORE_PATH, score)
 
 
 @app.route("/")

--- a/tools/json_io.py
+++ b/tools/json_io.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+import json, io, os
+from typing import Any
+
+
+def load_json_safe(path: str | os.PathLike, default: Any = None) -> Any:
+    """
+    Load JSON from `path`. If file is missing, empty, or invalid, return `default` (or {}).
+    Logs a short warning to stdout so launchers can continue.
+    """
+    if default is None:
+        default = {}
+    try:
+        with io.open(path, "r", encoding="utf-8") as f:
+            data = f.read().strip()
+            if not data:
+                print(f"[warn] Empty JSON file: {path} -> using default")
+                return default
+            return json.loads(data)
+    except FileNotFoundError:
+        print(f"[warn] JSON file not found: {path} -> using default")
+        return default
+    except json.JSONDecodeError as e:
+        print(f"[warn] Invalid JSON in {path}: {e} -> using default")
+        return default
+
+
+def dump_json_safe(path: str | os.PathLike, obj: Any) -> None:
+    with io.open(path, "w", encoding="utf-8") as f:
+        json.dump(obj, f, indent=2, ensure_ascii=False)

--- a/tools/list_audio.py
+++ b/tools/list_audio.py
@@ -1,10 +1,32 @@
+"""List available audio devices.
+
+Usage:
+  PYTHONPATH=. python3 -m tools.list_audio
+  PYTHONPATH=. python3 -m tools.list_audio --json
+"""
+
+import argparse, json
+
 from tools.audio_devices import diag
 
-if __name__ == "__main__":
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="List audio devices")
+    parser.add_argument("--json", action="store_true", help="output JSON instead of text")
+    args = parser.parse_args()
+
     info = diag()
+    if args.json:
+        print(json.dumps(info))
+        return
+
     print("Pulse sources:")
     for s in info["pulse"]:
         print(f"  - {s}")
     print("\nALSA devices:")
     for d in info["alsa"]:
         print(f"  - {d}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Fix bash launcher to use portable `env` exec and strict error handling
- Add `tools/json_io` helper for safe JSON reading/writing with warnings
- Use resilient loader in dashboard modules and add `--json` flag to `list_audio`

## Testing
- `:> config/gameday.json && PYTHONPATH=. python3 - <<'PY'
from tools.json_io import load_json_safe
print(load_json_safe("config/gameday.json"))
PY`
- `YOUTUBE_RTMP_URL=rtmp://example ./gameday >/tmp/gameday.log 2>&1; tail -n 20 /tmp/gameday.log`
- `python -m pytest`
- ⚠️ `dos2unix gameday` *(command not found, apt repositories unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a76b7cf588832daa5f09f175b79aa6