### PR TITLE
Refine FFmpeg streaming command

### DIFF
--- a/stream_to_youtube.py
+++ b/stream_to_youtube.py
@@ -39,13 +39,6 @@ from config import StreamConfig, load_config
 load_env()
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
 
-# Try both the old and new env var names
-YOUTUBE_URL = (
-    os.environ.get("YT_RTMP_URL")
-    or os.environ.get("YOUTUBE_RTMP_URL")
-    or require(["YT_RTMP_URL", "YOUTUBE_RTMP_URL"])
-)
-
 
 def _pick_encoder():
     preferred = os.environ.get("PREFERRED_ENCODERS")
@@ -616,6 +609,22 @@ def validate_rtmp_url(url: str) -> bool:
     return parsed.scheme in {"rtmp", "rtmps"} and bool(parsed.netloc) and bool(parsed.path)
 
 
+def normalize_youtube_url(url_or_key: str) -> str:
+    """Return a canonical YouTube RTMP(S) ingest URL.
+
+    ``url_or_key`` may be a full URL or just the stream key.
+    """
+    parsed = urlparse(url_or_key)
+    if parsed.scheme in {"rtmp", "rtmps"}:
+        key = parsed.path.rsplit("/", 1)[-1]
+        scheme = parsed.scheme
+    else:
+        key = url_or_key
+        scheme = "rtmps"
+    host = "a.rtmps.youtube.com" if scheme == "rtmps" else "a.rtmp.youtube.com"
+    return f"{scheme}://{host}/live2/{key}"
+
+
 def mask_stream_url(url: str) -> str:
     """Return the stream URL with the secret key portion hidden."""
     return re.sub(r"/[^/]+$", "/<hidden>", url)
@@ -877,15 +886,6 @@ def launch_ffmpeg(
     log_fp = log_file.open("w", encoding="utf-8", errors="replace")
 
     extra = ["-fflags", "nobuffer", "-flush_packets", "1"]
-    if not retry:
-        extra += [
-            "-reconnect",
-            "1",
-            "-reconnect_streamed",
-            "1",
-            "-reconnect_delay_max",
-            "2",
-        ]
     ffmpeg_command = build_ffmpeg_args(
         video_source="-",
         audio_device=mic_input,
@@ -1183,10 +1183,18 @@ def main() -> None:
     signal.signal(signal.SIGINT, _handle_signal)
     signal.signal(signal.SIGTERM, _handle_signal)
 
-    stream_url = args.stream_key or cfg.stream_key or os.getenv("YOUTUBE_STREAM_KEY")
+    stream_url = (
+        args.stream_key
+        or cfg.stream_key
+        or os.getenv("YT_RTMP_URL")
+        or os.getenv("YOUTUBE_RTMP_URL")
+        or os.getenv("YOUTUBE_STREAM_KEY")
+    )
 
     if not stream_url:
         raise ValueError("❌ Stream URL is missing or invalid. Aborting stream.")
+
+    stream_url = normalize_youtube_url(stream_url)
 
     logging.info(f"[DEBUG] Using stream URL: {stream_url}")
     global RTMP_URL, RTMP_REACHABLE

--- a/tools/ffmpeg_stream.py
+++ b/tools/ffmpeg_stream.py
@@ -1,7 +1,26 @@
-import os, subprocess, sys, time
+import os, subprocess, sys, time, shlex, shutil
+from urllib.parse import urlparse
 
 
-def build_ffmpeg_cmd(pulse_source, rtmp_url, video_input=None):
+def build_ffmpeg_cmd(
+    pulse_source,
+    rtmp_url,
+    video_input=None,
+    *,
+    width=1280,
+    height=720,
+    fps=30,
+    vbitrate="2500k",
+    maxrate="3000k",
+    bufsize="3000k",
+):
+    """Construct an FFmpeg command for streaming.
+
+    If ``video_input`` is ``None`` a black video source is generated.
+    ``pulse_source`` is *not* shell expanded; callers must supply the exact
+    Pulse device name.
+    """
+
     # Audio filter chain:
     #  - aformat to s16:48k
     #  - channelmap: if mono, duplicate to stereo
@@ -11,35 +30,93 @@ def build_ffmpeg_cmd(pulse_source, rtmp_url, video_input=None):
         "aformat=sample_fmts=s16:sample_rates=48000",
         "channelmap=channel_layout=stereo",
         "compand=attack=0.01:decay=0.2:points=-80/-80|-30/-10|-10/-4|0/-2",
-        "alimiter=limit=0.9"
+        "alimiter=limit=0.9",
     ]
-    audio_in = ["-f","pulse","-thread_queue_size","1024","-ac","2","-ar","48000","-i", pulse_source]
 
-    # Video: if we have a v4l2 device or x11grab, add it; otherwise stream audio-only with a black testsrc
+    audio_in = [
+        "-f",
+        "pulse",
+        "-thread_queue_size",
+        "1024",
+        "-ac",
+        "2",
+        "-ar",
+        "48000",
+        "-i",
+        pulse_source,
+    ]
+
+    # Video: if we have a v4l2 device or x11grab, add it; otherwise stream
+    # audio-only with a black color source
     if video_input:
-        video_in = ["-f","v4l2","-framerate","30","-video_size","1280x720","-i", video_input]
+        video_in = [
+            "-f",
+            "v4l2",
+            "-framerate",
+            str(fps),
+            "-video_size",
+            f"{width}x{height}",
+            "-i",
+            video_input,
+        ]
     else:
-        video_in = ["-f","lavfi","-i","color=size=1280x720:rate=30:color=black"]
+        video_in = [
+            "-f",
+            "lavfi",
+            "-i",
+            f"color=size={width}x{height}:rate={fps}:color=black",
+        ]
 
     out = [
         # Encode
-        "-c:v","libx264","-preset","veryfast","-b:v","2500k","-maxrate","3000k","-bufsize","3000k",
-        "-g","60","-pix_fmt","yuv420p",
-        "-c:a","aac","-b:a","160k","-ar","48000",
-        "-af", ",".join(af),
+        "-c:v",
+        "libx264",
+        "-preset",
+        "veryfast",
+        "-b:v",
+        vbitrate,
+        "-maxrate",
+        maxrate,
+        "-bufsize",
+        bufsize,
+        "-g",
+        str(fps * 2),
+        "-pix_fmt",
+        "yuv420p",
+        "-c:a",
+        "aac",
+        "-b:a",
+        "160k",
+        "-ar",
+        "48000",
+        "-af",
+        ",".join(af),
         # Low-latency/robustness
-        "-tune","zerolatency",
-        "-rtmp_buffer","0",
-        "-f","flv", rtmp_url
+        "-tune",
+        "zerolatency",
+        "-flvflags",
+        "no_duration_filesize",
+        "-f",
+        "flv",
+        rtmp_url,
     ]
-    return ["ffmpeg","-hide_banner","-reconnect","1","-reconnect_at_eof","1","-reconnect_streamed","1","-nostats","-loglevel","warning"] + audio_in + video_in + out
+
+    return [
+        "ffmpeg",
+        "-hide_banner",
+        "-nostats",
+        "-loglevel",
+        "warning",
+    ] + audio_in + video_in + out
 
 
 def stream_loop(pulse_source, rtmp_url, video_input=None, max_retries=100, backoff=5):
     tries = 0
     while True:
         cmd = build_ffmpeg_cmd(pulse_source, rtmp_url, video_input)
-        print(f"[ffmpeg] launching: {' '.join(cmd)}")
+        print(
+            f"[ffmpeg] launching: {' '.join(shlex.quote(c) for c in cmd)}"
+        )
         try:
             rc = subprocess.call(cmd)
         except FileNotFoundError:
@@ -52,11 +129,49 @@ def stream_loop(pulse_source, rtmp_url, video_input=None, max_retries=100, backo
         time.sleep(backoff)
 
 
+def _normalize_youtube_url(url_or_key: str) -> str:
+    """Return a canonical YouTube RTMP(S) ingest URL."""
+    parsed = urlparse(url_or_key)
+    if parsed.scheme in {"rtmp", "rtmps"}:
+        key = parsed.path.rsplit("/", 1)[-1]
+        scheme = parsed.scheme
+    else:
+        key = url_or_key
+        scheme = "rtmps"
+    host = "a.rtmps.youtube.com" if scheme == "rtmps" else "a.rtmp.youtube.com"
+    return f"{scheme}://{host}/live2/{key}"
+
+
+def _ensure_pulse_source(src: str) -> str:
+    """Return ``src`` if it exists, otherwise ``default``."""
+    if not src:
+        return "default"
+    try:
+        if shutil.which("pactl"):
+            out = subprocess.check_output(
+                ["pactl", "list", "sources", "short"],
+                text=True,
+                stderr=subprocess.DEVNULL,
+            )
+            names = [line.split("\t", 2)[1] for line in out.splitlines()]
+            if src in names:
+                return src
+    except Exception:
+        pass
+    return "default"
+
+
 if __name__ == "__main__":
-    src = os.environ.get("PULSE_SOURCE")
-    url = os.environ.get("YOUTUBE_RTMP_URL")
+    src_env = os.environ.get("PULSE_SOURCE")
+    url_env = (
+        os.environ.get("YOUTUBE_RTMP_URL")
+        or os.environ.get("YT_RTMP_URL")
+        or os.environ.get("YOUTUBE_STREAM_KEY")
+    )
     vid = os.environ.get("VIDEO_INPUT")  # optional, e.g., /dev/video0
-    if not src or not url:
-        print("Missing PULSE_SOURCE or YOUTUBE_RTMP_URL", file=sys.stderr)
+    if not url_env:
+        print("Missing YOUTUBE_RTMP_URL/YT_RTMP_URL/YOUTUBE_STREAM_KEY", file=sys.stderr)
         sys.exit(2)
+    url = _normalize_youtube_url(url_env)
+    src = _ensure_pulse_source(src_env)
     stream_loop(src, url, vid)


### PR DESCRIPTION
## Summary
- normalize YouTube RTMP(S) URLs and drop unsupported reconnect options
- improve ffmpeg_stream helper with robust audio + black video baseline
- allow Pulse source fallback and quote device names in logs

## Testing
- `pytest` *(fails: SyntaxError: from __future__ import annotations must be at top of tools/json_io.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a7724bf32c832da8f31d861cc8920b