### PR TITLE
feat: improve gameday config handling and ffmpeg audio chain

### DIFF
--- a/gameday
+++ b/gameday
@@ -7,6 +7,22 @@ cd "$REPO_DIR"
 export PYTHONUNBUFFERED=1
 export PYTHONPATH="$REPO_DIR${PYTHONPATH:+:${PYTHONPATH}}"
 
+python3 - <<'PY'
+import os, json, pathlib
+p = pathlib.Path(os.environ.get("CONFIG_PATH", "config/gameday.json"))
+raw = p.read_text(encoding="utf-8").strip() if p.exists() else ""
+if not raw:
+    print(f"[diag] config empty or missing at {p}; using {}")
+    cfg = {}
+else:
+    try:
+        cfg = json.loads(raw)
+    except json.JSONDecodeError as e:
+        print(f"[diag] invalid JSON in {p}: {e}; using {}")
+        cfg = {}
+print("[diag] config keys:", ", ".join(sorted(cfg.keys())))
+PY
+
 echo "[diag] Listing audio devices (run: PYTHONPATH=. python3 -m tools.list_audio)"
 PYTHONPATH=. python3 -m tools.list_audio || true
 

--- a/tools/ffmpeg_stream.py
+++ b/tools/ffmpeg_stream.py
@@ -24,12 +24,12 @@ def build_ffmpeg_cmd(
     # Audio filter chain:
     #  - aformat to s16:48k
     #  - channelmap: if mono, duplicate to stereo
-    #  - compand: light compression to lift quiet speech
+    #  - acompressor: light compression to lift quiet speech
     #  - alimiter: prevent clipping at 0dBFS
     af = [
         "aformat=sample_fmts=s16:sample_rates=48000",
         "channelmap=channel_layout=stereo",
-        "compand=attack=0.01:decay=0.2:points=-80/-80|-30/-10|-10/-4|0/-2",
+        "acompressor=threshold=-18dB:ratio=3:attack=10:release=200:makeup=6",
         "alimiter=limit=0.9",
     ]
 
@@ -114,11 +114,10 @@ def stream_loop(pulse_source, rtmp_url, video_input=None, max_retries=100, backo
     tries = 0
     while True:
         cmd = build_ffmpeg_cmd(pulse_source, rtmp_url, video_input)
-        print(
-            f"[ffmpeg] launching: {' '.join(shlex.quote(c) for c in cmd)}"
-        )
+        cmd_str = " ".join(shlex.quote(c) for c in cmd)
+        print(f"[ffmpeg] launching: {cmd_str}")
         try:
-            rc = subprocess.call(cmd)
+            rc = subprocess.call(cmd_str, shell=True)
         except FileNotFoundError:
             rc = 1
             print("[ffmpeg] executable not found")
@@ -132,9 +131,9 @@ def stream_loop(pulse_source, rtmp_url, video_input=None, max_retries=100, backo
 def _normalize_youtube_url(url_or_key: str) -> str:
     """Return a canonical YouTube RTMP(S) ingest URL."""
     parsed = urlparse(url_or_key)
-    if parsed.scheme in {"rtmp", "rtmps"}:
+    scheme = parsed.scheme.lower()
+    if scheme in {"rtmp", "rtmps"}:
         key = parsed.path.rsplit("/", 1)[-1]
-        scheme = parsed.scheme
     else:
         key = url_or_key
         scheme = "rtmps"


### PR DESCRIPTION
## Summary
- load gameday config with robust JSON parsing and diagnostics
- adjust ffmpeg streaming filters to use acompressor + limiter
- quote ffmpeg command for pulse devices and normalize YouTube host

## Testing
- `pytest` *(fails: Module 'cv2' was found, but when imported by pytest it raised: ImportError('libGL.so.1: cannot open shared object file: No such file or directory'))*

------
https://chatgpt.com/codex/tasks/task_e_68a7748acc2c832daee5ceb43f1b097d