### PR TITLE
Fix f-string with bare {} in gameday launcher

### DIFF
--- a/gameday
+++ b/gameday
@@ -12,13 +12,13 @@ import os, json, pathlib
 p = pathlib.Path(os.environ.get("CONFIG_PATH", "config/gameday.json"))
 raw = p.read_text(encoding="utf-8").strip() if p.exists() else ""
 if not raw:
-    print(f"[diag] config empty or missing at {p}; using {}")
+    print(f"[diag] config empty or missing at {p}; using {{}}")
     cfg = {}
 else:
     try:
         cfg = json.loads(raw)
     except json.JSONDecodeError as e:
-        print(f"[diag] invalid JSON in {p}: {e}; using {}")
+        print(f"[diag] invalid JSON in {p}: {e}; using {{}}")
         cfg = {}
 print("[diag] config keys:", ", ".join(sorted(cfg.keys())))
 PY


### PR DESCRIPTION
## Summary
- escape empty dict braces in gameday launcher diagnostics

## Testing
- `pytest` *(fails: SyntaxError: from __future__ imports must occur at the beginning of the file)*

------
https://chatgpt.com/codex/tasks/task_e_68a787a4484c832d9a5ce76e4bebf401