### PR TITLE
Improve config diagnostics in gameday script

### DIFF
--- a/gameday
+++ b/gameday
@@ -8,19 +8,16 @@ export PYTHONUNBUFFERED=1
 export PYTHONPATH="$REPO_DIR${PYTHONPATH:+:${PYTHONPATH}}"
 
 python3 - <<'PY'
-import os, json, pathlib
+import os, json, pathlib, sys
 p = pathlib.Path(os.environ.get("CONFIG_PATH", "config/gameday.json"))
-raw = p.read_text(encoding="utf-8").strip() if p.exists() else ""
-if not raw:
-    print(f"[diag] config empty or missing at {p}; using {{}}")
+try:
+    raw = p.read_text(encoding="utf-8").strip() if p.exists() else ""
+    cfg = json.loads(raw) if raw else {}
+except json.JSONDecodeError as e:
+    print(f"[diag] invalid JSON in {p}: {e}; using {{}}")
     cfg = {}
-else:
-    try:
-        cfg = json.loads(raw)
-    except json.JSONDecodeError as e:
-        print(f"[diag] invalid JSON in {p}: {e}; using {{}}")
-        cfg = {}
-print("[diag] config keys:", ", ".join(sorted(cfg.keys())))
+print("[diag] config path:", p)
+print("[diag] config keys:", ", ".join(sorted(cfg.keys())) or "(none)")
 PY
 
 echo "[diag] Listing audio devices (run: PYTHONPATH=. python3 -m tools.list_audio)"


### PR DESCRIPTION
## Summary
- enhance gameday configuration diagnostics by checking path from env var, handling missing or invalid JSON, and reporting config path and keys

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a78e43470c832dbd367ba01ae94ee4