### PR TITLE
Improve gameday launcher and config handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,29 @@ export PULSE_DEV='alsa_input.usb-R__DE_R__DE_VideoMic_GO_II_17477F5D-00.mono-fal
 scripts/gameday_launcher.sh
 ```
 
+## Gameday Quick Start
+
+- Port 443 via RTMPS is preferred; port 1935 may be blocked.
+- List audio devices: `./gameday --diag`
+- Push a generated test card + tone (no devices needed): `./gameday --test-pattern`
+- Set your stream key:
+
+```bash
+export YOUTUBE_RTMP_URL='rtmps://a.rtmps.youtube.com/live2/xxxxxxxxxxxxxxxxxxxx'
+```
+
+### Troubleshooting
+
+If YouTube shows *No data* or a tiny bitrate, check:
+
+- Time sync: `timedatectl status` (enable NTP)
+- CA bundles installed/updated
+- Key has no `< >` or spaces
+- Nothing else is using `/dev/video0` or the Pulse source:
+  - `fuser -v /dev/video0`
+  - `pactl list short source-outputs`
+- Try `b.rtmps.youtube.com` if `a.rtmps` is flaky.
+
 ## Automated Film Analysis
 
 The `analysis` package provides a small end-to-end pipeline that ingests a

--- a/analysis/highlights.py
+++ b/analysis/highlights.py
@@ -69,8 +69,9 @@ def build_highlight(clips_dir: pathlib.Path, out_dir: pathlib.Path):
             "0:a:0?",
             "-vsync",
             "vfr",
+            # Our ffmpeg build lacks support for min_*comp flags on aresample.
             "-af",
-            "aresample=async=1:min_hard_comp=0.100:first_pts=0",
+            "aresample=async=1:first_pts=0",
             "-ar",
             "48000",
             "-ac",

--- a/config/gameday.json
+++ b/config/gameday.json
@@ -1,5 +1,5 @@
 {
-  "rtmp_url": "rtmp://a.rtmp.youtube.com/live2/REPLACE_ME",
+  "rtmp_url": "rtmps://a.rtmps.youtube.com/live2/<STREAM_KEY>",
   "video_dev": "/dev/video0",
   "pulse_source": "alsa_input.usb-R__DE_R__DE_VideoMic_GO_II_17477F5D-00.mono-fallback",
   "video_size": "1280x720",

--- a/gameday
+++ b/gameday
@@ -1,44 +1,82 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# --- Kill stragglers that could hold the devices
-pkill -9 -f 'gameday|ffmpeg.*video4linux2|python.*(opencv|cv2|camera)|gst-launch' 2>/dev/null || true
-sleep 0.7
+# Kill any stragglers that might be holding devices (but not this script)
+for pid in $(pgrep -f 'gameday|ffmpeg.video4linux2|python.(opencv|cv2|camera)|gst-launch' || true); do
+  if [[ "$pid" != "$$" ]]; then kill -9 "$pid" 2>/dev/null || true; fi
+done
 
-# --- Resolve config/env
-VIDEO_DEV="${VIDEO_DEV:-/dev/video0}"
-PULSE_DEV="${PULSE_DEV:-alsa_input.usb-R__DE_R__DE_VideoMic_GO_II_17477F5D-00.mono-fallback}"
-YOUTUBE_RTMP_URL="${YOUTUBE_RTMP_URL:-rtmp://a.rtmp.youtube.com/live2/REPLACE_ME}"
+if [[ "${1:-}" == "--diag" ]]; then
+  if PYTHONPATH=. python3 -m tools.list_audio 2>/dev/null; then :; else
+    echo "Pulse sources:"; pactl list short sources 2>/dev/null | sed 's/^/  /' || true
+    echo; echo "ALSA devices:"; arecord -l 2>/dev/null | sed 's/^/  /' || true
+  fi
+  exit 0
+fi
 
-SIZE="${VIDEO_SIZE:-1280x720}"
-FPS="${FPS:-30}"
-VBR="${VIDEO_BITRATE:-3500k}"
-MAXRATE="${VIDEO_MAXRATE:-4000k}"
-BUFSIZE="${VIDEO_BUFSIZE:-6000k}"
-GOP="$(( FPS * 2 ))"   # ~2s keyframe interval
-
-echo "[gameday] Launch -> video=${VIDEO_DEV} ${SIZE}@${FPS} | pulse=${PULSE_DEV} | out=${YOUTUBE_RTMP_URL}" >&2
-
-# --- Validation
-if [[ "$YOUTUBE_RTMP_URL" == *REPLACE_ME* ]] || [[ "$YOUTUBE_RTMP_URL" = "" ]]; then
-  echo "[gameday] ERROR: YOUTUBE_RTMP_URL not set to a real stream key." >&2
+cfg="$(mktemp)"
+trap 'rm -f "$cfg"' EXIT
+if ! scripts/_resolve_config.py 1>"$cfg"; then
+  echo "[gameday] config resolution failed" >&2
   exit 2
 fi
 
-# --- ffmpeg: Encode to H.264 + AAC (YouTube requires this; do NOT copy MJPEG)
-# Notes:
-# - libx264 veryfast + zerolatency keeps CPU modest and reduces buffering.
-# - mono AAC at 48k; many on-field mics are mono.
-# - -flvflags no_duration_filesize silences harmless FLV header warnings.
-exec ffmpeg -hide_banner -loglevel info \
+mapfile -t CFG < <(
+PYTHONPATH=. python3 - "$cfg" <<'PY'
+import sys, json; cfg=json.load(open(sys.argv[1]))
+print("\n".join([cfg['video_dev'], cfg['pulse_source'], cfg['rtmp_url'], cfg['video_size'], str(cfg['fps'])]))
+PY
+)
+VIDEO_DEV="${CFG[0]}"
+PULSE_DEV="${CFG[1]}"
+RTMP_URL="${CFG[2]}"
+VIDEO_SIZE="${CFG[3]}"
+FPS="${CFG[4]}"
+
+if [[ -z "$VIDEO_DEV" || ! -e "$VIDEO_DEV" ]]; then
+  echo "[gameday] missing video device $VIDEO_DEV" >&2; exit 2
+fi
+if [[ -z "$PULSE_DEV" ]]; then
+  echo "[gameday] missing pulse source" >&2; exit 2
+fi
+if [[ -z "$RTMP_URL" || "$RTMP_URL" == *'<'* || "$RTMP_URL" == *'>'* ]]; then
+  echo "[gameday] missing or invalid RTMP URL" >&2; exit 2
+fi
+
+if [[ "$RTMP_URL" == rtmp://* ]]; then
+  host=$(echo "$RTMP_URL" | cut -d/ -f3)
+  key="${RTMP_URL##*/}"
+  if ! timeout 1 bash -c "exec 3<>/dev/tcp/$host/1935" 2>/dev/null; then
+    RTMP_URL="rtmps://a.rtmps.youtube.com/live2/$key"
+  fi
+fi
+
+if [[ "${1:-}" == "--test-pattern" ]]; then
+  ffmpeg -hide_banner -loglevel info -re \
+    -f lavfi -i "testsrc2=size=1280x720:rate=30" \
+    -f lavfi -i "sine=frequency=1000:sample_rate=48000" \
+    -c:v libx264 -preset veryfast -tune zerolatency -pix_fmt yuv420p \
+    -b:v 3000k -maxrate 3500k -bufsize 4500k -g 60 -r 30 \
+    -c:a aac -b:a 128k -ar 48000 -ac 1 \
+    -flvflags no_duration_filesize \
+    -f flv "$RTMP_URL" \
+    || { code=$?; echo "[gameday] ffmpeg failed (exit $code). Check network (RTMPS 443), stream key, or device conflicts." >&2; exit $code; }
+  exit 0
+fi
+
+echo "[gameday] Launch -> video=$VIDEO_DEV $VIDEO_SIZE@$FPS | pulse=$PULSE_DEV | rtmp=set" >&2
+
+ffmpeg -hide_banner -loglevel info \
   -fflags +genpts -use_wallclock_as_timestamps 1 \
-  -thread_queue_size 4096 \
-  -f video4linux2 -input_format mjpeg -video_size "${SIZE}" -framerate "${FPS}" -i "${VIDEO_DEV}" \
-  -thread_queue_size 1024 -f pulse -i "${PULSE_DEV}" \
+  -thread_queue_size 1024 \
+  -f video4linux2 -input_format mjpeg -video_size "$VIDEO_SIZE" -framerate "$FPS" -i "$VIDEO_DEV" \
+  -thread_queue_size 1024 -f pulse -i "$PULSE_DEV" \
   -map 0:v:0 -map 1:a:0 \
-  -c:v libx264 -preset veryfast -tune zerolatency -pix_fmt yuv420p \
-  -b:v "${VBR}" -maxrate "${MAXRATE}" -bufsize "${BUFSIZE}" \
-  -g "${GOP}" -r "${FPS}" \
+  -vf "scale=iw:ih:in_range=jpeg:out_range=tv,format=yuv420p" \
+  -c:v libx264 -preset veryfast -tune zerolatency \
+  -b:v 3000k -maxrate 3500k -bufsize 4500k -g 60 -r "$FPS" \
   -c:a aac -b:a 128k -ar 48000 -ac 1 \
-  -flvflags no_duration_filesize \
-  -f flv "${YOUTUBE_RTMP_URL}"
+  -f flv "$RTMP_URL" \
+  || { code=$?; echo "[gameday] ffmpeg failed (exit $code). Check network (RTMPS 443), stream key, or device conflicts." >&2; exit $code; }
+exit 0
+

--- a/scripts/_resolve_config.py
+++ b/scripts/_resolve_config.py
@@ -25,7 +25,8 @@ def list_pulse_sources():
 
 def choose_pulse_source(desired):
     sources = list_pulse_sources()
-    if desired and any(desired in s for s in sources):
+    # Honor an explicit override even if we cannot query Pulse for sources
+    if desired and (not sources or any(desired in s for s in sources)):
         return desired
     # Prefer RØDE if present
     for s in sources:
@@ -63,7 +64,8 @@ def main():
     if not ok:
         sys.exit(2)
 
-    sys.stdout.write(
+    # stdout must contain **only** the compact JSON blob used by the launcher.
+    print(
         json.dumps(
             {
                 "rtmp_url": rtmp,


### PR DESCRIPTION
## Summary
- keep _resolve_config.py JSON clean, log status to stderr, and allow env Pulse overrides even without pactl
- strip unsupported aresample flags and add RTMPS-friendly gameday launcher with diagnostics and test-pattern mode
- add RTMPS defaults and quick start docs for YouTube streaming

## Testing
- `VIDEO_DEV=/dev/null PULSE_DEV=dummy YOUTUBE_RTMP_URL=rtmps://a.rtmps.youtube.com/live2/test scripts/_resolve_config.py 1>/tmp/cfg.json 2>/dev/null && python3 -c 'import json,sys;print(json.load(open("/tmp/cfg.json"))["video_dev"])'`
- `./gameday --diag`
- `VIDEO_DEV=/dev/null PULSE_DEV=dummy YOUTUBE_RTMP_URL=rtmp://example.com/live2/test ./gameday --test-pattern`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8f66a4958832db938e92d0e16cfe0