### PR TITLE
Support legacy stream URL env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ EXTRA_GAIN_DB=4 ./gameday --audio-source pulse            # manual tweak
 scripts/doctor.sh
 
 # 1) Set your stream key (NO angle brackets, no spaces)
-export YOUTUBE_RTMP_URL='rtmps://a.rtmps.youtube.com/live2/<your_key>'
+export YT_RTMP_URL='rtmps://a.rtmps.youtube.com/live2/<your_key>'
+# (``YOUTUBE_RTMP_URL`` is also accepted)
 
 # 2) Optional: override devices (else put them in config/gameday.json)
 export VIDEO_DEV=/dev/video0

--- a/env.sample
+++ b/env.sample
@@ -1,5 +1,6 @@
 # Copy to .env and fill in before streaming
 YT_RTMP_URL=rtmps://a.rtmp.youtube.com/live2/xcuz-3x1d-9y7v-ghec-2xmh
+# (alias: set ``YOUTUBE_RTMP_URL`` if preferred)
 AUDIO_GAIN_DB=8
 AUDIO_MODE=speech
 AUDIO_HIGHPASS=120

--- a/scripts/_resolve_config.py
+++ b/scripts/_resolve_config.py
@@ -20,9 +20,16 @@ def load_cfg():
     return {}
 
 def coalesce(cfg_key, env_key, default=None):
-    v = os.environ.get(env_key)
-    if v is not None and v.strip():
-        return v.strip()
+    """Return the first non-empty env var among ``env_key`` or config fallback."""
+    if isinstance(env_key, (list, tuple)):
+        for ek in env_key:
+            v = os.environ.get(ek)
+            if v is not None and v.strip():
+                return v.strip()
+    else:
+        v = os.environ.get(env_key)
+        if v is not None and v.strip():
+            return v.strip()
     return (cfg.get(cfg_key) if (cfg_key in cfg and cfg[cfg_key]) else default)
 
 def _valid_rtmp(u: str) -> bool:
@@ -43,7 +50,8 @@ video_dev   = coalesce("video_dev",   "VIDEO_DEV")
 pulse_src   = coalesce("pulse_source","PULSE_DEV")
 video_size  = coalesce("video_size",  "VIDEO_SIZE",  "1280x720")
 fps         = int(coalesce("fps",     "FPS",         "30"))
-rtmp_url    = coalesce("rtmp_url",    "YOUTUBE_RTMP_URL", "")
+# Accept common aliases like YT_RTMP_URL for backward compatibility
+rtmp_url    = coalesce("rtmp_url",    ("YOUTUBE_RTMP_URL", "YT_RTMP_URL", "RTMP_URL"), "")
 
 # ---- sanity checks
 if not video_dev:


### PR DESCRIPTION
## Summary
- allow `gameday` config resolver to read `YT_RTMP_URL`/`RTMP_URL`
- document legacy `YT_RTMP_URL` variable and alias

## Testing
- `PYTHONDONTWRITEBYTECODE=1 pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a9184b0f08832d89eff780e94e54e6