### PR TITLE
Improve encoder detection fallback

### DIFF
--- a/ffmpeg_utils.py
+++ b/ffmpeg_utils.py
@@ -4,47 +4,68 @@ import threading
 from typing import List, Optional, Tuple
 
 
-def detect_encoder(input_type: str | None = None) -> str:
+def _sanity_probe(name: str) -> bool:
+    """Return ``True`` if ``ffmpeg`` can open the given encoder."""
+
+    cmd = [
+        "ffmpeg",
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-f",
+        "lavfi",
+        "-i",
+        "testsrc2=size=1280x720:rate=30",
+        "-t",
+        "1",
+        "-c:v",
+        name,
+        "-f",
+        "null",
+        "-",
+    ]
+    try:
+        subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
+def detect_encoder(
+    preferred: Optional[List[str]] = None,
+    input_type: str | None = None,
+) -> str:
     """Detect and return a usable H.264 encoder.
 
-    Preference order:
-    1. ``h264_v4l2m2m`` (Jetson hardware encoder)
-    2. ``h264_nvmpi``
-    3. ``libx264``
-
-    ``h264_omx`` is intentionally skipped due to reliability issues. A
-    ``RuntimeError`` is raised if no suitable encoder is found.
-
-    When ``input_type`` is ``"image2pipe"`` (MJPEG frames piped via stdin),
-    Jetson hardware encoders output an empty stream. In this case ``libx264`` is
-    forced if available.
+    ``preferred`` may specify a custom encoder search order.  When ``input_type``
+    is ``"image2pipe"`` (piped MJPEG frames), hardware encoders are skipped in
+    favour of ``libx264``.
     """
-
     try:
-        result = subprocess.run(
-            ["ffmpeg", "-encoders"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
+        encoders = subprocess.check_output(
+            ["ffmpeg", "-hide_banner", "-encoders"], text=True
         )
-        encoders = result.stdout
-        if input_type == "image2pipe":
-            print("⚠️ Forcing encoder to libx264 due to piped MJPEG input (image2pipe)")
-            if "libx264" in encoders:
-                return "libx264"
-        else:
-            if "h264_v4l2m2m" in encoders:
-                return "h264_v4l2m2m"
-            if "h264_nvmpi" in encoders:
-                return "h264_nvmpi"
-            if "libx264" in encoders:
-                return "libx264"
     except Exception:
-        pass
-    raise RuntimeError(
-        "❌ No usable H.264 encoder found (looked for h264_v4l2m2m, h264_nvmpi, libx264)."
-    )
+        encoders = ""
 
+    candidates = preferred or ["h264_v4l2m2m", "h264_nvmpi", "libx264"]
+
+    if input_type == "image2pipe":
+        if "libx264" in encoders and _sanity_probe("libx264"):
+            return "libx264"
+    else:
+        for name in candidates:
+            if name not in encoders:
+                continue
+            if _sanity_probe(name):
+                return name
+
+    if _sanity_probe("libx264"):
+        return "libx264"
+
+    raise RuntimeError(
+        "❌ No usable H.264 encoder found (looked for h264_v4l2m2m, h264_nvmpi, libx264).",
+    )
 
 def run_ffmpeg_command(cmd: List[str], timeout: int = 15) -> Tuple[int, str, str]:
     """Run an FFmpeg command with realtime stderr streaming.

--- a/stream_to_youtube.py
+++ b/stream_to_youtube.py
@@ -42,11 +42,14 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name
 
 def _pick_encoder():
     preferred = os.environ.get("PREFERRED_ENCODERS")
-    if os.environ.get("USE_SW_ENC","0") == "1":
-        preferred = "libx264"
-    cmd = ["tools/encoder_detect.py"] + ([preferred] if preferred else [])
-    enc_flag = subprocess.check_output(cmd, text=True).strip()
-    return shlex.split(enc_flag)
+    if os.environ.get("USE_SW_ENC", "0") == "1":
+        pref_list = ["libx264"]
+    elif preferred:
+        pref_list = [p.strip() for p in preferred.split(",") if p.strip()]
+    else:
+        pref_list = None
+    enc_name = detect_encoder(pref_list)
+    return ["-c:v", enc_name]
 
 
 def choose_free_video_device(preferred=("0", "1", "2", "3")):


### PR DESCRIPTION
## Summary
- add sanity probe to ffmpeg encoder detection to avoid unavailable hardware
- select encoder in `stream_to_youtube.py` via enhanced detector and env preference

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a918ed6284832da1824723b98637ba