### PR TITLE
Avoid exiting gameday when no conflicting processes

### DIFF
--- a/gameday
+++ b/gameday
@@ -67,7 +67,7 @@ kill_conflicts() {
         if [[ "$pid" != "$me" && "$pid" != "$ppid" ]]; then
           kill -9 "$pid" 2>/dev/null || true
         fi
-      done
+      done || true
   # Release Pulse source outputs that may latch the mic
   pactl list short source-outputs 2>/dev/null | awk '{print $1}' | xargs -r -n1 pactl kill-client 2>/dev/null || true
 }


### PR DESCRIPTION
## Summary
- prevent `gameday` launcher from exiting when `pgrep` finds no conflicting processes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a91b3a046c832d98e1663063279b9d