### PR TITLE
fix: avoid config parsing errors in gameday

### DIFF
--- a/gameday
+++ b/gameday
@@ -82,16 +82,16 @@ sleep 0.5
 if [[ -n "$OVERRIDE_RTMP" ]]; then
   export RTMP_URL="$OVERRIDE_RTMP"
 fi
-CFG_JSON="$(scripts/_resolve_config.py 2> >(tee /dev/stderr))" || {
+CFG_JSON="$(scripts/_resolve_config.py)" || {
   log "failed to resolve config."
   exit 2
 }
 
 # Safe JSON extraction
-json_get() { python3 - "$1" <<<"$CFG_JSON" <<'PY' || true
+json_get() { python3 - "$1" "$CFG_JSON" <<'PY' || true
 import json,sys
 k=sys.argv[1]
-cfg=json.loads(sys.stdin.read())
+cfg=json.loads(sys.argv[2])
 v=cfg.get(k,"")
 print(v if v is not None else "")
 PY


### PR DESCRIPTION
## Summary
- fix config resolver call so stderr doesn't contaminate JSON
- simplify JSON helper to pass config via argv

## Testing
- `pytest -q`
- `./gameday` (fails: video device not found)


------
https://chatgpt.com/codex/tasks/task_e_68a91fea95d0832d932929551ec8a428