### PR TITLE
fix: robust h264 encoder detection

### DIFF
--- a/gameday
+++ b/gameday
@@ -187,17 +187,25 @@ ENC_V=""
 
 # Query available encoders once to avoid repeated ffmpeg calls
 ENC_LIST="$(ffmpeg -hide_banner -encoders 2>/dev/null || true)"
-if echo "$ENC_LIST" | grep -q '^ ..S... libx264'; then
-  ENC_V="-c:v libx264 ${ENC_PRESET} -tune zerolatency ${ENC_OPTS}"
-else
-  HW_ENC="$(echo "$ENC_LIST" | awk '$0 ~ /^ ..S... h264_/ {print $2; exit}')"
-  if [[ -n "$HW_ENC" ]]; then
-    ENC_V="-c:v ${HW_ENC} ${ENC_PRESET} ${ENC_OPTS}"
-    log "libx264 missing; using ${HW_ENC}"
-  else
-    log "ERROR: no H.264 encoder available (libx264 or any h264_* encoder)."
-    exit 4
+# Prefer libx264; otherwise fall back to the first available h264_* encoder.
+select_h264_encoder() {
+  local list="$1"
+  if echo "$list" | grep -qE '^ V.* libx264\b'; then
+    echo "-c:v libx264 ${ENC_PRESET} -tune zerolatency ${ENC_OPTS}"
+    return 0
   fi
+  local hw
+  hw="$(echo "$list" | awk '/^ V.* h264_/ {print $2; exit}')"
+  if [[ -n "$hw" ]]; then
+    log "libx264 missing; using ${hw}"
+    echo "-c:v ${hw} ${ENC_PRESET} ${ENC_OPTS}"
+    return 0
+  fi
+  return 1
+}
+if ! ENC_V="$(select_h264_encoder "$ENC_LIST")"; then
+  log "ERROR: no H.264 encoder available (libx264 or any h264_* encoder)."
+  exit 4
 fi
 ENC_A="-c:a aac -b:a 128k -ar 48000 -ac 1"
 


### PR DESCRIPTION
## Summary
- handle ffmpeg encoder list correctly when selecting H.264 encoder
- log and fall back to first available `h264_*` encoder

## Testing
- `pytest -q`
- `shellcheck gameday` *(fails: command not found; `apt-get update` 403 forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a9270f4c94832dace869733931f974