### PR TITLE
Improve pipeline robustness and add helper scripts

### DIFF
--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -280,14 +280,26 @@ def _run_pipeline(args: argparse.Namespace) -> None:
         print(f"[formation_detector] {seg_id}: {formation_name} conf={formation_conf:.2f}")
 
         playcall = classify_play(feat.get("features", {}), formation_name, raw_pb)
-        print(f"[play_classifier] {seg_id}: {playcall['name']} conf={playcall['confidence']:.2f}")
-        play_name = playcall.get("name")
-        play_conf = playcall.get("confidence", 0.0)
-        play_family = playcall.get("family", "")
-        if play_name == "Unknown":
-            play_family = ""
+        play_name = playcall.get("name") or ""
+        play_conf = float(playcall.get("confidence", 0.0))
+        play_family = playcall.get("family", "") if play_name else ""
+        disp_name = play_name or "Unknown"
+        print(f"[play_classifier] {seg_id}: {disp_name} conf={play_conf:.2f}")
+        if (not play_name) or (play_conf < 0.5):
+            cands = ", ".join(
+                [
+                    f"{c['name']}:{c.get('score', 0):.2f}"
+                    for c in playcall.get("candidates", [])[:3]
+                ]
+            )
+            if cands:
+                print(f"[play_classifier:candidates] {seg_id}: {cands}")
 
-        playcall_dict = playcall
+        playcall_dict = {
+            "name": play_name,
+            "confidence": play_conf,
+            "candidates": playcall.get("candidates", []),
+        }
 
         # grades -- simple constant grade for each detected player
         for pl in players:
@@ -339,6 +351,7 @@ def _run_pipeline(args: argparse.Namespace) -> None:
                 "clip_path": str(clip_out),
                 "formation": formation_name,
                 "formation_confidence": formation_conf,
+                "playcall": play_name,
                 "play_family": play_family,
                 "playcall_confidence": float(play_conf or 0.0),
                 "outcome": "",
@@ -355,24 +368,23 @@ def _run_pipeline(args: argparse.Namespace) -> None:
     _write_jsonl(grade_rows, run_dir / "grades.jsonl")
 
     # plays index
+    csv_columns = [
+        "play_id",
+        "t0",
+        "t1",
+        "snap",
+        "whistle",
+        "clip_path",
+        "formation",
+        "formation_confidence",
+        "playcall",
+        "play_family",
+        "playcall_confidence",
+        "outcome",
+        "clip_duration",
+    ]
     with (run_dir / "plays_index.csv").open("w", newline="", encoding="utf8") as f:
-        writer = csv.DictWriter(
-            f,
-            fieldnames=[
-                "play_id",
-                "t0",
-                "t1",
-                "snap",
-                "whistle",
-                "clip_path",
-                "formation",
-                "formation_confidence",
-                "play_family",
-                "playcall_confidence",
-                "outcome",
-                "clip_duration",
-            ],
-        )
+        writer = csv.DictWriter(f, fieldnames=csv_columns)
         writer.writeheader()
         writer.writerows(plays_index)
 
@@ -394,7 +406,7 @@ def _run_pipeline(args: argparse.Namespace) -> None:
     (run_dir / "summary.json").write_text(json.dumps(summary, indent=2))
     if args.generate_report:
         (run_dir / "report.md").write_text("# Automated Report\n")
-    print(f"[pipeline] run complete -> {run_dir}")
+    print(f"[pipeline] run complete -> \"{run_dir}\"")
 
 def run_pipeline(*, args: argparse.Namespace | None = None, **kwargs) -> None:
     """Wrapper allowing kwargs or an argparse Namespace."""

--- a/analysis/play_classifier.py
+++ b/analysis/play_classifier.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Dict, Any
+import os
 
 
 class PlayClassifier:
@@ -88,8 +89,12 @@ class PlayClassifier:
             score = inter / union
             if formation_hint and row["formation"] and formation_hint.lower() in row["formation"].lower():
                 score += 0.15
-            scored.append((score, row))
-        scored.sort(key=lambda x: x[0], reverse=True)
+            scored.append({"score": score, "name": row["name"], "family": row["family"]})
+        scored.sort(key=lambda x: x["score"], reverse=True)
+        candidates = [
+            {"name": s["name"], "score": s["score"], "family": s["family"]}
+            for s in scored[:5]
+        ]
 
         # Fallback heuristics: unique family by formation = high confidence
         if formation_hint:
@@ -108,21 +113,42 @@ class PlayClassifier:
                     "name": f"Leo {fam}" if "left" in fh else f"Reo {fam}",
                     "confidence": choice[1],
                     "family": fam,
-                    "candidates": [],
+                    "candidates": candidates,
                 }
 
-        if scored and scored[0][0] >= 0.10:
-            best = scored[0][1]
+        if scored and scored[0]["score"] >= 0.10:
+            best = scored[0]
             fam = self.alias.get(best["family"] or best["name"], best["family"] or "Unknown")
-            conf = min(0.98, max(0.70, 0.70 + scored[0][0]))
+            conf = min(0.98, max(0.70, 0.70 + best["score"]))
             return {
                 "name": best["name"] or fam,
                 "confidence": conf,
                 "family": fam,
-                "candidates": [r[1]["name"] for r in scored[:5]],
+                "candidates": candidates,
             }
 
-        return {"name": "Unknown", "confidence": 0.0, "family": "", "candidates": []}
+        fallback_on = os.getenv("PLAYCALL_FALLBACK", "0") == "1"
+        bias_family = os.getenv("PLAYCALL_BIAS_FAMILY", "").strip()
+        best = candidates[0] if candidates else None
+        name, conf, fam = "", 0.0, ""
+        if best and fallback_on and best.get("score", 0) >= 0.35:
+            name, conf = best["name"], float(best["score"])
+            fam = self.alias.get(best.get("family") or best["name"], best.get("family") or "")
+
+        if bias_family and candidates:
+            fam_hits = [c for c in candidates if c["name"].endswith(bias_family)]
+            if fam_hits:
+                fh = max(fam_hits, key=lambda c: c["score"])
+                if fallback_on and fh["score"] >= 0.35:
+                    name, conf = fh["name"], float(fh["score"])
+                    fam = self.alias.get(fh.get("family") or fh["name"], fh.get("family") or "")
+
+        return {
+            "name": name,
+            "confidence": conf,
+            "family": fam if name else "",
+            "candidates": candidates,
+        }
 
 
 __all__ = ["PlayClassifier"]

--- a/analysis/segmentation.py
+++ b/analysis/segmentation.py
@@ -1,8 +1,7 @@
 from dataclasses import dataclass
 from typing import List, Dict
 import numpy as np
-import json, subprocess, shlex
-from pathlib import Path
+import subprocess, json, math, shlex
 
 try:  # pragma: no cover
     import cv2
@@ -36,13 +35,12 @@ def segment_video(
     spanning the entire video duration (via ``ffprobe``).
     """
     if cv2 is None:
-        import subprocess, json as json_module
         try:
             out = subprocess.check_output([
                 "ffprobe", "-v", "error", "-select_streams", "v:0", "-show_entries",
                 "stream=duration", "-of", "json", path
             ])
-            dur = float(json_module.loads(out)["streams"][0].get("duration", 0.0))
+            dur = float(json.loads(out)["streams"][0].get("duration", 0.0))
         except Exception:
             dur = 0.0
         return [{"id": "PLAY_001", "t0": 0.0, "t1": max(10.0, dur)}]
@@ -52,23 +50,40 @@ def segment_video(
         raise FileNotFoundError(f"Cannot open video: {path}")
 
     fps = cap.get(cv2.CAP_PROP_FPS) or 0.0
-    # Re-probe with ffprobe if fps is invalid (< 1.0) or NaN.
-    try:
-        if not fps or fps < 1.0:
-            import json, subprocess
-            probe = [
-                "ffprobe", "-v", "error",
-                "-select_streams", "v:0",
-                "-show_entries", "stream=r_frame_rate",
+
+    def _probe_fps_with_ffprobe(path: str) -> float:
+        try:
+            # ffprobe json for avg_frame_rate, fall back to r_frame_rate
+            cmd = [
+                "ffprobe", "-v", "error", "-select_streams", "v:0",
+                "-show_entries", "stream=avg_frame_rate,r_frame_rate",
                 "-of", "json", path
             ]
-            out = subprocess.check_output(probe, text=True)
-            rate = json.loads(out)["streams"][0]["r_frame_rate"]
-            # r_frame_rate like "30000/1001"
-            num, den = rate.split("/")
-            fps = float(num) / float(den) if float(den) != 0 else 30.0
-    except Exception:
-        fps = fps if fps and fps >= 1.0 else 30.0
+            out = subprocess.check_output(cmd, text=True)
+            data = json.loads(out)
+            st = (data.get("streams") or [{}])[0]
+            for key in ("avg_frame_rate", "r_frame_rate"):
+                fr = st.get(key, "0/0")
+                if fr and "/" in fr:
+                    num, den = fr.split("/")
+                    try:
+                        num, den = float(num), float(den)
+                        if den != 0:
+                            val = num / den
+                            if 5.0 <= val <= 120.0:
+                                return val
+                    except Exception:
+                        pass
+        except Exception:
+            pass
+        return 30.0  # sane default
+
+    def _fps_is_bad(x: float) -> bool:
+        return (not x) or (isinstance(x, float) and (math.isnan(x) or x < 5.0 or x > 120.0))
+
+    if _fps_is_bad(fps):
+        fps = _probe_fps_with_ffprobe(path)
+        print(f"[video_probe] OpenCV FPS bad; ffprobe FPS={fps:.3f}")
 
     W = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH) or 0)
     H = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT) or 0)

--- a/scripts/clip_previews.sh
+++ b/scripts/clip_previews.sh
@@ -1,16 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
-: "${RUN_DIR:?Set RUN_DIR to a pipeline output game dir}"
 
-echo "First few clips:"
-ls -1 "$RUN_DIR"/clips/*/*.mp4 | head -n 10 || true
+if [[ -z "${RUN_DIR:-}" ]]; then
+  echo "RUN_DIR: Set RUN_DIR to a pipeline output game dir"
+  exit 1
+fi
 
-# 3s GIF previews next to each mp4 (idempotent)
-for c in "$RUN_DIR"/clips/*/*.mp4; do
-  [[ -f "$c" ]] || continue
-  gif="${c%.mp4}.gif"
-  if [[ ! -f "$gif" ]]; then
-    ffmpeg -y -i "$c" -t 3 -vf "fps=10,scale=512:-1" "$gif" >/dev/null 2>&1 || true
-  fi
+shopt -s nullglob
+for c in "${RUN_DIR}"/clips/*/*.mp4; do
+  out="${c%.mp4}.gif"
+  ffmpeg -y -i "$c" -t 3 -vf "fps=10,scale=512:-1" "$out"
 done
 

--- a/scripts/run_utils.sh
+++ b/scripts/run_utils.sh
@@ -2,37 +2,50 @@
 set -euo pipefail
 
 get_run_dir () {
+  # Usage: get_run_dir LOGFILE
+  # Prints the run dir path from a pipeline log (handles quotes and spaces)
   awk '
     $0 ~ /^== Summary ==/ { in_sum=1; next }
     in_sum && $0 ~ /^Run dir:/ {
-      sub(/^Run dir:[[:space:]]*/, "", $0);
-      # strip optional surrounding quotes
-      gsub(/^"/, "", $0); gsub(/"$/, "", $0);
-      print $0; exit
+      sub(/^Run dir:[[:space:]]*/, "", $0)
+      gsub(/^"|"$/, "", $0)  # strip surrounding quotes if present
+      print $0
+      exit
     }
   ' "${1:-/dev/stdin}"
 }
 
 check_csv () {
-  local run_dir="$1"
-  local csv="$run_dir/plays_index.csv"
-  [[ -f "$csv" ]] || { echo "❌ missing plays_index.csv"; return 1; }
-  local got
-  got="$(head -n1 "$csv")"
-  # Accept header that includes playcall column (preferred) or older one without it
-  if [[ "$got" != "play_id,t0,t1,snap,whistle,clip_path,formation,formation_confidence,playcall,play_family,playcall_confidence,outcome,clip_duration" \
-     && "$got" != "play_id,t0,t1,snap,whistle,clip_path,formation,formation_confidence,play_family,playcall_confidence,outcome,clip_duration" ]]; then
+  # Usage: check_csv RUN_DIR
+  local RUN_DIR="${1:-}"
+  if [[ -z "${RUN_DIR}" || ! -d "${RUN_DIR}" ]]; then
+    echo "Run dir: (invalid)"
+    exit 1
+  fi
+  echo "Run dir: ${RUN_DIR}"
+  local CSV="${RUN_DIR}/plays_index.csv"
+  if [[ ! -f "$CSV" ]]; then
+    echo "❌ Missing plays_index.csv"
+    exit 1
+  fi
+
+  local EXPECTED="play_id,t0,t1,snap,whistle,clip_path,formation,formation_confidence,playcall,play_family,playcall_confidence,outcome,clip_duration"
+  local GOT
+  GOT="$(head -n1 "$CSV" | tr -d '\r')"
+  if [[ "$GOT" != "$EXPECTED" ]]; then
     echo "⚠️ CSV header is unexpected but proceeding:"
-    echo "Got: $got"
+    echo "Got: $GOT"
   else
     echo "✅ CSV header OK"
   fi
-  if [[ "$(wc -l < "$csv")" -le 1 ]]; then
-    echo "❌ CSV has no data rows"
-    return 1
-  fi
-  echo "✅ CSV has data rows"
-}
 
-"$@"
+  if [[ $(wc -l < "$CSV") -gt 1 ]]; then
+    echo "✅ CSV has data rows"
+  else
+    echo "❌ CSV has no data rows"
+  fi
+
+  echo "First few clips:"
+  awk -F, 'NR>1 && $6!="" {print $6}' "$CSV" | head -n 10
+}
 

--- a/tools/run_and_backfill.sh
+++ b/tools/run_and_backfill.sh
@@ -46,20 +46,20 @@ ARGS=(
   --min-play-length "$MIN_LEN"
 )
 (( GEN_REPORT == 1 )) && ARGS+=( --generate-report )
-LOG=${LOG:-/dev/null}
 
-if [[ "${GOOGLE_DRIVE_SYNC:-}" == "1" ]]; then
-  echo "[gdrive] Drive sync ENABLED"
-else
-  echo "[gdrive] Drive sync DISABLED"
-fi
+run_main() {
+  if [[ "${GOOGLE_DRIVE_SYNC:-}" == "1" ]]; then
+    echo "[gdrive] Drive sync ENABLED"
+  else
+    echo "[gdrive] Drive sync DISABLED"
+  fi
 
-(( GEN_CLIPS == 1 )) && ARGS+=( --generate-clips )
+  (( GEN_CLIPS == 1 )) && ARGS+=( --generate-clips )
 
-python3 "${ARGS[@]}" 2>&1 | tee "$LOG"
+  python3 "${ARGS[@]}"
 
-# determine run directory via Python helper (matches pipeline logic)
-RUN_DIR=$(python3 - "$VIDEO" "$OUT" <<'PY'
+  # determine run directory via Python helper (matches pipeline logic)
+  RUN_DIR=$(python3 - "$VIDEO" "$OUT" <<'PY'
 import sys, hashlib
 from pathlib import Path
 video, out = sys.argv[1], sys.argv[2]
@@ -73,23 +73,28 @@ fp = hashlib.sha1(raw.encode()).hexdigest()[:12]
 run = (Path(out) / "games" / f"{p.stem}__{fp}").resolve()
 print(run)
 PY
-)
+  )
 
-{
   echo "== Summary =="
   echo "Run dir: \"$RUN_DIR\""
-} | tee -a "$LOG"
 
-if [[ "${GOOGLE_DRIVE_SYNC:-}" == "1" ]]; then
-  if [[ -f "$RUN_DIR/plays_index.csv" ]]; then
-    echo "[gdrive] uploading $RUN_DIR/plays_index.csv" | tee -a "$LOG"
-    if python3 upload_to_drive.py "$RUN_DIR/plays_index.csv" >> "$LOG" 2>&1; then
-      echo "[gdrive] upload OK" | tee -a "$LOG"
+  if [[ "${GOOGLE_DRIVE_SYNC:-}" == "1" ]]; then
+    if [[ -f "$RUN_DIR/plays_index.csv" ]]; then
+      echo "[gdrive] uploading $RUN_DIR/plays_index.csv"
+      if python3 upload_to_drive.py "$RUN_DIR/plays_index.csv"; then
+        echo "[gdrive] upload OK"
+      else
+        echo "[gdrive] upload FAILED"
+      fi
     else
-      echo "[gdrive] upload FAILED" | tee -a "$LOG"
+      echo "[gdrive] nothing to upload"
     fi
-  else
-    echo "[gdrive] nothing to upload" | tee -a "$LOG"
   fi
+}
+
+if [[ -n "$LOG" ]]; then
+  run_main 2>&1 | tee "$LOG"
+else
+  run_main
 fi
 


### PR DESCRIPTION
## Summary
- Quote run directory in pipeline logs for shell-safe parsing and add playcall candidate logging
- Re-probe video FPS with ffprobe when OpenCV returns invalid values
- Expand play classifier with candidate lists, optional env-based fallbacks, and maintain stable CSV schema including playcall column
- Add run utilities and clip preview scripts, and make run_and_backfill support optional log files

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ada80bf23c832da85d8805ad928afa