### PR TITLE
Improve pipeline robustness and classification

### DIFF
--- a/analysis/classification.py
+++ b/analysis/classification.py
@@ -2,7 +2,24 @@
 
 import logging
 from dataclasses import dataclass
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Sequence, Tuple
+
+SOFT_THR = 0.85
+TOP_K = 3
+
+
+def postprocess_playcall(pred_dist: Sequence[Tuple[str, float]]):
+    """
+    pred_dist: list of (name, prob) sorted descending
+    Returns: (name, conf, candidates)
+    """
+    candidates = [
+        {"name": n, "confidence": float(p)} for n, p in pred_dist[:TOP_K]
+    ]
+    if candidates and candidates[0]["confidence"] >= SOFT_THR:
+        top = candidates[0]
+        return top["name"], top["confidence"], candidates
+    return "Unknown", 0.0, candidates
 
 
 @dataclass
@@ -110,5 +127,5 @@ def classify_play(frame_window, playbook, formation, logger, cues=None):
     return {"name": best.name, "confidence": best.confidence, "candidates": [c.__dict__ for c in others]}
 
 
-__all__ = ["classify_play", "PlayCandidate"]
+__all__ = ["classify_play", "PlayCandidate", "postprocess_playcall"]
 

--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -57,7 +57,8 @@ from formation_detector import detect_formation
 from fnmatch import fnmatch
 from playbooks import load_offense_playbook
 from .playbook.schema import validate_playbook
-from analysis.classifier import classify_play
+from analysis.classifier import model_predict_candidates, FORMATION_FAMILY_PRIOR
+from analysis.classification import postprocess_playcall
 
 
 # ---------------------------------------------------------------------------
@@ -200,6 +201,9 @@ def _run_pipeline(args: argparse.Namespace) -> None:
     plays = raw_pb.get("plays", [])
     pb = validate_playbook({"plays": plays, "formations": raw_pb.get("formations", [])}) if plays else None
     name_to_family = {p.name: p.family or p.name for p in pb.plays.values()} if pb else {}
+
+    def derive_family(name: str) -> str:
+        return name_to_family.get(name, "")
     print(
         f"[config] min_play_length={args.min_play_length} min_play_gap={args.min_play_gap} "
         f"report={args.generate_report} clips={args.generate_clips} highlights={args.generate_highlights} overlay={getattr(args, 'make_overlay', getattr(args, 'overlay', False))}"
@@ -279,26 +283,36 @@ def _run_pipeline(args: argparse.Namespace) -> None:
             formation_conf = 0.8
         print(f"[formation_detector] {seg_id}: {formation_name} conf={formation_conf:.2f}")
 
-        playcall = classify_play(feat.get("features", {}), formation_name, raw_pb)
-        play_name = playcall.get("name") or ""
-        play_conf = float(playcall.get("confidence", 0.0))
-        play_family = playcall.get("family", "") if play_name else ""
-        disp_name = play_name or "Unknown"
-        print(f"[play_classifier] {seg_id}: {disp_name} conf={play_conf:.2f}")
-        if (not play_name) or (play_conf < 0.5):
-            cands = ", ".join(
-                [
-                    f"{c['name']}:{c.get('score', 0):.2f}"
-                    for c in playcall.get("candidates", [])[:3]
-                ]
-            )
-            if cands:
-                print(f"[play_classifier:candidates] {seg_id}: {cands}")
+        candidates_raw = model_predict_candidates(feat.get("features", {}), raw_pb)
+        families_ok = FORMATION_FAMILY_PRIOR.get(formation_name)
+        if families_ok:
+            candidates_raw = [
+                c
+                for c in candidates_raw
+                if (c.get("family") in families_ok or c.get("name") in families_ok)
+            ]
+        total_score = sum(max(c["score"], 0.0) for c in candidates_raw) or 1.0
+        pred_dist = sorted(
+            [(c["name"], c["score"] / total_score) for c in candidates_raw],
+            key=lambda x: x[1],
+            reverse=True,
+        )
+        play_name, play_conf, candidates = postprocess_playcall(pred_dist)
+        play_family = derive_family(play_name) if play_name != "Unknown" else ""
+        cand_str = ", ".join([
+            f'{c["name"]}:{c["confidence"]:.2f}' for c in candidates
+        ])
+        if play_name == "Unknown":
+            print(f"[play_classifier] {seg_id}: Unknown conf=0.00")
+            if cand_str:
+                print(f"[play_classifier:candidates] {seg_id}: {cand_str}")
+        else:
+            print(f"[play_classifier] {seg_id}: {play_name} conf={play_conf:.2f}")
 
         playcall_dict = {
             "name": play_name,
             "confidence": play_conf,
-            "candidates": playcall.get("candidates", []),
+            "candidates": candidates,
         }
 
         # grades -- simple constant grade for each detected player
@@ -323,8 +337,8 @@ def _run_pipeline(args: argparse.Namespace) -> None:
         play_rec = {
             "play_id": seg_id,
             "clip_path": str(clip_out),
-            "t0": "",
-            "t1": "",
+            "t0": str(t0),
+            "t1": str(t1),
             "formation": formation_name,
             "formation_confidence": float(formation_conf),
             "playcall": playcall_dict,
@@ -341,23 +355,22 @@ def _run_pipeline(args: argparse.Namespace) -> None:
         }
         prediction_rows.append(play_rec)
 
-        plays_index.append(
-            {
-                "play_id": seg_id,
-                "t0": t0,
-                "t1": t1,
-                "snap": t0,
-                "whistle": t1,
-                "clip_path": str(clip_out),
-                "formation": formation_name,
-                "formation_confidence": formation_conf,
-                "playcall": play_name,
-                "play_family": play_family,
-                "playcall_confidence": float(play_conf or 0.0),
-                "outcome": "",
-                "clip_duration": float(clip_duration),
-            }
-        )
+        row = {
+            "play_id": seg_id,
+            "t0": t0,
+            "t1": t1,
+            "snap": t0,
+            "whistle": t1,
+            "clip_path": str(clip_out),
+            "formation": formation_name,
+            "formation_confidence": formation_conf,
+            "playcall": play_name,
+            "playcall_confidence": float(play_conf or 0.0),
+            "play_family": play_family,
+            "outcome": "",
+            "clip_duration": float(clip_duration),
+        }
+        plays_index.append(row)
 
     if cap is not None:
         cap.release()
@@ -368,7 +381,7 @@ def _run_pipeline(args: argparse.Namespace) -> None:
     _write_jsonl(grade_rows, run_dir / "grades.jsonl")
 
     # plays index
-    csv_columns = [
+    PREFERRED = [
         "play_id",
         "t0",
         "t1",
@@ -378,15 +391,41 @@ def _run_pipeline(args: argparse.Namespace) -> None:
         "formation",
         "formation_confidence",
         "playcall",
+        "playcall_confidence",
+        "play_family",
+        "outcome",
+        "clip_duration",
+    ]
+    LEGACY = [
+        "play_id",
+        "t0",
+        "t1",
+        "snap",
+        "whistle",
+        "clip_path",
+        "formation",
+        "formation_confidence",
         "play_family",
         "playcall_confidence",
         "outcome",
         "clip_duration",
     ]
+    write_legacy = os.getenv("PIPELINE_WRITE_LEGACY_CSV", "0") == "1"
     with (run_dir / "plays_index.csv").open("w", newline="", encoding="utf8") as f:
-        writer = csv.DictWriter(f, fieldnames=csv_columns)
+        writer = csv.DictWriter(f, fieldnames=PREFERRED)
         writer.writeheader()
-        writer.writerows(plays_index)
+        for row in plays_index:
+            writer.writerow({k: row.get(k, "") for k in PREFERRED})
+    if write_legacy:
+        with (run_dir / "plays_index_legacy.csv").open(
+            "w", newline="", encoding="utf8"
+        ) as f:
+            w = csv.DictWriter(f, fieldnames=LEGACY)
+            w.writeheader()
+            for row in plays_index:
+                legacy_row = {k: row.get(k, "") for k in LEGACY}
+                legacy_row["play_family"] = row.get("play_family", "")
+                w.writerow(legacy_row)
 
     # player grade summary
     with (run_dir / "player_grades.csv").open("w", newline="", encoding="utf8") as f:

--- a/analysis/segmentation.py
+++ b/analysis/segmentation.py
@@ -1,12 +1,29 @@
 from dataclasses import dataclass
 from typing import List, Dict
 import numpy as np
-import subprocess, json, math, shlex
+import subprocess, json, shlex
 
 try:  # pragma: no cover
     import cv2
 except Exception:  # pragma: no cover
     cv2 = None  # type: ignore
+
+
+def _probe_fps_ffprobe(path: str) -> float:
+    try:
+        cmd = (
+            f'ffprobe -v error -select_streams v:0 -show_entries stream=r_frame_rate '
+            f'-of json {shlex.quote(path)}'
+        )
+        out = subprocess.check_output(cmd, shell=True).decode("utf-8", "ignore")
+        data = json.loads(out)
+        rate = data["streams"][0].get("r_frame_rate", "0/1")
+        num, den = rate.split("/")
+        num, den = float(num), float(den)
+        return num / den if den else 0.0
+    except Exception as e:
+        print(f"[ffprobe] failed to probe fps: {e}")
+        return 0.0
 
 
 @dataclass
@@ -51,39 +68,14 @@ def segment_video(
 
     fps = cap.get(cv2.CAP_PROP_FPS) or 0.0
 
-    def _probe_fps_with_ffprobe(path: str) -> float:
-        try:
-            # ffprobe json for avg_frame_rate, fall back to r_frame_rate
-            cmd = [
-                "ffprobe", "-v", "error", "-select_streams", "v:0",
-                "-show_entries", "stream=avg_frame_rate,r_frame_rate",
-                "-of", "json", path
-            ]
-            out = subprocess.check_output(cmd, text=True)
-            data = json.loads(out)
-            st = (data.get("streams") or [{}])[0]
-            for key in ("avg_frame_rate", "r_frame_rate"):
-                fr = st.get(key, "0/0")
-                if fr and "/" in fr:
-                    num, den = fr.split("/")
-                    try:
-                        num, den = float(num), float(den)
-                        if den != 0:
-                            val = num / den
-                            if 5.0 <= val <= 120.0:
-                                return val
-                    except Exception:
-                        pass
-        except Exception:
-            pass
-        return 30.0  # sane default
-
-    def _fps_is_bad(x: float) -> bool:
-        return (not x) or (isinstance(x, float) and (math.isnan(x) or x < 5.0 or x > 120.0))
-
-    if _fps_is_bad(fps):
-        fps = _probe_fps_with_ffprobe(path)
-        print(f"[video_probe] OpenCV FPS bad; ffprobe FPS={fps:.3f}")
+    if not fps or fps < 5 or fps > 240:
+        print(f"[video] OpenCV fps={fps} looks wrong; reprobing via ffprobe…")
+        fps2 = _probe_fps_ffprobe(path)
+        if fps2 > 1:
+            print(f"[video] using ffprobe fps={fps2}")
+            fps = fps2
+        else:
+            print("[video] ffprobe also failed; keeping OpenCV fps")
 
     W = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH) or 0)
     H = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT) or 0)

--- a/scripts/clip_previews.sh
+++ b/scripts/clip_previews.sh
@@ -1,14 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
+RUN_DIR="${RUN_DIR:-}"
+if [ -z "$RUN_DIR" ]; then echo "RUN_DIR: Set RUN_DIR to a pipeline output game dir"; exit 1; fi
 
-if [[ -z "${RUN_DIR:-}" ]]; then
-  echo "RUN_DIR: Set RUN_DIR to a pipeline output game dir"
-  exit 1
-fi
+echo "First few clips:"
+ls -1 "$RUN_DIR"/clips/*/*.mp4 | head -n 10 || true
 
-shopt -s nullglob
-for c in "${RUN_DIR}"/clips/*/*.mp4; do
-  out="${c%.mp4}.gif"
-  ffmpeg -y -i "$c" -t 3 -vf "fps=10,scale=512:-1" "$out"
+# Optional quick GIF previews (3s each)
+for c in "$RUN_DIR"/clips/*/*.mp4; do
+  [ -f "$c" ] || continue
+  ffmpeg -y -loglevel error -i "$c" -t 3 -vf "fps=10,scale=512:-1" "${c%.mp4}.gif" || true
 done
-

--- a/scripts/run_utils.sh
+++ b/scripts/run_utils.sh
@@ -2,50 +2,29 @@
 set -euo pipefail
 
 get_run_dir () {
-  # Usage: get_run_dir LOGFILE
-  # Prints the run dir path from a pipeline log (handles quotes and spaces)
   awk '
     $0 ~ /^== Summary ==/ { in_sum=1; next }
     in_sum && $0 ~ /^Run dir:/ {
-      sub(/^Run dir:[[:space:]]*/, "", $0)
-      gsub(/^"|"$/, "", $0)  # strip surrounding quotes if present
-      print $0
-      exit
+      sub(/^Run dir:[[:space:]]*/, "", $0);
+      gsub(/^"|"$/, "", $0); # strip surrounding quotes
+      print $0; exit
     }
   ' "${1:-/dev/stdin}"
 }
 
 check_csv () {
-  # Usage: check_csv RUN_DIR
-  local RUN_DIR="${1:-}"
-  if [[ -z "${RUN_DIR}" || ! -d "${RUN_DIR}" ]]; then
-    echo "Run dir: (invalid)"
-    exit 1
-  fi
-  echo "Run dir: ${RUN_DIR}"
-  local CSV="${RUN_DIR}/plays_index.csv"
-  if [[ ! -f "$CSV" ]]; then
-    echo "❌ Missing plays_index.csv"
-    exit 1
-  fi
-
-  local EXPECTED="play_id,t0,t1,snap,whistle,clip_path,formation,formation_confidence,playcall,play_family,playcall_confidence,outcome,clip_duration"
-  local GOT
-  GOT="$(head -n1 "$CSV" | tr -d '\r')"
-  if [[ "$GOT" != "$EXPECTED" ]]; then
-    echo "⚠️ CSV header is unexpected but proceeding:"
-    echo "Got: $GOT"
-  else
+  local RUN_DIR="$1"
+  local CSV="$RUN_DIR/plays_index.csv"
+  if [ ! -f "$CSV" ]; then echo "❌ no plays_index.csv in $RUN_DIR"; return 1; fi
+  local HDR_NEW='play_id,t0,t1,snap,whistle,clip_path,formation,formation_confidence,playcall,playcall_confidence,play_family,outcome,clip_duration'
+  local HDR_OLD='play_id,t0,t1,snap,whistle,clip_path,formation,formation_confidence,play_family,playcall_confidence,outcome,clip_duration'
+  local HDR_GOT
+  HDR_GOT=$(head -n1 "$CSV")
+  if [ "$HDR_GOT" = "$HDR_NEW" ] || [ "$HDR_GOT" = "$HDR_OLD" ]; then
     echo "✅ CSV header OK"
-  fi
-
-  if [[ $(wc -l < "$CSV") -gt 1 ]]; then
-    echo "✅ CSV has data rows"
   else
-    echo "❌ CSV has no data rows"
+    echo "⚠️ CSV header is unexpected but proceeding:"
+    echo "Got: $HDR_GOT"
   fi
-
-  echo "First few clips:"
-  awk -F, 'NR>1 && $6!="" {print $6}' "$CSV" | head -n 10
+  if [ "$(wc -l < "$CSV")" -gt 1 ]; then echo "✅ CSV has data rows"; else echo "❌ CSV has no data rows"; fi
 }
-

--- a/tools/backfill_from_clips.py
+++ b/tools/backfill_from_clips.py
@@ -1,6 +1,6 @@
 # tools/backfill_from_clips.py
 from __future__ import annotations
-import csv, json, subprocess, sys
+import csv, json, subprocess, sys, os
 from pathlib import Path
 from typing import Any
 from .json_io import iter_jsonl_safe
@@ -116,7 +116,7 @@ def backfill(run_dir: Path) -> int:
     with plays_jsonl.open("w", encoding="utf8") as jf, plays_csv.open(
         "w", newline="", encoding="utf8"
     ) as cf:
-        fieldnames = [
+        PREFERRED = [
             "play_id",
             "t0",
             "t1",
@@ -126,13 +126,36 @@ def backfill(run_dir: Path) -> int:
             "formation",
             "formation_confidence",
             "playcall",
+            "playcall_confidence",
+            "play_family",
+            "outcome",
+            "clip_duration",
+        ]
+        LEGACY = [
+            "play_id",
+            "t0",
+            "t1",
+            "snap",
+            "whistle",
+            "clip_path",
+            "formation",
+            "formation_confidence",
             "play_family",
             "playcall_confidence",
             "outcome",
             "clip_duration",
         ]
-        w = csv.DictWriter(cf, fieldnames=fieldnames)
+        write_legacy = os.getenv("PIPELINE_WRITE_LEGACY_CSV", "0") == "1"
+        w = csv.DictWriter(cf, fieldnames=PREFERRED)
         w.writeheader()
+        legacy_writer = None
+        cf_legacy = None
+        if write_legacy:
+            cf_legacy = (run_dir / "plays_index_legacy.csv").open(
+                "w", newline="", encoding="utf8"
+            )
+            legacy_writer = csv.DictWriter(cf_legacy, fieldnames=LEGACY)
+            legacy_writer.writeheader()
         for pid, mp4 in pairs:
             dur = ffprobe_duration(mp4)
             pred = pred_map.get(pid, {})
@@ -188,29 +211,34 @@ def backfill(run_dir: Path) -> int:
             }
             jf.write(json.dumps(row_json) + "\n")
 
-            w.writerow(
-                {
-                    "play_id": pid,
-                    "t0": t0 if t0 is not None else "",
-                    "t1": t1 if t1 is not None else "",
-                    "snap": existing.get("snap", ""),
-                    "whistle": existing.get("whistle", ""),
-                    "clip_path": str(mp4),
-                    "formation": formation_name,
-                    "formation_confidence": float(formation_conf),
-                    "playcall": playcall_name if playcall_name else "",
-                    "play_family": play_family,
-                    "playcall_confidence": float(playcall_conf),
-                    "outcome": existing.get("outcome", ""),
-                    "clip_duration": clip_duration,
-                }
-            )
+            row = {
+                "play_id": pid,
+                "t0": t0 if t0 is not None else "",
+                "t1": t1 if t1 is not None else "",
+                "snap": existing.get("snap", ""),
+                "whistle": existing.get("whistle", ""),
+                "clip_path": str(mp4),
+                "formation": formation_name,
+                "formation_confidence": float(formation_conf),
+                "playcall": playcall_name if playcall_name else "",
+                "playcall_confidence": float(playcall_conf),
+                "play_family": play_family,
+                "outcome": existing.get("outcome", ""),
+                "clip_duration": clip_duration,
+            }
+            w.writerow({k: row.get(k, "") for k in PREFERRED})
+            if legacy_writer:
+                legacy_row = {k: row.get(k, "") for k in LEGACY}
+                legacy_row["play_family"] = row.get("play_family", "")
+                legacy_writer.writerow(legacy_row)
             print(
                 f"[backfill] play {pid}: formation={formation_name} conf={formation_conf} "
                 f"playcall={playcall_name or ''} conf={playcall_conf}"
             )
             total += 1
 
+    if write_legacy and legacy_writer and cf_legacy:
+        cf_legacy.close()
     print(f"[backfill] wrote {total} plays -> {plays_jsonl} and {plays_csv}")
     return total
 

--- a/tools/run_and_backfill.sh
+++ b/tools/run_and_backfill.sh
@@ -48,10 +48,17 @@ ARGS=(
 (( GEN_REPORT == 1 )) && ARGS+=( --generate-report )
 
 run_main() {
-  if [[ "${GOOGLE_DRIVE_SYNC:-}" == "1" ]]; then
+  if [ "${GOOGLE_DRIVE_SYNC:-0}" != "0" ]; then
     echo "[gdrive] Drive sync ENABLED"
+    if [ -z "${GDRIVE_FOLDER_ID:-}" ]; then
+      echo "[gdrive] WARNING: GDRIVE_FOLDER_ID is not set; skipping Drive upload"
+      DO_DRIVE=0
+    else
+      DO_DRIVE=1
+    fi
   else
     echo "[gdrive] Drive sync DISABLED"
+    DO_DRIVE=0
   fi
 
   (( GEN_CLIPS == 1 )) && ARGS+=( --generate-clips )
@@ -78,14 +85,12 @@ PY
   echo "== Summary =="
   echo "Run dir: \"$RUN_DIR\""
 
-  if [[ "${GOOGLE_DRIVE_SYNC:-}" == "1" ]]; then
-    if [[ -f "$RUN_DIR/plays_index.csv" ]]; then
+  if [ "$DO_DRIVE" -eq 1 ]; then
+    if [ -f "$RUN_DIR/plays_index.csv" ]; then
       echo "[gdrive] uploading $RUN_DIR/plays_index.csv"
-      if python3 upload_to_drive.py "$RUN_DIR/plays_index.csv"; then
-        echo "[gdrive] upload OK"
-      else
+      python3 tools/upload_to_drive.py --folder-id "$GDRIVE_FOLDER_ID" "$RUN_DIR/plays_index.csv" || {
         echo "[gdrive] upload FAILED"
-      fi
+      }
     else
       echo "[gdrive] nothing to upload"
     fi


### PR DESCRIPTION
## Summary
- Re-probe video FPS via ffprobe when OpenCV reports unrealistic values.
- Emit top-k play classification candidates with fallback handling and new CSV schema support.
- Gracefully handle optional Drive sync and add helper scripts for run dir and clip previews.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68adcb17fd68832d887ec696986bf51e