### PR TITLE
Refine Gameday pipeline classification and helpers

### DIFF
--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -24,6 +24,10 @@ from tools.storage_cleanup import ensure_min_free_space
 DEFAULT_MIN_PLAY_GAP = 1.5
 DEFAULT_MIN_PLAY_LEN = 6.0
 
+# Play classifier thresholds
+HARD_MIN = 0.35
+TOP1_MIN = 0.55
+
 # Optional shared config; fall back to internal defaults if missing
 try:
     from analysis.config import PROFILE_DEFAULTS as _PROFILE_DEFAULTS  # type: ignore
@@ -51,14 +55,17 @@ try:  # pragma: no cover
 except Exception:  # pragma: no cover
     cv2 = None  # type: ignore
 
-from .segmentation import segment_video
-from . import detect_track, features, orientation, zoom
-from formation_detector import detect_formation
+from analysis.segmentation import segment_video
+from analysis import detect_track, features, orientation, zoom
+try:
+    from analysis.formation_detector import detect_formation
+except Exception:  # fallback for standalone module
+    from formation_detector import detect_formation  # type: ignore
 from fnmatch import fnmatch
 from playbooks import load_offense_playbook
-from .playbook.schema import validate_playbook
+from analysis.playbook.schema import validate_playbook
 from analysis.classifier import model_predict_candidates, FORMATION_FAMILY_PRIOR
-from analysis.classification import postprocess_playcall
+from analysis.play_classifier import normalize_label, FAMILY
 
 
 # ---------------------------------------------------------------------------
@@ -203,7 +210,7 @@ def _run_pipeline(args: argparse.Namespace) -> None:
     name_to_family = {p.name: p.family or p.name for p in pb.plays.values()} if pb else {}
 
     def derive_family(name: str) -> str:
-        return name_to_family.get(name, "")
+        return name_to_family.get(name, FAMILY.get(name, ""))
     print(
         f"[config] min_play_length={args.min_play_length} min_play_gap={args.min_play_gap} "
         f"report={args.generate_report} clips={args.generate_clips} highlights={args.generate_highlights} overlay={getattr(args, 'make_overlay', getattr(args, 'overlay', False))}"
@@ -291,23 +298,34 @@ def _run_pipeline(args: argparse.Namespace) -> None:
                 for c in candidates_raw
                 if (c.get("family") in families_ok or c.get("name") in families_ok)
             ]
+        for c in candidates_raw:
+            c["name"] = normalize_label(c.get("name", ""))
         total_score = sum(max(c["score"], 0.0) for c in candidates_raw) or 1.0
         pred_dist = sorted(
             [(c["name"], c["score"] / total_score) for c in candidates_raw],
             key=lambda x: x[1],
             reverse=True,
         )
-        play_name, play_conf, candidates = postprocess_playcall(pred_dist)
+        candidates = [
+            {"name": n, "confidence": float(p)} for n, p in pred_dist[:3]
+        ]
+        top_name, top_score = pred_dist[0] if pred_dist else ("Unknown", 0.0)
+        play_name = "Unknown"
+        play_conf = 0.0
+        if top_score >= TOP1_MIN:
+            play_name, play_conf = top_name, top_score
+        elif top_score >= HARD_MIN:
+            play_name, play_conf = top_name, top_score
         play_family = derive_family(play_name) if play_name != "Unknown" else ""
-        cand_str = ", ".join([
-            f'{c["name"]}:{c["confidence"]:.2f}' for c in candidates
-        ])
+        cand_str = ", ".join(
+            [f"{c['name']}:{c['confidence']:.2f}" for c in candidates]
+        )
         if play_name == "Unknown":
             print(f"[play_classifier] {seg_id}: Unknown conf=0.00")
-            if cand_str:
-                print(f"[play_classifier:candidates] {seg_id}: {cand_str}")
         else:
             print(f"[play_classifier] {seg_id}: {play_name} conf={play_conf:.2f}")
+        if cand_str:
+            print(f"[play_classifier:candidates] {seg_id}: {cand_str}")
 
         playcall_dict = {
             "name": play_name,
@@ -334,6 +352,13 @@ def _run_pipeline(args: argparse.Namespace) -> None:
         clip_out.parent.mkdir(parents=True, exist_ok=True)
         export_clip(args.video, clip_start, clip_end, clip_out, rotation)
 
+        outcome = {
+            "yards": 0,
+            "success": False,
+            "explosive": False,
+            "turnover": False,
+            "penalty": False,
+        }
         play_rec = {
             "play_id": seg_id,
             "clip_path": str(clip_out),
@@ -343,13 +368,7 @@ def _run_pipeline(args: argparse.Namespace) -> None:
             "formation_confidence": float(formation_conf),
             "playcall": playcall_dict,
             "play_family": play_family,
-            "outcome": {
-                "yards": 0,
-                "success": False,
-                "explosive": False,
-                "turnover": False,
-                "penalty": False,
-            },
+            "outcome": outcome,
             "cues": {},
             "clip_duration": float(clip_duration),
         }
@@ -365,9 +384,9 @@ def _run_pipeline(args: argparse.Namespace) -> None:
             "formation": formation_name,
             "formation_confidence": formation_conf,
             "playcall": play_name,
-            "playcall_confidence": float(play_conf or 0.0),
             "play_family": play_family,
-            "outcome": "",
+            "playcall_confidence": float(play_conf or 0.0),
+            "outcome": json.dumps(outcome, separators=(",",":")),
             "clip_duration": float(clip_duration),
         }
         plays_index.append(row)
@@ -391,8 +410,8 @@ def _run_pipeline(args: argparse.Namespace) -> None:
         "formation",
         "formation_confidence",
         "playcall",
-        "playcall_confidence",
         "play_family",
+        "playcall_confidence",
         "outcome",
         "clip_duration",
     ]

--- a/analysis/play_classifier.py
+++ b/analysis/play_classifier.py
@@ -1,15 +1,38 @@
-DEFAULT_MIN_CONF = 0.35
-TOPK=3
 from __future__ import annotations
+
+HARD_MIN = 0.35
+TOP1_MIN = 0.55
+TOPK = 3
 
 """Lightweight play classifier with caching and heuristics."""
 
 from pathlib import Path
 from typing import Dict, Any
 import os
-
-
 import re
+
+ALIASES = {
+    "leo_f_stick": "Leo F Stick",
+    "leo-stick": "Leo F Stick",
+    "lit_jet_sweep": "Lit Jet Sweep",
+    "rit_jet_sweep": "Rit Jet Sweep",
+    "rit_8_option": "Rit 8 Option",
+    "flare_boot_rit": "Rit Flare Boot",
+    "f_screen_rit": "Rit F Screen",
+}
+
+FAMILY = {
+    "Leo F Stick": "F Stick",
+    "Rit Jet Sweep": "Jet Sweep",
+    "Lit Jet Sweep": "Jet Sweep",
+    "Rit Flare Boot": "Boot",
+    "Rit F Screen": "Screen",
+    "Rit 8 Option": "Option",
+}
+
+def normalize_label(s: str) -> str:
+    key = s.strip().lower().replace(" ", "_").replace("-", "_")
+    return ALIASES.get(key, s.strip())
 def _norm_name(x:str)->str:
     x = x.lower().strip()
     x = re.sub(r'[^a-z0-9]+', ' ', x)
@@ -169,7 +192,7 @@ class PlayClassifier:
         }
 
 
-__all__ = ["PlayClassifier"]
+__all__ = ["PlayClassifier", "normalize_label", "FAMILY", "HARD_MIN", "TOP1_MIN"]
 
 
 def build_playbook_index(playbook)->dict:

--- a/analysis/segmentation.py
+++ b/analysis/segmentation.py
@@ -1,29 +1,14 @@
 from dataclasses import dataclass
 from typing import List, Dict
+import json
+import math
+import subprocess
 import numpy as np
-import subprocess, json, shlex
 
 try:  # pragma: no cover
     import cv2
 except Exception:  # pragma: no cover
     cv2 = None  # type: ignore
-
-
-def _probe_fps_ffprobe(path: str) -> float:
-    try:
-        cmd = (
-            f'ffprobe -v error -select_streams v:0 -show_entries stream=r_frame_rate '
-            f'-of json {shlex.quote(path)}'
-        )
-        out = subprocess.check_output(cmd, shell=True).decode("utf-8", "ignore")
-        data = json.loads(out)
-        rate = data["streams"][0].get("r_frame_rate", "0/1")
-        num, den = rate.split("/")
-        num, den = float(num), float(den)
-        return num / den if den else 0.0
-    except Exception as e:
-        print(f"[ffprobe] failed to probe fps: {e}")
-        return 0.0
 
 
 @dataclass
@@ -67,15 +52,32 @@ def segment_video(
         raise FileNotFoundError(f"Cannot open video: {path}")
 
     fps = cap.get(cv2.CAP_PROP_FPS) or 0.0
-
-    if not fps or fps < 5 or fps > 240:
-        print(f"[video] OpenCV fps={fps} looks wrong; reprobing via ffprobe…")
-        fps2 = _probe_fps_ffprobe(path)
-        if fps2 > 1:
-            print(f"[video] using ffprobe fps={fps2}")
-            fps = fps2
-        else:
-            print("[video] ffprobe also failed; keeping OpenCV fps")
+    if (not math.isfinite(fps)) or fps < 1.0:
+        try:
+            probe = subprocess.run(
+                [
+                    "ffprobe",
+                    "-v",
+                    "error",
+                    "-select_streams",
+                    "v:0",
+                    "-show_entries",
+                    "stream=r_frame_rate",
+                    "-of",
+                    "json",
+                    path,
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            r = json.loads(probe.stdout)["streams"][0]["r_frame_rate"]
+            num, den = (int(x) for x in r.split("/"))
+            fps = num / den if den else 30.0
+            print(f"[video_profile] ffprobe fallback FPS={fps:.2f}")
+        except Exception as e:
+            print(f"[video_profile] ffprobe fallback failed: {e}; defaulting to 30")
+            fps = 30.0
 
     W = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH) or 0)
     H = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT) or 0)

--- a/scripts/run_utils.sh
+++ b/scripts/run_utils.sh
@@ -1,78 +1,66 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Usage:
-#   scripts/run_utils.sh get_run_dir /path/to/log
-#   scripts/run_utils.sh check_csv   /path/to/run_dir
-#   scripts/run_utils.sh clip_previews /path/to/run_dir  [seconds=3]
+usage() {
+  cat <<USG
+Usage:
+  scripts/run_utils.sh get_run_dir /path/to/pipeline.log
+  scripts/run_utils.sh check_csv /path/to/run_dir
+  scripts/run_utils.sh clip_previews /path/to/run_dir [seconds=3]
+USG
+}
 
-cmd="${1:-}"; shift || true
-
-get_run_dir () {
-  local log="${1:-}"
-  [ -f "$log" ] || { echo "Log not found: $log" >&2; exit 2; }
-  # Accept both: Run dir: /path..  and Run dir: "/path with spaces"
+get_run_dir() {
+  local log="$1"
   awk '
-    BEGIN{found=0}
     $0 ~ /^== Summary ==/ { in_sum=1; next }
     in_sum && $0 ~ /^Run dir:/ {
-      found=1
-      sub(/^Run dir:[[:space:]]*/, "", $0)
-      gsub(/^"/, "", $0); gsub(/"$/, "", $0)
+      sub(/^Run dir:[[:space:]]*"/,"",$0); sub(/"$/,"",$0);
       print $0; exit
     }
-    END{ if(!found) exit 3 }
   ' "$log"
 }
 
-check_csv () {
-  local run_dir="${1:-}"
-  [ -n "${run_dir:-}" ] && [ -d "$run_dir" ] || { echo "RUN_DIR: Set RUN_DIR to a pipeline output game dir" >&2; exit 2; }
-  local csv="$run_dir/plays_index.csv"
-  [ -f "$csv" ] || { echo "❌ plays_index.csv missing in $run_dir" >&2; exit 3; }
-  local hdr got
-  hdr="play_id,t0,t1,snap,whistle,clip_path,formation,formation_confidence,playcall,playcall_confidence,play_family,outcome,clip_duration"
+check_csv() {
+  local rd="$1"
+  [[ -d "$rd" ]] || { echo "RUN_DIR does not exist: $rd" >&2; exit 2; }
+  local csv="$rd/plays_index.csv"
+  [[ -f "$csv" ]] || { echo "❌ missing plays_index.csv in $rd"; exit 2; }
+
+  local expect="play_id,t0,t1,snap,whistle,clip_path,formation,formation_confidence,playcall,play_family,playcall_confidence,outcome,clip_duration"
+  local got
   got="$(head -n1 "$csv" | tr -d '\r')"
 
-  if [ "$got" = "$hdr" ]; then
+  if [[ "$got" == "$expect" ]]; then
     echo "✅ CSV header OK"
   else
-    # Back-compat: accept older header (missing playcall) and warn
-    legacy="play_id,t0,t1,snap,whistle,clip_path,formation,formation_confidence,play_family,playcall_confidence,outcome,clip_duration"
-    if [ "$got" = "$legacy" ]; then
-      echo "⚠️ CSV header is legacy (no playcall). Proceeding."
-    else
-      echo "⚠️ CSV header is unexpected but proceeding:"
-      echo "Got: $got"
-    fi
+    echo "⚠️ CSV header is unexpected but proceeding:"
+    echo "Got: $got"
   fi
 
-  # Quick sanity: at least one data row
-  if [ "$(wc -l < "$csv")" -gt 1 ]; then
+  if [[ "$(wc -l < "$csv")" -gt 1 ]]; then
     echo "✅ CSV has data rows"
+    echo "First few clips:"
+    awk -F, 'NR>1 && $6!="" {print $6}' "$csv" | head -n 10
   else
-    echo "❌ CSV has no data rows"; exit 4
+    echo "❌ $csv has no data rows"
+    exit 2
   fi
-
-  # Show a few clips if present
-  echo "First few clips:"
-  find "$run_dir/clips" -type f -name '*.mp4' | sort | head -10
 }
 
-clip_previews () {
-  local run_dir="${1:-}"; local dura="${2:-3}"
-  [ -d "$run_dir" ] || { echo "RUN_DIR: Set RUN_DIR to a pipeline output game dir" >&2; exit 2; }
-  command -v ffmpeg >/dev/null || { echo "ffmpeg not found"; exit 5; }
+clip_previews() {
+  local rd="$1"; local secs="${2:-3}"
+  [[ -d "$rd" ]] || { echo "RUN_DIR does not exist: $rd" >&2; exit 2; }
   shopt -s nullglob
-  for c in "$run_dir"/clips/*/*.mp4; do
-    ffmpeg -y -loglevel error -i "$c" -t "$dura" -vf "fps=10,scale=512:-1" "${c%.mp4}.gif" || true
+  for mp4 in "$rd"/clips/*/*.mp4; do
+    ffmpeg -y -i "$mp4" -t "$secs" -vf "fps=10,scale=512:-1" "${mp4%.mp4}.gif" >/dev/null 2>&1 || true
   done
   echo "GIF previews written next to each clip."
 }
 
-case "$cmd" in
-  get_run_dir)    get_run_dir "$@";;
-  check_csv)      check_csv "$@";;
-  clip_previews)  clip_previews "$@";;
-  *) echo "Usage: $0 {get_run_dir LOG|check_csv RUN_DIR|clip_previews RUN_DIR [seconds]}"; exit 1;;
-esac
+case "${1:-}" in
+  get_run_dir)    shift; get_run_dir "$@";;
+  check_csv)      shift; check_csv "$@";;
+  clip_previews)  shift; clip_previews "$@";;
+  *) usage; exit 2;;
+fi

--- a/tools/gdrive_sync.sh
+++ b/tools/gdrive_sync.sh
@@ -1,22 +1,27 @@
 #!/usr/bin/env bash
 set -euo pipefail
-# Env:
-#   GOOGLE_DRIVE_SYNC=1 to enable
-#   GOOGLE_APPLICATION_CREDENTIALS=/path/key.json
-#   GDRIVE_FOLDER_ID=folderid
-#   TOOLS_UPLOAD=tools/upload_to_drive.py
-if [ "${GOOGLE_DRIVE_SYNC:-0}" != "1" ]; then echo "[gdrive] Drive sync DISABLED"; exit 0; fi
-echo "[gdrive] Drive sync ENABLED"
 
-TOOLS_UPLOAD="${TOOLS_UPLOAD:-tools/upload_to_drive.py}"
-if [ ! -f "$TOOLS_UPLOAD" ]; then
-  echo "[gdrive] uploader script missing ($TOOLS_UPLOAD); skipping"; exit 0
-fi
-if [ -z "${GDRIVE_FOLDER_ID:-}" ]; then
-  echo "[gdrive] GDRIVE_FOLDER_ID not set; skipping"; exit 0
-fi
-if [ -z "${GOOGLE_APPLICATION_CREDENTIALS:-}" ] || [ ! -f "${GOOGLE_APPLICATION_CREDENTIALS:-/nope}" ]; then
-  echo "[gdrive] creds missing; skipping"; exit 0
+files=( "$@" )
+echo "[gdrive] Drive sync ${GOOGLE_DRIVE_SYNC:+ENABLED:- DISABLED}"
+if [[ "${GOOGLE_DRIVE_SYNC:-}" != "1" ]]; then
+  echo "[gdrive] Drive sync DISABLED"; exit 0
 fi
 
-python3 "$TOOLS_UPLOAD" --folder-id "$GDRIVE_FOLDER_ID" "$@"
+if [[ -z "${GDRIVE_FOLDER_ID:-}" ]]; then
+  echo "[gdrive] missing GDRIVE_FOLDER_ID; skipping"; exit 0
+fi
+
+UPLOADER="${TOOLS_UPLOAD:-tools/upload_to_drive.py}"
+if [[ ! -f "$UPLOADER" ]]; then
+  echo "[gdrive] uploader script missing ($UPLOADER); skipping"; exit 0
+fi
+
+if [[ ! -f "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
+  echo "[gdrive] GOOGLE_APPLICATION_CREDENTIALS missing; skipping"; exit 0
+fi
+
+for f in "${files[@]}"; do
+  [[ -f "$f" ]] || continue
+  echo "[gdrive] uploading $f"
+  python3 "$UPLOADER" --folder-id "$GDRIVE_FOLDER_ID" "$f" || echo "[gdrive] upload FAILED for $f"
+done

--- a/tools/run_and_backfill.sh
+++ b/tools/run_and_backfill.sh
@@ -1,46 +1,51 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-LOG="${LOG:-/tmp/pipeline_$(date +%s).log}"
+VIDEO=""
+TEAM=""
+PLAYBOOK=""
+OUT=""
+MIN_GAP="1.5"
+MIN_LEN="3.0"
+GEN_REPORT=0
+GEN_CLIPS=0
+LOG="${LOG:-}"
 
-print_usage(){ cat <<USAGE
-Usage:
-  $0 --video FILE --team TEAM --playbook FILE --out DIR [--min-play-gap S] [--min-play-length S] [--generate-report] [--generate-clips]
-Environment:
-  LOG=/path/to/log (optional; defaults to /tmp/pipeline_*.log)
-USAGE
-}
-
-# Parse args
-VIDEO=""; TEAM=""; PLAYBOOK=""; OUT=""
-MIN_GAP="1.5"; MIN_LEN="3.0"; GEN_REP=0; GEN_CLIP=0
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --video) VIDEO="$2"; shift 2;;
-    --team) TEAM="$2"; shift 2;;
-    --playbook) PLAYBOOK="$2"; shift 2;;
-    --out) OUT="$2"; shift 2;;
-    --min-play-gap) MIN_GAP="$2"; shift 2;;
-    --min-play-length) MIN_LEN="$2"; shift 2;;
-    --generate-report) GEN_REP=1; shift;;
-    --generate-clips)  GEN_CLIP=1; shift;;
-    *) echo "Unknown arg: $1"; print_usage; exit 1;;
+    --video) VIDEO="$2"; shift 2 ;;
+    --team) TEAM="$2"; shift 2 ;;
+    --playbook) PLAYBOOK="$2"; shift 2 ;;
+    --out) OUT="$2"; shift 2 ;;
+    --min-play-gap) MIN_GAP="$2"; shift 2 ;;
+    --min-play-length) MIN_LEN="$2"; shift 2 ;;
+    --generate-report) GEN_REPORT=1; shift ;;
+    --generate-clips) GEN_CLIPS=1; shift ;;
+    --log) LOG="$2"; shift 2 ;;
+    *) echo "Unknown arg: $1" >&2; exit 2 ;;
   esac
 done
-[ -n "$VIDEO" ] || { echo "ERROR: --video required"; print_usage; exit 2; }
-[ -n "$TEAM" ] || { echo "ERROR: --team required";  print_usage; exit 2; }
-[ -n "$PLAYBOOK" ] || { echo "ERROR: --playbook required"; print_usage; exit 2; }
-[ -n "$OUT" ] || { echo "ERROR: --out required"; print_usage; exit 2; }
 
-# Run pipeline
-PYTHONPATH=. python3 analysis/pipeline.py \
-  --video "$VIDEO" --team "$TEAM" --playbook "$PLAYBOOK" --out "$OUT" \
-  --min-play-gap "$MIN_GAP" --min-play-length "$MIN_LEN" \
-  $( [ $GEN_REP  -eq 1 ] && echo --generate-report ) \
-  $( [ $GEN_CLIP -eq 1 ] && echo --generate-clips ) \
-  2>&1 | tee "$LOG"
+[[ -n "$VIDEO" ]] || { echo "VIDEO: --video required" >&2; exit 2; }
+[[ -n "$TEAM" ]] || { echo "TEAM: --team required" >&2; exit 2; }
+[[ -n "$PLAYBOOK" ]] || { echo "PLAYBOOK: --playbook required" >&2; exit 2; }
+[[ -n "$OUT" ]] || { echo "OUT: --out required" >&2; exit 2; }
 
-# Extract and echo run dir robustly
-RUN_DIR="$(scripts/run_utils.sh get_run_dir "$LOG" || true)"
-echo '== Summary =='
-echo "Run dir: \"${RUN_DIR}\""
+export PYTHONPATH="${PYTHONPATH:-.}"
+
+cmd=( python3 -m analysis.pipeline
+  --video "$VIDEO"
+  --team "$TEAM"
+  --playbook "$PLAYBOOK"
+  --out "$OUT"
+  --min-play-gap "$MIN_GAP"
+  --min-play-length "$MIN_LEN"
+)
+[[ "$GEN_REPORT" == "1" ]] && cmd+=( --generate-report )
+[[ "$GEN_CLIPS" == "1" ]] && cmd+=( --generate-clips )
+
+if [[ -n "${LOG}" ]]; then
+  "${cmd[@]}" | tee "$LOG"
+else
+  "${cmd[@]}"
+fi


### PR DESCRIPTION
## Summary
- normalize playcall labels, apply thresholds, and track play families
- add ffprobe-based FPS fallback and JSON outcome rows
- overhaul helper scripts for running, checking, and Drive sync

## Testing
- `pytest`
- `pytest tests/test_pipeline_smoke.py`


------
https://chatgpt.com/codex/tasks/task_e_68ade3762c18832db9f24396be52d279