### PR TITLE
Improve analysis pipeline and helper scripts

### DIFF
--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -1,1 +1,1 @@
-# analysis package marker
+# makes analysis a package

--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -1,18 +1,15 @@
 from __future__ import annotations
-import os, sys, json, argparse, pathlib, time
-from dataclasses import dataclass, asdict
 
-# --- import guard so this works as script or module ---
-if __package__ is None or __package__ == '':
-    # Running as script: add repo root so "analysis.*" works
-    repo_root = pathlib.Path(__file__).resolve().parents[1]
-    sys.path.insert(0, str(repo_root))
-    # Now we can import analysis.* with absolute package names
-    from analysis.play_classifier import classify_plays
-    from analysis.segmentation import segment_video
-else:
+try:
+    # normal, when run via `python -m analysis.pipeline`
     from .play_classifier import classify_plays
     from .segmentation import segment_video
+except Exception:
+    # fallback when run as script or when PYTHONPATH is set to repo root
+    from analysis.play_classifier import classify_plays  # type: ignore
+    from analysis.segmentation import segment_video       # type: ignore
+
+import os, json, argparse, pathlib
 
 CSV_HEADER = [
     "play_id","t0","t1","snap","whistle","clip_path",
@@ -67,7 +64,7 @@ def main(argv=None):
     print(f"[pipeline] segments detected: {len(segments)}")
 
     # Step 2: classify (returns list of per-play dicts with keys including candidates[])
-    plays = classify_plays(segments, playbook=playbook, video_profile=None)
+    plays = classify_plays(segments)
 
     # Normalize rows for CSV, and build report with candidates
     csv_rows = []
@@ -88,14 +85,38 @@ def main(argv=None):
         csv_rows.append(row)
         # Put candidates + all fields in report
         rp = dict(p)
-        rp["playcall_candidates"] = p.get("candidates", [])  # ensure present
+        rp["candidates"] = p.get("candidates", [])  # ensure present
         report["plays"].append(rp)
 
     # Write outputs
     plays_csv = game_dir / "plays_index.csv"
-    report_json = game_dir / "report.json"
     write_csv(csv_rows, plays_csv)
-    write_json(report, report_json)
+    if args.generate_report:
+        report_json = game_dir / "report.json"
+        write_json(report, report_json)
+
+    # Optional clip generation
+    if args.generate_clips:
+        import subprocess, csv as _csv
+        clips_dir = os.path.join(game_dir, "clips")
+        os.makedirs(clips_dir, exist_ok=True)
+
+        with open(plays_csv, "r", newline="") as f:
+            reader = _csv.DictReader(f)
+            for row in reader:
+                play_id = row["play_id"]
+                t0 = float(row["t0"])
+                t1 = float(row["t1"])
+                src = args.video
+                out_dir = os.path.join(clips_dir, play_id)
+                os.makedirs(out_dir, exist_ok=True)
+                out_mp4 = os.path.join(out_dir, f"{play_id}.mp4")
+                if not os.path.exists(out_mp4):
+                    subprocess.run([
+                        "ffmpeg", "-y", "-hide_banner", "-loglevel", "error",
+                        "-ss", f"{t0}", "-to", f"{t1}", "-i", src,
+                        "-c:v", "libx264", "-pix_fmt", "yuv420p", "-an", out_mp4
+                    ], check=True)
     print(f"[pipeline] run complete -> {game_dir}")
     return 0
 

--- a/analysis/play_classifier.py
+++ b/analysis/play_classifier.py
@@ -1,57 +1,79 @@
-from __future__ import annotations
-import math, random
+from typing import Dict, List, Any, Tuple
 
-MIN_PLAYCALL_CONF = float(os.environ.get("MIN_PLAYCALL_CONF", "0.5")) if "os" in globals() else 0.5
-try:
-    import os
-except:
-    import os
+UNKNOWN_THRESH = 0.45           # below this => "Unknown"
+FORMATION_BOOST = 1.10          # light bump for formation-compatible plays
+MAX_CANDIDATES = 5
 
-def _softmax(scores, temperature: float = 1.0):
-    exps = [math.exp(s / max(1e-6, temperature)) for s in scores]
-    s = sum(exps) or 1.0
-    return [e / s for e in exps]
+# Example lookup of which plays are compatible with which formations.
+# Expand as needed; unknown formations won't filter.
+FORMATION_PLAY_FILTER: Dict[str, List[str]] = {
+    "Trips Left":  ["Leo F Stick","Lit Jet Sweep","Lit Flare Boot","Lit F Screen","Lit 8 Option"],
+    "Trips Right": ["Rit Jet Sweep","Rit Flare Boot","Rit F Screen","Rit 8 Option","Leo F Stick"],
+}
 
-def _topk(candidates, k=3):
-    return sorted(candidates, key=lambda x: x[1], reverse=True)[:k]
 
-def classify_plays(segments, playbook, video_profile=None):
+def _model_scores_for_segment(seg: Dict[str, Any]) -> List[Tuple[str, float]]:
     """
-    Return a list of dicts:
-      play_id, t0, t1, snap, whistle, clip_path, formation, formation_confidence,
-      play_family, playcall_confidence, outcome, clip_duration, candidates=[(name,prob),...]
+    Return [(play_name, score_0to1), ...] sorted desc. 
+    Replace this stub with the real model call as appropriate.
     """
-    plays_def = playbook.get("plays", [])
-    known_names = [p.get("name", "") for p in plays_def]
+    # If you already have model outputs on the segment, adapt here.
+    # But always normalize to 0..1 floats and sort desc.
+    raw = seg.get("_model_logits") or []
+    pairs = [(name, float(score)) for name, score in raw]
+    pairs.sort(key=lambda x: x[1], reverse=True)
+    return pairs
 
-    results = []
+
+def _rescore_by_formation(cands: List[Tuple[str, float]], formation: str) -> List[Tuple[str, float]]:
+    if not cands:
+        return cands
+    legal = set(FORMATION_PLAY_FILTER.get(formation or "", []))
+    rescored: List[Tuple[str, float]] = []
+    for name, score in cands:
+        bump = FORMATION_BOOST if name in legal else 1.0
+        rescored.append((name, min(1.0, score * bump)))
+    rescored.sort(key=lambda x: x[1], reverse=True)
+    return rescored
+
+
+def classify_plays(segments: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """
+    For each detected segment, return a dict with:
+      - 'play_family': str (or 'Unknown')
+      - 'playcall_confidence': float in [0,1]
+      - 'candidates': list of {'name': str, 'score': float}
+    Safe under empty/low-confidence outputs.
+    """
+    results: List[Dict[str, Any]] = []
     for i, seg in enumerate(segments, start=1):
-        # Dummy features -> demo probabilities (replace with real model as available)
-        base_scores = [random.random() for _ in known_names]
-        probs = _softmax(base_scores, temperature=0.8)
-        candidates = list(zip(known_names, probs))
-        top = _topk(candidates, 3)
+        formation = seg.get("formation") or ""
+        cands = _model_scores_for_segment(seg)
+        cands = _rescore_by_formation(cands, formation)
 
-        top_name, top_prob = (top[0] if top else ("Unknown", 0.0))
+        # truncate + standardize candidate objects
+        cand_objs = [{"name": n, "score": float(s)} for n, s in cands[:MAX_CANDIDATES]]
 
-        # Unknown fallback
-        play_family = top_name if top_prob >= MIN_PLAYCALL_CONF else "Unknown"
-        playcall_conf = float(top_prob if play_family != "Unknown" else 0.0)
+        top_name, top_score = ("Unknown", 0.0)
+        if cand_objs:
+            top_name, top_score = cand_objs[0]["name"], cand_objs[0]["score"]
 
-        results.append({
-            "play_id": f"PLAY_{i:03d}",
+        play_family = top_name if top_score >= UNKNOWN_THRESH else "Unknown"
+
+        result: Dict[str, Any] = {
+            "play_id": seg.get("play_id") or seg.get("id") or f"PLAY_{i:03d}",
             "t0": seg.get("t0", 0.0),
             "t1": seg.get("t1", 0.0),
-            "snap": seg.get("snap", None),
-            "whistle": seg.get("whistle", None),
+            "snap": seg.get("snap"),
+            "whistle": seg.get("whistle"),
             "clip_path": seg.get("clip_path", ""),
-            "formation": seg.get("formation", "Unknown"),
-            "formation_confidence": seg.get("formation_confidence", 0.0),
+            "formation": formation or "Unknown",
+            "formation_confidence": float(seg.get("formation_confidence", 0.0)),
             "play_family": play_family,
-            "playcall_confidence": playcall_conf,
+            "playcall_confidence": float(top_score),
             "outcome": seg.get("outcome", ""),
-            "clip_duration": round(max(0.0, seg.get("t1", 0.0) - seg.get("t0", 0.0)), 3),
-            "candidates": [(n, round(float(p), 3)) for (n, p) in top],
-        })
+            "clip_duration": float(seg.get("clip_duration", max(0.0, (seg.get("t1", 0.0) or 0.0) - (seg.get("t0", 0.0) or 0.0)))),
+            "candidates": cand_objs,
+        }
+        results.append(result)
     return results
-

--- a/scripts/run_utils.sh
+++ b/scripts/run_utils.sh
@@ -10,51 +10,72 @@ Usage:
 EOF
 }
 
-if [[ $# -lt 1 ]]; then usage; exit 1; fi
-cmd="${1:-}"; shift || true
+get_run_dir() {
+  local log="${1:-}"
+  [[ -f "$log" ]] || { echo "could not extract run dir from $log"; return 1; }
+  # Look for: "[pipeline] run complete -> /path..."
+  local path
+  path="$(grep -oE '\[pipeline\] run complete -> .*' "$log" | tail -n1 | sed -E 's/.* -> //')"
+  [[ -n "${path:-}" && -d "$path" ]] || { echo "could not extract run dir from $log"; return 1; }
+  echo "$path"
+}
 
-case "$cmd" in
-  get_run_dir)
-    log="${1:-}"
-    [[ -z "${log}" || ! -f "${log}" ]] && { echo 'Run dir: '; exit 0; }
-    rd=$(grep -oE '\[pipeline\] run complete -> .*' "$log" | tail -n1 | sed 's/.*-> //')
-    [[ -z "${rd}" ]] && { echo 'Run dir: '; exit 0; }
-    echo "Run dir: ${rd}"
-    ;;
-  check_csv)
-    run_dir="${1:-}"; [[ -z "${run_dir}" || ! -d "${run_dir}" ]] && { echo "run_dir required"; exit 1; }
-    csv="${run_dir}/plays_index.csv"
-    if [[ ! -f "$csv" ]]; then
-      echo "❌ plays_index.csv missing"; exit 1
-    fi
-    header=$(head -n1 "$csv")
-    expected="play_id,t0,t1,snap,whistle,clip_path,formation,formation_confidence,play_family,playcall_confidence,outcome,clip_duration"
-    if [[ "$header" == "$expected" ]]; then
+check_csv() {
+  local run_dir="${1:-}"
+  [[ -n "${run_dir:-}" && -d "$run_dir" ]] || { echo "run_dir required"; return 1; }
+  local csv="$run_dir/plays_index.csv"
+  [[ -f "$csv" ]] || { echo "❌ no plays_index.csv in $run_dir"; return 1; }
+
+  # Accept either strict or extended header; warn if unexpected
+  local header
+  header="$(head -n1 "$csv")"
+  case "$header" in
+    "play_id,t0,t1,snap,whistle,clip_path,formation,formation_confidence,play_family,playcall_confidence,outcome,clip_duration")
       echo "✅ CSV header OK"
-    else
+      ;;
+    *)
       echo "⚠️ CSV header is unexpected but proceeding:"
       echo "Got: $header"
-    fi
-    if [[ $(wc -l < "$csv") -gt 1 ]]; then
-      echo "✅ CSV has data rows"
-    else
-      echo "❌ CSV empty"
-      exit 1
-    fi
-    echo "First few clips:"
-    find "$run_dir/clips" -type f -name '*.mp4' | head -n 10
-    ;;
-  clip_previews)
-    run_dir="${1:-}"; secs="${2:-3}"
-    [[ -z "${run_dir}" || ! -d "${run_dir}" ]] && { echo "RUN_DIR: Set RUN_DIR to a pipeline output game dir"; exit 1; }
-    while IFS= read -r mp4; do
-      gif="${mp4%.mp4}.gif"
-      mkdir -p "$(dirname "$gif")"
-      ffmpeg -y -hide_banner -loglevel error -t "$secs" -i "$mp4" -vf "fps=10,scale=512:-1:flags=lanczos" "$gif" || true
-    done < <(find "$run_dir/clips" -type f -name '*.mp4' | sort)
-    echo "GIF previews written next to each clip."
-    ;;
-  *)
-    usage; exit 1;;
-esac
+      ;;
+  esac
 
+  # Any data rows?
+  if [[ $(wc -l < "$csv") -gt 1 ]]; then
+    echo "✅ CSV has data rows"
+  else
+    echo "❌ CSV has no data rows"
+    return 1
+  fi
+
+  echo "First few clips:"
+  local clips_dir="$run_dir/clips"
+  if [[ -d "$clips_dir" ]]; then
+    find "$clips_dir" -type f -name '*.mp4' | head -n 10 || true
+  else
+    echo "(no clips directory found at $clips_dir)"
+  fi
+}
+
+clip_previews() {
+  local run_dir="${1:-}"
+  local seconds="${2:-3}"
+  [[ -n "${run_dir:-}" && -d "$run_dir" ]] || { echo "RUN_DIR: Set RUN_DIR to a pipeline output game dir"; return 1; }
+  local clips_dir="$run_dir/clips"
+  [[ -d "$clips_dir" ]] || { echo "No clips dir at $clips_dir"; return 0; }
+  mapfile -t clips < <(find "$clips_dir" -type f -name '*.mp4' | sort)
+  [[ ${#clips[@]} -gt 0 ]] || { echo "No mp4 clips to preview"; return 0; }
+
+  for mp4 in "${clips[@]}"; do
+    local out="${mp4%.mp4}.gif"
+    ffmpeg -y -hide_banner -loglevel error -t "$seconds" -i "$mp4" -vf fps=10,scale=512:-2 "$out" || true
+  done
+  echo "GIF previews written next to each clip."
+}
+
+cmd="${1:-}"
+case "$cmd" in
+  get_run_dir)   shift; get_run_dir "$@";;
+  check_csv)     shift; check_csv "$@";;
+  clip_previews) shift; clip_previews "$@";;
+  *) usage; exit 1;;
+ esac

--- a/tools/gdrive_sync.sh
+++ b/tools/gdrive_sync.sh
@@ -1,19 +1,20 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Usage: tools/gdrive_sync.sh file1 [file2 ...]
+# Respects:
+#   GOOGLE_DRIVE_SYNC=1 to enable
+#   GOOGLE_APPLICATION_CREDENTIALS must point to a json key file
+#   GDRIVE_FOLDER_ID must be set
+#   TOOLS_UPLOAD (python script) must exist
+
 if [[ "${GOOGLE_DRIVE_SYNC:-0}" != "1" ]]; then
   echo "[gdrive] Drive sync DISABLED"
   exit 0
 fi
 
-if [[ -z "${GOOGLE_APPLICATION_CREDENTIALS:-}" || ! -f "${GOOGLE_APPLICATION_CREDENTIALS:-/nope}" ]]; then
+if [[ -z "${GOOGLE_APPLICATION_CREDENTIALS:-}" || ! -f "$GOOGLE_APPLICATION_CREDENTIALS" ]]; then
   echo "[gdrive] missing GOOGLE_APPLICATION_CREDENTIALS; skipping"
-  exit 0
-fi
-
-UPLOADER="${TOOLS_UPLOAD:-tools/upload_to_drive.py}"
-if [[ ! -f "$UPLOADER" ]]; then
-  echo "[gdrive] uploader script missing ($UPLOADER); skipping"
   exit 0
 fi
 
@@ -22,10 +23,11 @@ if [[ -z "${GDRIVE_FOLDER_ID:-}" ]]; then
   exit 0
 fi
 
-echo "[gdrive] Drive sync ENABLED"
-for f in "$@"; do
-  [[ -f "$f" ]] || continue
-  echo "[gdrive] uploading $f"
-  python3 "$UPLOADER" --folder-id "$GDRIVE_FOLDER_ID" "$f" || { echo "[gdrive] upload FAILED"; exit 1; }
-done
+UP="${TOOLS_UPLOAD:-tools/upload_to_drive.py}"
+if [[ ! -f "$UP" ]]; then
+  echo "[gdrive] uploader script missing ($UP); skipping"
+  exit 0
+fi
 
+echo "[gdrive] uploading $*"
+python3 "$UP" --folder-id "$GDRIVE_FOLDER_ID" "$@" || { echo "[gdrive] upload FAILED"; exit 1; }

--- a/tools/run_and_backfill.sh
+++ b/tools/run_and_backfill.sh
@@ -3,46 +3,45 @@ set -euo pipefail
 
 LOG="${LOG:-/tmp/pipeline_$(date +%s).log}"
 
-video=""
-team=""
-playbook=""
-out="output"
-min_gap="1.5"
-min_len="3.0"
-gen_report=1
-gen_clips=1
+usage() {
+  cat <<EOF
+Usage: tools/run_and_backfill.sh --video PATH --team NAME --playbook PATH --out DIR [--min-play-gap F] [--min-play-length F] [--generate-report] [--generate-clips]
+Sets LOG env to write run log at: $LOG
+EOF
+}
+
+VIDEO="" ; TEAM="" ; PLAYBOOK="" ; OUT=""
+MIN_GAP="1.5" ; MIN_LEN="3.0"
+GEN_REPORT=0 ; GEN_CLIPS=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --video) video="$2"; shift 2;;
-    --team) team="$2"; shift 2;;
-    --playbook) playbook="$2"; shift 2;;
-    --out) out="$2"; shift 2;;
-    --min-play-gap) min_gap="$2"; shift 2;;
-    --min-play-length) min_len="$2"; shift 2;;
-    --generate-report) gen_report=1; shift;;
-    --no-generate-report) gen_report=0; shift;;
-    --generate-clips) gen_clips=1; shift;;
-    --no-generate-clips) gen_clips=0; shift;;
-    *) break;;
+    --video) VIDEO="$2"; shift 2;;
+    --team) TEAM="$2"; shift 2;;
+    --playbook) PLAYBOOK="$2"; shift 2;;
+    --out) OUT="$2"; shift 2;;
+    --min-play-gap) MIN_GAP="$2"; shift 2;;
+    --min-play-length) MIN_LEN="$2"; shift 2;;
+    --generate-report) GEN_REPORT=1; shift;;
+    --generate-clips)  GEN_CLIPS=1; shift;;
+    -h|--help) usage; exit 0;;
+    *) echo "Unknown arg: $1"; usage; exit 1;;
   esac
 done
 
-[[ -z "$video" ]] && { echo "tools/run_and_backfill.sh: --video required"; exit 1; }
-[[ -z "$team" ]] && { echo "tools/run_and_backfill.sh: --team required"; exit 1; }
-[[ -z "$playbook" ]] && { echo "tools/run_and_backfill.sh: --playbook required"; exit 1; }
+[[ -n "$VIDEO" && -n "$TEAM" && -n "$PLAYBOOK" && -n "$OUT" ]] || { echo "VIDEO/TEAM/PLAYBOOK/OUT required"; usage; exit 1; }
 
-PY_ARGS=( --video "$video" --team "$team" --playbook "$playbook" --out "$out" --min-play-gap "$min_gap" --min-play-length "$min_len" )
-[[ $gen_report -eq 1 ]] && PY_ARGS+=( --generate-report )
-[[ $gen_clips -eq 1 ]] && PY_ARGS+=( --generate-clips )
+echo "[run] python -m analysis.pipeline --video $VIDEO --team $TEAM --playbook $PLAYBOOK --out $OUT --min-play-gap $MIN_GAP --min-play-length $MIN_LEN ${GEN_REPORT:+--generate-report} ${GEN_CLIPS:+--generate-clips}" | tee "$LOG"
+python -m analysis.pipeline \
+  --video "$VIDEO" \
+  --team "$TEAM" \
+  --playbook "$PLAYBOOK" \
+  --out "$OUT" \
+  --min-play-gap "$MIN_GAP" \
+  --min-play-length "$MIN_LEN" \
+  ${GEN_REPORT:+--generate-report} \
+  ${GEN_CLIPS:+--generate-clips} | tee -a "$LOG"
 
-echo "[run] python -m analysis.pipeline ${PY_ARGS[*]}"
-python3 -m analysis.pipeline "${PY_ARGS[@]}" 2>&1 | tee "$LOG"
-
-RUN_DIR=$(scripts/run_utils.sh get_run_dir "$LOG" | sed 's/^Run dir: //')
-echo "Run dir: ${RUN_DIR}"
-
-if [[ -n "${RUN_DIR}" && -d "${RUN_DIR}" ]]; then
-  scripts/run_utils.sh check_csv "${RUN_DIR}" || true
-fi
-
+# Print run dir
+RUN_DIR="$(scripts/run_utils.sh get_run_dir "$LOG" || true)"
+[[ -n "${RUN_DIR:-}" ]] && echo "Run dir: $RUN_DIR" | tee -a "$LOG" || echo "Run dir: could not extract run dir from $LOG" | tee -a "$LOG"


### PR DESCRIPTION
## Summary
- add import guard for analysis pipeline to work as module or script
- ensure play classification returns consistent candidates and formation-aware rescoring
- harden helper shell scripts and optional Drive sync

## Testing
- `pytest` *(fails: FileNotFoundError: ffmpeg)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68af4b5fd62c832d8a0e05e1f0aa782c