### PR TITLE
Add spot check helper script

### DIFF
--- a/scripts/spot_check.sh
+++ b/scripts/spot_check.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ $# -gt 0 ]; then
+  RUNS=("$@")
+else
+  RUNS=(output/games/*)
+fi
+
+for RUN_DIR in "${RUNS[@]}"; do
+  [ -d "$RUN_DIR" ] || continue
+  echo -e "\n== $RUN_DIR =="
+
+  CSV="$RUN_DIR/plays_index.csv"
+  if [ -f "$CSV" ]; then
+    head -n 6 "$CSV"
+  else
+    echo "missing CSV: $CSV"
+  fi
+
+  CLIPS=$(find "$RUN_DIR/clips" -type f -name '*.mp4' 2>/dev/null | wc -l | awk '{print $1}')
+  echo "Total clips: $CLIPS"
+  find "$RUN_DIR/clips" -type f -name '*.mp4' 2>/dev/null | sort | head -n 10
+done


### PR DESCRIPTION
## Summary
- add `scripts/spot_check.sh` to preview CSV headers and clip counts for analysis runs

## Testing
- `pytest` *(fails: run_pipeline() missing 3 required positional arguments)*
- `python -m analysis.pipeline --video "$VID_DIR/IMG_4129.MP4" ...` *(segments detected: 0)*
- `python -m analysis.pipeline --video "$VID_DIR/Scrimmage 2 - Part 1.MP4" ...` *(segments detected: 0)*
- `python -m analysis.pipeline --video "$VID_DIR/Scrimmage 2 - Part 2.MP4" ...` *(segments detected: 0)*
- `scripts/ensure_single_analysis.sh "$VID_DIR/IMG_4129.MP4" "WHITE"`
- `scripts/ensure_single_analysis.sh "$VID_DIR/Scrimmage 2 - Part 1.MP4" "WHITE"`
- `scripts/ensure_single_analysis.sh "$VID_DIR/Scrimmage 2 - Part 2.MP4" "WHITE"`
- `scripts/run_utils.sh clip_previews "$OUT_DIR/games/IMG_4129__latest" 3` *(missing ffmpeg)*
- `scripts/run_utils.sh clip_previews "$OUT_DIR/games/Scrimmage 2 - Part 1__latest" 3` *(missing ffmpeg)*
- `scripts/run_utils.sh clip_previews "$OUT_DIR/games/Scrimmage 2 - Part 2__latest" 3` *(missing ffmpeg)*
- `bash scripts/spot_check.sh "$OUT_DIR/games/IMG_4129__latest" "$OUT_DIR/games/Scrimmage 2 - Part 1__latest" "$OUT_DIR/games/Scrimmage 2 - Part 2__latest"`
- `scripts/run_utils.sh dedupe_all --dry-run`
- `scripts/run_utils.sh dedupe_all --prune`
- `tools/gdrive_sync.sh "$OUT_DIR/games/IMG_4129__latest/plays_index.csv" "$OUT_DIR/games/IMG_4129__latest/report.json"`
- `tools/gdrive_sync.sh "$OUT_DIR/games/Scrimmage 2 - Part 1__latest/plays_index.csv" "$OUT_DIR/games/Scrimmage 2 - Part 1__latest/report.json"`
- `tools/gdrive_sync.sh "$OUT_DIR/games/Scrimmage 2 - Part 2__latest/plays_index.csv" "$OUT_DIR/games/Scrimmage 2 - Part 2__latest/report.json"`

------
https://chatgpt.com/codex/tasks/task_e_68b08f2c0ca8832da17b6ec732d952c1