### PR TITLE
Avoid splitting run paths

### DIFF
--- a/scripts/run_utils.sh
+++ b/scripts/run_utils.sh
@@ -86,14 +86,18 @@ clip_previews() {
 
 latest_run_for() {
   local base="$1"
-  ls -td "$PWD/output/games/${base}__"* 2>/dev/null | head -1 || true
+  ls -1td -- "$PWD/output/games/${base}__"* 2>/dev/null | head -n1 || true
 }
 
 clean_old_runs() {
   local base="$1"
   local newest; newest="$(latest_run_for "$base")"
   [[ -z "$newest" ]] && { echo "no runs for $base"; return 0; }
-  ls -td "$PWD/output/games/${base}__"* 2>/dev/null | tail -n +2 | xargs -r rm -rf
+  ls -1td -- "$PWD/output/games/${base}__"* 2>/dev/null |
+    tail -n +2 |
+    while IFS= read -r old; do
+      rm -rf -- "$old"
+    done
   echo "kept: $newest"
 }
 
@@ -101,14 +105,20 @@ dedupe_all() {
   local dry=0
   if [[ "${1:-}" == "--dry-run" ]]; then dry=1; shift; fi
   cd "$PWD/output/games" 2>/dev/null || return 0
-  for base in $(ls -d *__* 2>/dev/null | sed 's/__.*//' | sort -u); do
+  declare -A seen=()
+  while IFS= read -r -d '' dir; do
+    local base
+    base="${dir#./}"
+    base="${base%%__*}"
+    [[ -n ${seen["$base"]:-} ]] && continue
+    seen["$base"]=1
     if [[ $dry -eq 1 ]]; then
       echo "would clean $base"
-      ls -td "${base}__"* 2>/dev/null | tail -n +2
+      ls -1td -- "${base}__"* 2>/dev/null | tail -n +2
     else
       "$PWD/../../scripts/run_utils.sh" clean_old_runs "$base"
     fi
-  done
+  done < <(find . -maxdepth 1 -mindepth 1 -type d -name '*__*' -print0)
 }
 
 case "${1:-}" in


### PR DESCRIPTION
## Summary
- Safely handle run directories with spaces when listing and cleaning runs
- Use `find -print0` with a `while` loop to dedupe runs without word splitting
- Replace `xargs` deletions with quoted `rm` loop

## Testing
- `bash -n scripts/run_utils.sh`
- `pytest` *(fails: run_pipeline() missing 3 required positional arguments)*

------
https://chatgpt.com/codex/tasks/task_e_68b0d02272d4832d9a33dfb2433bdde2