### PR TITLE
feat: improve spot check script

### DIFF
--- a/scripts/spot_check.sh
+++ b/scripts/spot_check.sh
@@ -1,12 +1,51 @@
 #!/usr/bin/env bash
 set -euo pipefail
-if [ $# -gt 0 ]; then RUNS=("$@"); else RUNS=(output/games/*); fi
-for RUN_DIR in "${RUNS[@]}"; do
-  [ -d "$RUN_DIR" ] || continue
-  echo -e "\n== $RUN_DIR =="
-  CSV="$RUN_DIR/plays_index.csv"
-  [ -f "$CSV" ] && head -n 6 "$CSV" || echo "missing CSV: $CSV"
-  CLIPS=$(find "$RUN_DIR/clips" -type f -name '*.mp4' 2>/dev/null | wc -l | awk '{print $1}')
-  echo "Total clips: $CLIPS"
-  find "$RUN_DIR/clips" -type f -name '*.mp4' 2>/dev/null | sort | head -n 10
+shopt -s nullglob
+
+# Default (latest of each game): scripts/spot_check.sh
+# Specific run dir: scripts/spot_check.sh "output/games/Scrimmage 2 - Part 1__d25a14a6115"
+
+if (( $# > 0 )); then
+  run_dirs=("$@")
+else
+  run_dirs=(output/games/*__latest)
+  if (( ${#run_dirs[@]} == 0 )); then
+    run_dirs=(output/games/*__*)
+  fi
+fi
+
+for dir in "${run_dirs[@]}"; do
+  echo "$dir"
+
+  if [[ -f "$dir/plays_index.csv" ]]; then
+    head -n 6 "$dir/plays_index.csv" | sed 's/^/  /'
+  else
+    echo "  missing plays_index.csv"
+  fi
+
+  if [[ -d "$dir/clips" ]]; then
+    clip_count=$(find "$dir/clips" -type f -name '*.mp4' | wc -l)
+  else
+    clip_count=0
+  fi
+  echo "  $clip_count clip(s)"
+
+  if [[ -d "$dir/report" ]]; then
+    files=("$dir/report/index.html" "$dir/report"/*.png)
+    if (( ${#files[@]} > 0 )); then
+      echo "  report files:"
+      for f in "${files[@]}"; do
+        if [[ -e "$f" ]]; then
+          echo "    $(basename "$f")"
+        fi
+      done
+    else
+      echo "  report (no summary files)"
+    fi
+  else
+    echo "  missing report/"
+  fi
+
 done
+
+exit 0


### PR DESCRIPTION
## Summary
- refactor `spot_check.sh` to handle default/latest run directories
- show brief run summaries including top of CSV, MP4 clip count, and report files

## Testing
- `pytest`
- `shellcheck scripts/spot_check.sh` *(fails: command not found; package install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68b12a6b7134832d9f7f07a3dfdfb940