### PR TITLE
Add batch analysis helper script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,32 @@ coach report under `output/reports/`.
 The coach summary report includes per-play tables and player grades. A
 sample output is generated during tests under `tests/data`.
 
+### Batch fresh analyses
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+export PYTHONPATH=.
+FILES=("IMG_4129.MP4" "Scrimmage 2 - Part 1.MP4" "Scrimmage 2 - Part 2.MP4")
+for F in "${FILES[@]}"; do
+  python -m analysis.pipeline \
+    --video "video/manual_uploads/${F}" \
+    --team WHITE \
+    --playbook "playbooks/mca_5th_playbook.json" \
+    --out "output" \
+    --min-play-gap 1.5 \
+    --min-play-length 3.0 \
+    --report \
+    --clips
+done
+# Update symlinks for all
+bash scripts/update_latest_symlinks.sh
+```
+
+Or run `scripts/run_batch.sh` to use this loop.
+
+
+
 ### One-click end-to-end analysis
 
 Run the entire processing pipeline and summary generation with a single command:

--- a/README_snippets.md
+++ b/README_snippets.md
@@ -26,3 +26,25 @@ Outputs will be under: output/games/IMG_4129__<hash>/...
 
 Re-running the same command refreshes the same folder (no clutter).
 
+
+### Batch fresh analyses
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+export PYTHONPATH=.
+FILES=("IMG_4129.MP4" "Scrimmage 2 - Part 1.MP4" "Scrimmage 2 - Part 2.MP4")
+for F in "${FILES[@]}"; do
+  python -m analysis.pipeline \
+    --video "video/manual_uploads/${F}" \
+    --team WHITE \
+    --playbook "playbooks/mca_5th_playbook.json" \
+    --out "output" \
+    --min-play-gap 1.5 \
+    --min-play-length 3.0 \
+    --report \
+    --clips
+done
+# Update symlinks for all
+bash scripts/update_latest_symlinks.sh
+```

--- a/scripts/run_batch.sh
+++ b/scripts/run_batch.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export PYTHONPATH=.
+FILES=("IMG_4129.MP4" "Scrimmage 2 - Part 1.MP4" "Scrimmage 2 - Part 2.MP4")
+for F in "${FILES[@]}"; do
+  python -m analysis.pipeline \
+    --video "video/manual_uploads/${F}" \
+    --team WHITE \
+    --playbook "playbooks/mca_5th_playbook.json" \
+    --out "output" \
+    --min-play-gap 1.5 \
+    --min-play-length 3.0 \
+    --report \
+    --clips
+done
+# Update symlinks for all
+bash scripts/update_latest_symlinks.sh


### PR DESCRIPTION
## Summary
- Document a clean batch analysis loop with proper quoting
- Add `scripts/run_batch.sh` as a ready-to-run helper
- Reference the helper loop in README and snippets

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b12a763800832d9cd3668b965feafc