### PR TITLE
Add classifier weakness observability & sane fallbacks

### DIFF
--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -36,6 +36,7 @@ def run_pipeline(
     postroll: float = 0.75,
     generate_report: bool = False,
     generate_clips: bool = False,
+    debug_weak: bool = False,
 ) -> str:
     video = os.path.abspath(video)
     out_dir = os.path.abspath(out_dir)
@@ -80,6 +81,14 @@ def run_pipeline(
                 "formation_confidence": float(det.get("formation_confidence", 0.0)),
                 "play_family": det.get("play_family", "Unknown"),
                 "playcall_confidence": float(det.get("playcall_confidence", 0.0)),
+                # Observability fields
+                "clf_top1": det.get("clf_top1", det.get("play_family", "")),
+                "clf_top1_conf": float(det.get("clf_top1_conf", det.get("playcall_confidence", 0.0))),
+                "clf_top3": ";".join(
+                    f"{n}:{s:.2f}" for n, s in det.get("clf_top3", det.get("candidates", []))
+                ),
+                "clf_weak_flag": int(det.get("clf_weak_flag", 0)),
+                "clf_family": det.get("clf_family", ""),
                 "outcome": det.get("outcome") or "",
                 "clip_duration": max(0.0, float(seg["t1"]) - float(seg["t0"])),
                 "candidates": ";".join(
@@ -99,6 +108,11 @@ def run_pipeline(
         "formation_confidence",
         "play_family",
         "playcall_confidence",
+        "clf_top1",
+        "clf_top1_conf",
+        "clf_top3",
+        "clf_weak_flag",
+        "clf_family",
         "outcome",
         "clip_duration",
         "candidates",
@@ -155,6 +169,28 @@ def run_pipeline(
             for r in rows:
                 w.writerow(r)
 
+    # Optional debug frames for weak classifications
+    if debug_weak:
+        dbg_dir = os.path.join(run_dir, "debug", "weak")
+        os.makedirs(dbg_dir, exist_ok=True)
+        for idx, (seg, det) in enumerate(zip(segments, classifications), 1):
+            if det.get("clf_weak_flag"):
+                times = [
+                    float(seg["t0"]),
+                    float(seg["t0"] + seg["t1"]) / 2.0,
+                    float(seg["t1"]),
+                ]
+                for j, t in enumerate(times):
+                    _ffmpeg(
+                        "-ss",
+                        f"{t:.3f}",
+                        "-i",
+                        video,
+                        "-frames:v",
+                        "1",
+                        os.path.join(dbg_dir, f"seg_{idx}_{j}.jpg"),
+                    )
+
     if generate_report:
         report = {
             "video": video,
@@ -207,6 +243,7 @@ def main(argv=None) -> None:
     p.add_argument("--postroll", type=float, default=0.75)
     p.add_argument("--generate-report", action="store_true")
     p.add_argument("--generate-clips", action="store_true")
+    p.add_argument("--debug-weak", action="store_true")
     args = p.parse_args(argv)
 
     run_pipeline(
@@ -221,6 +258,7 @@ def main(argv=None) -> None:
         postroll=args.postroll,
         generate_report=args.generate_report,
         generate_clips=args.generate_clips,
+        debug_weak=args.debug_weak,
     )
 
 

--- a/analysis/play_classifier.py
+++ b/analysis/play_classifier.py
@@ -88,7 +88,13 @@ def _best_matches_from_playbook(
     pb: Any,
     topk: int = 3,
 ) -> List[Tuple[str, float]]:
-    """Return ``topk`` candidate names and scores from ``pb``."""
+    """Return ``topk`` candidate names and scores from ``pb``.
+
+    The scoring function is intentionally very lightweight – it simply
+    performs a loose formation match and then scores the candidate name based
+    on string similarity.  The resulting "scores" are used downstream as
+    pseudo logits for temporal smoothing heuristics.
+    """
 
     cands: List[Tuple[str, float]] = []
     for p in _iter_playbook_plays(pb):
@@ -108,11 +114,31 @@ def _best_matches_from_playbook(
                     break
             if not formation_match:
                 continue
-        sim = _name_similarity(name, name)  # placeholder self-similarity
+        # Compare the formation text with the play name as a loose proxy for a
+        # classifier score.  This keeps the implementation deterministic while
+        # still yielding a range of confidences for tests to exercise.
+        sim = _name_similarity(formation, name)
         score = min(1.0, sim + (0.2 if formation_match else 0.0))
         cands.append((name, score))
     cands.sort(key=lambda x: x[1], reverse=True)
     return cands[:topk]
+
+
+def _best_family_from_playbook(pb: Any, scores: Dict[str, float]) -> str:
+    """Return the highest scoring family from ``scores`` using ``pb``."""
+
+    fam_scores: Dict[str, float] = {}
+    if not scores:
+        return ""
+    for p in _iter_playbook_plays(pb):
+        name = p.get("name") or ""
+        if name in scores:
+            family = p.get("family") or ""
+            if family:
+                fam_scores[family] = fam_scores.get(family, 0.0) + scores[name]
+    if not fam_scores:
+        return ""
+    return max(fam_scores.items(), key=lambda x: x[1])[0]
 
 
 # ---------------------------------------------------------------------------
@@ -123,23 +149,79 @@ def classify_plays(
     segments: List[Dict[str, float]],
     playbook: Any,
     team: str,
+    *,
+    weak_threshold: float = 0.35,
+    smooth_radius: int = 4,
 ) -> List[Dict[str, Any]]:
-    """Classify each segment and propose candidate play names."""
+    """Classify each segment and propose candidate play names.
+
+    In addition to the top candidate, this helper also records a list of top-3
+    candidates, detects low-confidence ("weak") predictions, applies a simple
+    temporal smoothing fallback and, if necessary, backs off to family-level
+    classification.
+    """
+
+    # ------------------------------------------------------------------
+    # Pre-compute candidate score dictionaries for all segments so that
+    # temporal smoothing can operate on them.
+    # ------------------------------------------------------------------
+    raw_scores: List[Dict[str, float]] = []
+    formations: List[str] = []
+    for seg in segments:
+        formation = seg.get("formation", "") or ""
+        formations.append(formation)
+        cands = _best_matches_from_playbook(formation, playbook, topk=3)
+        raw_scores.append({n: s for n, s in cands})
 
     results: List[Dict[str, Any]] = []
+    total = len(segments)
     for i, seg in enumerate(segments, 1):
-        formation = seg.get("formation", "") or ""
-        candidates = _best_matches_from_playbook(formation, playbook, topk=3)
-        top_name, top_score = (candidates[0] if candidates else ("", 0.0))
+        scores = raw_scores[i - 1]
+        sorted_cands = sorted(scores.items(), key=lambda x: x[1], reverse=True)
+        top_name, top_score = (sorted_cands[0] if sorted_cands else ("", 0.0))
+        weak_flag = 0
+        final_scores = scores
+
+        if top_score < weak_threshold:
+            weak_flag = 1
+            # Temporal smoothing over neighbouring segments
+            start = max(0, (i - 1) - smooth_radius)
+            end = min(total, (i - 1) + smooth_radius + 1)
+            window = raw_scores[start:end]
+            names = {n for d in window for n in d}
+            smoothed: Dict[str, float] = {}
+            for n in names:
+                smoothed[n] = sum(d.get(n, 0.0) for d in window) / len(window)
+            final_scores = smoothed
+            sorted_cands = sorted(final_scores.items(), key=lambda x: x[1], reverse=True)
+            top_name, top_score = (sorted_cands[0] if sorted_cands else ("", 0.0))
+
+            # Back off to family-level classification if still weak
+            if top_score < weak_threshold:
+                clf_family = _best_family_from_playbook(playbook, final_scores)
+            else:
+                clf_family = ""
+        else:
+            clf_family = ""
+
+        top3 = sorted_cands[:3]
+
         results.append(
             {
                 "play_id": seg.get("id") or seg.get("play_id") or f"PLAY_{i:03d}",
-                "formation": formation,
+                "formation": formations[i - 1],
                 "formation_confidence": float(seg.get("formation_confidence", 0.0)),
+                # Existing fields for backwards compatibility
                 "play_family": top_name,
                 "playcall_confidence": float(top_score),
-                "candidates": candidates,
+                "candidates": top3,
                 "outcome": seg.get("outcome", ""),
+                # New observability fields
+                "clf_top1": top_name,
+                "clf_top1_conf": float(top_score),
+                "clf_top3": top3,
+                "clf_weak_flag": weak_flag,
+                "clf_family": clf_family,
             }
         )
     return results

--- a/analysis/report_builder.py
+++ b/analysis/report_builder.py
@@ -52,6 +52,25 @@ def build(
     }
     write_json(dashboards / "summary.json", summary)
 
+    # Classifier weakness stats from plays_index.csv
+    weak_count = 0
+    avg_conf = 0.0
+    confs: list[float] = []
+    index_csv = out_dir / "plays_index.csv"
+    if index_csv.exists():
+        with index_csv.open() as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                try:
+                    conf = float(row.get("clf_top1_conf", 0.0))
+                    confs.append(conf)
+                    if int(row.get("clf_weak_flag", 0)):
+                        weak_count += 1
+                except ValueError:
+                    continue
+    if confs:
+        avg_conf = sum(confs) / len(confs)
+
     rows = timeline_rows(joined)
     with (dashboards / "timeline.csv").open("w", newline="") as f:
         writer = csv.writer(f)
@@ -62,6 +81,11 @@ def build(
     md_lines = ["# Game Report", "", f"Total plays: {len(joined)}", ""]
     md_lines.append(f"Median confidence: {median_conf:.2f}")
     md_lines.append(f"Unknown predictions: {unknown_count}")
+    md_lines.append("")
+    md_lines.append("## Classifier Weakness")
+    md_lines.append("|Weak segments|Avg confidence|")
+    md_lines.append("|---|---|")
+    md_lines.append(f"|{weak_count}|{avg_conf:.2f}|")
     md_lines.append("")
 
     md_lines.append("## Unknown Root Causes")


### PR DESCRIPTION
## Summary
- Track per-segment classifier confidence, top-k predictions, weakness flag, and family fallback
- Add temporal smoothing and family-level backoff for weak classifications
- Emit debug frames for weak segments and summarize weakness stats in reports

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b12a7f454c832db99710e886ed7d97