### PR TITLE
Validate model labels against playbook wiring

### DIFF
--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -24,6 +24,40 @@ def _safe_name(s: str) -> str:
     return "".join(c if c.isalnum() or c in "._- " else "_" for c in s)
 
 
+def _load_model_labels(model_path: str | None = None) -> set[str]:
+    """Return classifier label set from a checkpoint or JSON mapping.
+
+    The function first attempts to load ``model_path`` using ``torch.load`` to
+    access a ``label_map`` attribute.  If that fails, it falls back to parsing
+    the file as JSON.  When ``model_path`` is ``None`` the environment variable
+    ``PLAY_CLASSIFIER_MODEL`` is consulted and finally a default checkpoint path
+    under ``models/play_classifier/latest.pt`` is used.  Any errors are
+    swallowed and an empty set is returned.
+    """
+
+    model_path = (
+        model_path
+        or os.environ.get("PLAY_CLASSIFIER_MODEL")
+        or os.path.join("models", "play_classifier", "latest.pt")
+    )
+    p = pathlib.Path(model_path)
+    if not p.exists():
+        return set()
+    label_map = {}
+    try:  # pragma: no cover - torch may be unavailable
+        import torch  # type: ignore
+
+        data = torch.load(p, map_location="cpu")
+        label_map = data.get("label_map", {})
+    except Exception:
+        try:
+            data = json.loads(p.read_text())
+            label_map = data.get("label_map", {})
+        except Exception:
+            return set()
+    return set(label_map.keys())
+
+
 def run_pipeline(
     video: str,
     team: str,
@@ -47,8 +81,39 @@ def run_pipeline(
     os.makedirs(run_dir, exist_ok=True)
     os.makedirs(os.path.join(run_dir, "clips"), exist_ok=True)
 
+    report_dir = os.path.join(run_dir, "report")
+    os.makedirs(report_dir, exist_ok=True)
+
     playbook = load_playbook(playbook_path)
     print(f"[playbook] source={playbook_path}")
+
+    # ------------------------------------------------------------------
+    # Validate classifier ↔ playbook wiring
+    # ------------------------------------------------------------------
+    validator_warnings: list[str] = []
+    model_labels = _load_model_labels()
+    if model_labels:
+        if hasattr(playbook, "plays"):
+            pb_labels = set(playbook.plays.keys())
+        else:
+            pb_labels = {p.get("name", "") for p in playbook.get("plays", [])}
+        missing_in_playbook = sorted(model_labels - pb_labels)
+        missing_in_model = sorted(pb_labels - model_labels)
+        if missing_in_playbook:
+            validator_warnings.append(
+                "Model labels not in playbook: " + ", ".join(missing_in_playbook)
+            )
+        if missing_in_model:
+            validator_warnings.append(
+                "Playbook labels missing from model: " + ", ".join(missing_in_model)
+            )
+    if validator_warnings:
+        warn_path = os.path.join(report_dir, "warnings.txt")
+        with open(warn_path, "w", encoding="utf-8") as wf:
+            for line in validator_warnings:
+                wf.write(line + "\n")
+        for line in validator_warnings:
+            print(f"⚠️ {line}")
 
     segments = segment_video(
         video,
@@ -211,7 +276,27 @@ def run_pipeline(
         if len(unknown) / len(rows) > 0.5:
             print("⚠️ formation/classifier weak")
 
-    print(f"[pipeline] run complete -> {run_dir}")
+    status_icon = "⚠️ " if validator_warnings else ""
+    print(f"{status_icon}[pipeline] run complete -> {run_dir}")
+
+    # ------------------------------------------------------------------
+    # Basic HTML report with sanity checks
+    # ------------------------------------------------------------------
+    index_path = os.path.join(report_dir, "index.html")
+    with open(index_path, "w", encoding="utf-8") as f:
+        f.write("<html><head><meta charset='utf-8'><title>Run Report</title></head><body>\n")
+        f.write(f"<h1>{status_icon.strip()}Analysis Report</h1>\n")
+        f.write("<h2>Sanity Checks</h2>\n<ul>\n")
+        f.write(
+            f"<li>Active thresholds: min_play_gap={min_play_gap}, min_play_length={min_play_length}, "
+            f"max_play_length={max_play_length}</li>\n"
+        )
+        if validator_warnings:
+            for line in validator_warnings:
+                f.write(f"<li>{line}</li>\n")
+        else:
+            f.write("<li>No unmapped labels</li>\n")
+        f.write("</ul>\n</body></html>\n")
 
 
     # Update the "__latest" symlink for this video base

--- a/tests/test_pipeline_label_validator.py
+++ b/tests/test_pipeline_label_validator.py
@@ -1,0 +1,30 @@
+import json, os, pathlib
+from analysis import pipeline
+
+
+def test_pipeline_label_mismatch(tmp_path, monkeypatch):
+    playbook = {"plays": [{"name": "Rit Sweep", "formation": "Rit"}]}
+    pb_path = tmp_path / "playbook.json"
+    pb_path.write_text(json.dumps(playbook))
+
+    model_ckpt = tmp_path / "model.json"
+    model_ckpt.write_text(json.dumps({"label_map": {"Rit Sweep": 0, "Foo": 1}}))
+    monkeypatch.setenv("PLAY_CLASSIFIER_MODEL", str(model_ckpt))
+
+    run_dir = pipeline.run_pipeline(
+        video="dummy.mp4",
+        team="WHITE",
+        playbook_path=str(pb_path),
+        out_dir=str(tmp_path / "out"),
+        min_play_gap=1.5,
+        min_play_length=3.0,
+        generate_report=True,
+        generate_clips=False,
+    )
+
+    run_dir = pathlib.Path(run_dir)
+    warn = (run_dir / "report" / "warnings.txt").read_text()
+    assert "Foo" in warn
+    html = (run_dir / "report" / "index.html").read_text()
+    assert "Foo" in html
+    assert "⚠️" in html

--- a/tests/test_pipeline_smoke.py
+++ b/tests/test_pipeline_smoke.py
@@ -24,3 +24,10 @@ def test_pipeline_smoke(tmp_path):
     run_dir = pathlib.Path(run_dir)
     assert (run_dir / "plays_index.csv").exists()
     assert (run_dir / "report.json").exists()
+    index_path = run_dir / "report" / "index.html"
+    assert index_path.exists()
+    html = index_path.read_text()
+    assert "Sanity Checks" in html
+    assert "min_play_length" in html
+    warnings_path = run_dir / "report" / "warnings.txt"
+    assert not warnings_path.exists()


### PR DESCRIPTION
## Summary
- validate classifier label map against playbook ids
- surface unmapped labels to stdout and report/warnings.txt
- add Sanity Checks section with active thresholds to report/index.html

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1963105d4832d94c4000cd3710e71