### PR TITLE
Add game run pruning tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .RECIPEPREFIX := >
-.PHONY: deps diag preflight audit fix-logging run testsrc audio fmt
+.PHONY: deps diag preflight audit fix-logging run testsrc audio fmt prune-runs
 deps:
 >scripts/install_deps.sh
 diag:
@@ -58,6 +58,9 @@ testsrc:
 
 audio:
 >PYTHONPATH=. python3 -m tools.list_audio
+
+prune-runs:
+>PYTHONPATH=. python3 tools/prune_runs.py --games-dir output/games --keep 3
 
 fmt:
 >@echo "no-op"

--- a/README_cleanup.md
+++ b/README_cleanup.md
@@ -15,6 +15,13 @@ Keep only the last 10 games (archive older):
 python3 tools/cleanup_outputs.py --out output --archive --retention 10
 ```
 
+Prune old runs per game (keep last 3):
+```bash
+python3 tools/prune_runs.py --games-dir output/games --keep 3
+# or
+make prune-runs
+```
+
 Run cleaner automatically before analysis:
 ```bash
 python3 -m analysis.pipeline \

--- a/tools/prune_runs.py
+++ b/tools/prune_runs.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Prune old game runs, keeping only the latest N per game.
+
+Example:
+    python3 tools/prune_runs.py --games-dir output/games --keep 3
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+from collections import defaultdict
+from pathlib import Path
+
+
+def prune_runs(games_dir: Path, keep: int) -> None:
+    groups: dict[str, list[Path]] = defaultdict(list)
+
+    if not games_dir.exists():
+        return
+
+    for entry in games_dir.iterdir():
+        if not entry.is_dir():
+            continue
+        name = entry.name
+        if "__" not in name:
+            continue
+        base, _, suffix = name.rpartition("__")
+        if suffix == "latest":
+            continue
+        groups[base].append(entry)
+
+    for base, runs in groups.items():
+        runs.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+        for old in runs[keep:]:
+            print(f"prune {old}")
+            shutil.rmtree(old, ignore_errors=True)
+        subprocess.run(["scripts/update_latest_symlinks.sh", base], check=False)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Prune old game runs")
+    parser.add_argument("--games-dir", default="output/games", type=Path)
+    parser.add_argument("--keep", default=3, type=int)
+    args = parser.parse_args()
+
+    prune_runs(args.games_dir, args.keep)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `tools/prune_runs.py` to delete older game runs and refresh `__latest` symlinks
- expose new pruning script via `make prune-runs`
- document pruning usage in `README_cleanup.md`

## Testing
- `python -m py_compile tools/prune_runs.py`
- `pytest tests/test_playbook_loader.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1963f4b08832db8b4a56cf27db608