### PR TITLE
Add activity-based play filtering

### DIFF
--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -32,6 +32,7 @@ def run_pipeline(
     min_play_gap: float = 1.5,
     min_play_length: float = 3.0,
     max_play_length: float = 12.0,
+    min_activity_ratio: float = 0.10,
     preroll: float = 0.75,
     postroll: float = 0.75,
     generate_report: bool = False,
@@ -42,7 +43,21 @@ def run_pipeline(
     out_dir = os.path.abspath(out_dir)
 
     tag = pathlib.Path(video).stem
-    short = hex(abs(hash((tag, playbook_path, min_play_gap, min_play_length))) & ((1 << 44) - 1))[2:]
+    short = hex(
+        abs(
+            hash(
+                (
+                    tag,
+                    playbook_path,
+                    min_play_gap,
+                    min_play_length,
+                    max_play_length,
+                    min_activity_ratio,
+                )
+            )
+        )
+        & ((1 << 44) - 1)
+    )[2:]
     run_dir = os.path.join(out_dir, "games", f"{_safe_name(tag)}__{short}")
     os.makedirs(run_dir, exist_ok=True)
     os.makedirs(os.path.join(run_dir, "clips"), exist_ok=True)
@@ -59,10 +74,15 @@ def run_pipeline(
         postroll=postroll,
     )
     print(
-        f"[config] min_play_length={min_play_length} max_play_length={max_play_length} min_play_gap={min_play_gap} "
-        f"report={generate_report} clips={generate_clips}"
+        f"[config] min_play_length={min_play_length} max_play_length={max_play_length} min_activity_ratio={min_activity_ratio} "
+        f"min_play_gap={min_play_gap} report={generate_report} clips={generate_clips}"
     )
     print(f"[pipeline] segments detected: {len(segments)}")
+
+    for seg in segments:
+        seg["low_activity"] = int(
+            seg.get("activity_ratio", 0.0) < min_activity_ratio and not seg.get("has_whistle")
+        )
 
     classifications = classify_plays(segments, playbook, team)
 
@@ -91,9 +111,8 @@ def run_pipeline(
                 "clf_family": det.get("clf_family", ""),
                 "outcome": det.get("outcome") or "",
                 "clip_duration": max(0.0, float(seg["t1"]) - float(seg["t0"])),
-                "candidates": ";".join(
-                    f"{n}:{s:.2f}" for n, s in det.get("candidates", [])
-                ),
+                "low_activity": int(seg.get("low_activity", 0)),
+                "candidates": ";".join(f"{n}:{s:.2f}" for n, s in det.get("candidates", [])),
             }
         )
 
@@ -115,6 +134,7 @@ def run_pipeline(
         "clf_family",
         "outcome",
         "clip_duration",
+        "low_activity",
         "candidates",
     ]
     csv_path = os.path.join(run_dir, "plays_index.csv")
@@ -197,6 +217,12 @@ def run_pipeline(
             "run_dir": run_dir,
             "n_segments": len(segments),
             "generated_clips": bool(generate_clips),
+            "config": {
+                "min_play_length": min_play_length,
+                "max_play_length": max_play_length,
+                "min_play_gap": min_play_gap,
+                "min_activity_ratio": min_activity_ratio,
+            },
             "plays": rows,
         }
         with open(os.path.join(run_dir, "report.json"), "w") as f:
@@ -251,6 +277,7 @@ def main(argv=None) -> None:
     p.add_argument("--min-play-gap", type=float, default=1.5)
     p.add_argument("--min-play-length", type=float, default=3.0)
     p.add_argument("--max-play-length", type=float, default=12.0)
+    p.add_argument("--min-activity-ratio", type=float, default=0.10)
     p.add_argument("--preroll", type=float, default=0.75)
     p.add_argument("--postroll", type=float, default=0.75)
     p.add_argument("--generate-report", action="store_true")
@@ -266,6 +293,7 @@ def main(argv=None) -> None:
         min_play_gap=args.min_play_gap,
         min_play_length=args.min_play_length,
         max_play_length=args.max_play_length,
+        min_activity_ratio=args.min_activity_ratio,
         preroll=args.preroll,
         postroll=args.postroll,
         generate_report=args.generate_report,

--- a/analysis/play_classifier.py
+++ b/analysis/play_classifier.py
@@ -171,6 +171,8 @@ def classify_plays(
         formation = seg.get("formation", "") or ""
         formations.append(formation)
         cands = _best_matches_from_playbook(formation, playbook, topk=3)
+        if seg.get("low_activity"):
+            cands = [(n, s * 0.5) for n, s in cands]
         raw_scores.append({n: s for n, s in cands})
 
     results: List[Dict[str, Any]] = []
@@ -179,7 +181,7 @@ def classify_plays(
         scores = raw_scores[i - 1]
         sorted_cands = sorted(scores.items(), key=lambda x: x[1], reverse=True)
         top_name, top_score = (sorted_cands[0] if sorted_cands else ("", 0.0))
-        weak_flag = 0
+        weak_flag = 1 if seg.get("low_activity") else 0
         final_scores = scores
 
         if top_score < weak_threshold:

--- a/analysis/segmentation.py
+++ b/analysis/segmentation.py
@@ -100,5 +100,17 @@ def segment_video(
         if seg["t1"] - seg["t0"] >= min_play_length:
             cleaned.append(seg)
     if not cleaned:
-        cleaned = [{"id": "PLAY_001", "t0": 0.0, "t1": min(duration, max_play_length), "snap": 0.0, "whistle": min(duration, max_play_length)}]
+        cleaned = [{
+            "id": "PLAY_001",
+            "t0": 0.0,
+            "t1": min(duration, max_play_length),
+            "snap": 0.0,
+            "whistle": min(duration, max_play_length),
+        }]
+
+    for seg in cleaned:
+        mask = (times >= seg["t0"]) & (times <= seg["t1"])
+        seg["activity_ratio"] = float(np.mean(activity[mask] > 0)) if mask.any() else 0.0
+        seg["has_whistle"] = int(any((p >= seg["t0"]) and (p <= seg["t1"]) for p in audio_peaks))
+
     return cleaned


### PR DESCRIPTION
## Summary
- expose `--min-activity-ratio` and show segmentation config in logs and reports
- flag low-activity segments and annotate them in `plays_index.csv`
- down-rank low activity plays in classification

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1964b0a5c832d9a1dea7c349b874a