### PR TITLE
Add legacy CLI flag aliases and config summary

### DIFF
--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -365,10 +365,13 @@ def main(argv=None) -> None:
     p.add_argument("--min-activity-ratio", type=float, default=0.10)
     p.add_argument("--preroll", type=float, default=0.75)
     p.add_argument("--postroll", type=float, default=0.75)
-    p.add_argument("--generate-report", action="store_true")
-    p.add_argument("--generate-clips", action="store_true")
+    p.add_argument("--generate-report", dest="generate_report", action="store_true", help="write HTML report")
+    p.add_argument("--report", dest="generate_report", action="store_true", help=argparse.SUPPRESS)
+    p.add_argument("--generate-clips", dest="generate_clips", action="store_true", help="export per-play mp4 clips")
+    p.add_argument("--clips", dest="generate_clips", action="store_true", help=argparse.SUPPRESS)
     p.add_argument("--debug-weak", action="store_true")
     args = p.parse_args(argv)
+    print(f"[pipeline] config: {json.dumps(vars(args), sort_keys=True)}")
 
     run_pipeline(
         video=args.video,


### PR DESCRIPTION
## Summary
- support legacy `--report` and `--clips` flags as aliases for `--generate-report` and `--generate-clips`
- print one-line configuration summary after argument parsing so logs show report/clip settings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1a2b6df48832d8b21b31aa4d250a6