### PR TITLE
Always emit plays_index.csv with header

### DIFF
--- a/analysis/reporter.py
+++ b/analysis/reporter.py
@@ -3,11 +3,33 @@ import json
 from pathlib import Path
 
 
+# Unified plays_index.csv header
+PLAY_INDEX_FIELDS = [
+    "seg_id",
+    "start_s",
+    "end_s",
+    "clf_top1",
+    "clf_top1_conf",
+    "clf_top3",
+    "clf_weak_flag",
+    "low_activity",
+]
+
+
 def write_play_index(outdir: Path, play_rows: list[dict]):
-    with open(outdir / "plays_index.csv", "w", newline="") as f:
-        w = csv.DictWriter(f, fieldnames=list(play_rows[0].keys()))
-        w.writeheader()
-        w.writerows(play_rows)
+    """Write plays_index.csv with a consistent header.
+
+    The file is emitted even when ``play_rows`` is empty so downstream tools do
+    not fail with a missing CSV.  Any keys not present in ``play_rows`` are
+    filled with empty strings.
+    """
+
+    path = outdir / "plays_index.csv"
+    with path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=PLAY_INDEX_FIELDS)
+        writer.writeheader()
+        for row in play_rows:
+            writer.writerow({k: row.get(k, "") for k in PLAY_INDEX_FIELDS})
 
 
 def write_coach_summary(outdir: Path, game_meta: dict, plays: list[dict], players: dict):


### PR DESCRIPTION
## Summary
- Define a unified plays_index.csv header
- Always write plays_index.csv even when no play rows are present

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1a2c3cdb4832d8f0a536903c3939c