### PR TITLE
Handle incomplete pipeline runs

### DIFF
--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -93,11 +93,7 @@ def run_pipeline(
         & ((1 << 44) - 1)
     )[2:]
     run_dir = os.path.join(out_dir, "games", f"{_safe_name(tag)}__{short}")
-    os.makedirs(run_dir, exist_ok=True)
-    os.makedirs(os.path.join(run_dir, "clips"), exist_ok=True)
-
     report_dir = os.path.join(run_dir, "report")
-    os.makedirs(report_dir, exist_ok=True)
 
     playbook = load_playbook(playbook_path)
     print(f"[playbook] source={playbook_path}")
@@ -122,14 +118,6 @@ def run_pipeline(
             validator_warnings.append(
                 "Playbook labels missing from model: " + ", ".join(missing_in_model)
             )
-    if validator_warnings:
-        warn_path = os.path.join(report_dir, "warnings.txt")
-        with open(warn_path, "w", encoding="utf-8") as wf:
-            for line in validator_warnings:
-                wf.write(line + "\n")
-        for line in validator_warnings:
-            print(f"⚠️ {line}")
-
     segments = segment_video(
         video,
         min_play_length=min_play_length,
@@ -180,7 +168,6 @@ def run_pipeline(
                 "candidates": ";".join(f"{n}:{s:.2f}" for n, s in det.get("candidates", [])),
             }
         )
-
     csv_header = [
         "play_id",
         "t0",
@@ -203,11 +190,34 @@ def run_pipeline(
         "candidates",
     ]
     csv_path = os.path.join(run_dir, "plays_index.csv")
-    with open(csv_path, "w", newline="") as f:
-        w = csv.DictWriter(f, fieldnames=csv_header)
-        w.writeheader()
-        for r in rows:
-            w.writerow(r)
+    run_dir_created = False
+    try:
+        os.makedirs(run_dir, exist_ok=True)
+        run_dir_created = True
+        os.makedirs(os.path.join(run_dir, "clips"), exist_ok=True)
+        os.makedirs(report_dir, exist_ok=True)
+
+        if validator_warnings:
+            warn_path = os.path.join(report_dir, "warnings.txt")
+            with open(warn_path, "w", encoding="utf-8") as wf:
+                for line in validator_warnings:
+                    wf.write(line + "\n")
+            for line in validator_warnings:
+                print(f"⚠️ {line}")
+
+        with open(csv_path, "w", newline="") as f:
+            w = csv.DictWriter(f, fieldnames=csv_header)
+            w.writeheader()
+            for r in rows:
+                w.writerow(r)
+    except Exception as e:
+        if run_dir_created:
+            try:
+                with open(os.path.join(run_dir, "RUN_FAILED.txt"), "w", encoding="utf-8") as f:
+                    f.write(str(e))
+            except Exception:
+                pass
+        raise
 
     if generate_clips:
         for r in rows:

--- a/tests/test_pipeline_failures.py
+++ b/tests/test_pipeline_failures.py
@@ -1,0 +1,51 @@
+import csv
+import json
+import pytest
+
+from analysis import pipeline
+
+
+def test_pipeline_no_run_dir_on_load_failure(tmp_path):
+    out_dir = tmp_path / "out"
+    playbook_path = tmp_path / "missing.json"
+
+    with pytest.raises(FileNotFoundError):
+        pipeline.run_pipeline(
+            video="dummy.mp4",
+            team="WHITE",
+            playbook_path=str(playbook_path),
+            out_dir=str(out_dir),
+        )
+
+    assert not (out_dir / "games").exists()
+
+
+def test_pipeline_marks_failed_run(tmp_path, monkeypatch):
+    playbook = {"plays": [{"name": "Rit Sweep", "formation": "Rit"}]}
+    pb_path = tmp_path / "playbook.json"
+    pb_path.write_text(json.dumps(playbook))
+
+    out_dir = tmp_path / "out"
+
+    class BoomWriter(csv.DictWriter):
+        def writeheader(self):  # type: ignore[override]
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(
+        pipeline.csv, "DictWriter", lambda f, fieldnames: BoomWriter(f, fieldnames)
+    )
+
+    with pytest.raises(RuntimeError):
+        pipeline.run_pipeline(
+            video="dummy.mp4",
+            team="WHITE",
+            playbook_path=str(pb_path),
+            out_dir=str(out_dir),
+        )
+
+    games_dir = out_dir / "games"
+    run_dirs = list(games_dir.glob("*"))
+    assert run_dirs, "run dir should exist"
+    run_dir = run_dirs[0]
+    assert (run_dir / "RUN_FAILED.txt").exists()
+


### PR DESCRIPTION
## Summary
- avoid creating run directory until outputs are ready
- write RUN_FAILED.txt if pipeline crashes after run directory creation
- test pipeline failure handling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1a2cebe60832d82dd0e93634ae75a