### PR TITLE
feat: enhance spot check diagnostics

### DIFF
--- a/scripts/spot_check.sh
+++ b/scripts/spot_check.sh
@@ -17,6 +17,10 @@ fi
 for dir in "${run_dirs[@]}"; do
   echo "$dir"
 
+  if [[ -L "$dir" && "$dir" == *__latest ]]; then
+    echo "  -> $(readlink -f "$dir")"
+  fi
+
   if [[ -f "$dir/plays_index.csv" ]]; then
     head -n 6 "$dir/plays_index.csv" | sed 's/^/  /'
   else
@@ -44,6 +48,16 @@ for dir in "${run_dirs[@]}"; do
     fi
   else
     echo "  missing report/"
+  fi
+
+  if [[ -f "$dir/pipeline.log" ]]; then
+    echo "  pipeline.log (last 20 lines):"
+    tail -n 20 "$dir/pipeline.log" | sed 's/^/    /'
+  fi
+
+  if [[ -f "$dir/RUN_FAILED.txt" ]]; then
+    echo "  RUN_FAILED.txt contents:"
+    sed 's/^/    /' "$dir/RUN_FAILED.txt"
   fi
 
 done


### PR DESCRIPTION
## Summary
- show resolved run dir for __latest symlinks
- surface pipeline.log tail and RUN_FAILED.txt in spot_check

## Testing
- `bash -n scripts/spot_check.sh`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1a491d800832da4381d1e9837992c