### PR TITLE
feat: clean old runs when updating latest symlinks

### DIFF
--- a/scripts/ensure_single_analysis.sh
+++ b/scripts/ensure_single_analysis.sh
@@ -19,8 +19,4 @@ python -m analysis.pipeline \
 
 base="$(basename "$VID")"
 name="${base%.*}"
-run="$(scripts/run_utils.sh latest_run_for "$name")"
-[ -n "$run" ] && {
-  ln -sfn "$run" "$OUT_DIR/games/${name}__latest"
-  scripts/run_utils.sh clean_old_runs "$name"
-}
+scripts/update_latest_symlinks.sh --clean "$name"

--- a/scripts/run_batch.sh
+++ b/scripts/run_batch.sh
@@ -15,4 +15,4 @@ for F in "${FILES[@]}"; do
     --generate-clips
 done
 # refresh latest pointers
-bash scripts/update_latest_symlinks.sh
+bash scripts/update_latest_symlinks.sh --clean

--- a/scripts/update_latest_symlinks.sh
+++ b/scripts/update_latest_symlinks.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 # Update "__latest" symlinks under output/games
-# Usage: scripts/update_latest_symlinks.sh [basename...]
+# Usage: scripts/update_latest_symlinks.sh [--clean] [basename...]
 
 cd "$(dirname "$0")/.."
+
+CLEAN=0
+if [[ "${1:-}" == "--clean" ]]; then
+  CLEAN=1
+  shift
+fi
 
 update_one() {
   local BASE="$1"
@@ -24,6 +30,13 @@ update_one() {
   local rel
   rel=$(realpath --relative-to="output/games" "$newest")
   ln -sfn "$rel" "output/games/${BASE}__latest"
+
+  if (( CLEAN )); then
+    for run in "${RUNS[@]}"; do
+      [[ "$run" == "$newest" ]] && continue
+      rm -rf -- "$run"
+    done
+  fi
 }
 
 if [[ $# -gt 0 ]]; then


### PR DESCRIPTION
## Summary
- support optional `--clean` flag in `scripts/update_latest_symlinks.sh` to prune older run directories while refreshing `<basename>__latest` pointers
- trigger cleanup in batch and single-analysis helpers

## Testing
- `bash -n scripts/update_latest_symlinks.sh`
- `bash scripts/update_latest_symlinks.sh`
- `bash scripts/update_latest_symlinks.sh --clean`
- `bash -n scripts/run_batch.sh`
- `bash -n scripts/ensure_single_analysis.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b1a4876ad8832da092ba5ee8a5a456