### PR TITLE
Add always-capture wrapper and strengthen streaming fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -728,3 +728,13 @@ sudo systemctl stop nvargus-daemon || true
 ```
 
 If Studio shows “low bitrate”, increase -b:v/-maxrate/-bufsize in gameday.
+
+### Gameday capture and log collection
+
+Run `tools/gameday_always_capture.sh` to stream with guaranteed local recording and logs.  After a game, bundle today's artifacts with `tools/collect_today_logs.sh`.
+
+The capture script stops PipeWire for reliability.  To restore audio services after the game, run:
+
+```bash
+systemctl --user start pipewire pipewire-media-session
+```

--- a/stream_to_youtube.py
+++ b/stream_to_youtube.py
@@ -121,63 +121,132 @@ def build_audio_filter():
     return ",".join(chain)
 
 
-def build_ffmpeg_cmd(video_dev, mic_dev, rtmp_url, out_path, width=1280, height=720, fps=30):
-    enc = _pick_encoder()
+def default_pulse_src() -> str:
+    try:
+        return subprocess.check_output(["pactl", "get-default-source"], text=True).strip()
+    except Exception:
+        return ""
 
-    v_in = [
-        "-f", "v4l2",
-        "-input_format", "mjpeg",
-        "-thread_queue_size", "512",
-        "-framerate", str(fps),
-        "-video_size", f"{width}x{height}",
-        "-i", video_dev,
-    ]
-    a_in = [
-        "-f", "alsa",
-        "-thread_queue_size", "512",
-        "-ar", "48000",
-        "-ac", "1",
-        "-i", mic_dev,
-    ]
 
-    v_out = [
-        *enc,
-        "-pix_fmt", "yuv420p",
-        "-vf", f"scale={width}:{height},format=yuv420p",
-        "-g", str(fps*2),
-        "-bf", "0",
-        "-b:v", os.environ.get("VIDEO_BITRATE","3500k"),
-        "-maxrate", os.environ.get("VIDEO_MAXRATE","4000k"),
-        "-bufsize", os.environ.get("VIDEO_BUFSIZE","6000k"),
-        "-preset", os.environ.get("X264_PRESET","veryfast"),
-        "-tune", os.environ.get("X264_TUNE","zerolatency"),
-    ]
-    a_out = ["-c:a", "aac", "-b:a", "128k", "-flags", "+global_header"]
-
-    tee = os.environ.get("RECORD_MP4","1") == "1"
-    if tee:
-        mp4 = str(Path(out_path).with_suffix(".mp4"))
-        out = ["-f", "tee", f"[f=flv]{rtmp_url}|[f=mp4]{mp4}"]
-    else:
-        out = ["-f", "flv", rtmp_url]
-
-    return [
+def build_ffmpeg_cmd(
+    input_fmt: str,
+    audio_source_mode: str,
+    encode_mode: str,
+    record_file: Path,
+    output_url: str,
+) -> list[str]:
+    cmd = [
         "ffmpeg",
         "-hide_banner",
+        "-loglevel",
+        "info",
         "-nostdin",
+        "-thread_queue_size",
+        "1024",
+        "-f",
+        "v4l2",
+        "-use_wallclock_as_timestamps",
+        "1",
+        "-input_format",
+        input_fmt,
+        "-framerate",
+        "30",
+        "-video_size",
+        "1280x720",
+        "-i",
+        VIDEO_DEV,
+    ]
+
+    if audio_source_mode == "alsa":
+        cmd += [
+            "-thread_queue_size",
+            "512",
+            "-f",
+            "alsa",
+            "-ar",
+            "48000",
+            "-ac",
+            "1",
+            "-i",
+            "hw:1,0",
+        ]
+    elif audio_source_mode == "pulse":
+        cmd += [
+            "-thread_queue_size",
+            "512",
+            "-f",
+            "pulse",
+            "-i",
+            default_pulse_src(),
+        ]
+
+    cmd += [
         "-fflags",
         "+genpts",
-        *v_in,
-        *a_in,
+        "-start_at_zero",
+        "-reset_timestamps",
+        "1",
+        "-vsync",
+        "1",
         "-map",
         "0:v:0",
-        "-map",
-        "1:a:0",
-        *v_out,
-        *a_out,
-        "-shortest",
-        *out,
     ]
+
+    if audio_source_mode != "none":
+        cmd += ["-map", "1:a:0"]
+
+    if encode_mode == "copy":
+        cmd += ["-c:v", "copy"]
+    else:
+        cmd += [
+            "-c:v",
+            "libx264",
+            "-preset",
+            "veryfast",
+            "-tune",
+            "zerolatency",
+            "-pix_fmt",
+            "yuv420p",
+            "-b:v",
+            "3500k",
+            "-maxrate",
+            "4000k",
+            "-bufsize",
+            "6000k",
+            "-g",
+            "60",
+        ]
+
+    if audio_source_mode != "none":
+        cmd += ["-c:a", "aac", "-b:a", "128k", "-ar", "48000"]
+    else:
+        cmd += ["-an"]
+
+    tee = (
+        f"[f=flv:onfail=ignore]{output_url}|[f=mp4:movflags=+frag_keyframe+empty_moov+faststart]{record_file}"
+    )
+    cmd += ["-f", "tee", tee]
+    return cmd
+
+
+def retry_matrix(record_file: Path, output_url: str, log_file: Path) -> int:
+    attempts = [
+        ("h264", "alsa", "copy"),
+        ("h264", "pulse", "copy"),
+        ("h264", "none", "copy"),
+        ("mjpeg", "none", "x264"),
+    ]
+    rc = 1
+    for idx, (fmt, audio, enc) in enumerate(attempts):
+        if idx > 0:
+            logging.error(f"[fallback] retrying with {fmt}/{audio}/{enc}")
+        cmd = build_ffmpeg_cmd(fmt, audio, enc, record_file, output_url)
+        with log_file.open("a") as log_fp:
+            proc = subprocess.run(cmd, stdout=log_fp, stderr=log_fp)
+            rc = proc.returncode
+        if rc == 0:
+            break
+    return rc
 
 
 
@@ -1136,7 +1205,8 @@ def main() -> None:
     parser.add_argument(
         "--keyint_min", type=int, default=30, help="Minimum GOP keyframe interval"
     )
-    parser.add_argument("--record", action="store_true", help="Also record locally")
+    parser.add_argument("--record", action="store_true", default=True, help="Also record locally")
+    parser.add_argument("--record-dir", default="video", help="Directory for recordings")
     parser.add_argument("--audio_meter", action="store_true", help="Overlay audio levels")
     parser.add_argument("--dry_run", action="store_true", help="Test devices only")
     parser.add_argument(
@@ -1155,6 +1225,7 @@ def main() -> None:
     args = parser.parse_args()
 
     # CLI has highest priority, then env, then auto-pick
+    global VIDEO_DEV
     VIDEO_DEV = (
         getattr(args, "video_device", None)
         or os.environ.get("VIDEO_DEVICE")
@@ -1215,31 +1286,19 @@ def main() -> None:
     logging.info(f"📡 Streaming to: {mask_stream_url(RTMP_URL)}")
     logging.info("🎥 Using video device: %s", VIDEO_DEV)
 
-    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-    log_dir = Path("livestream_logs")
-    log_dir.mkdir(exist_ok=True)
-    base_path = log_dir / f"stream_{timestamp}"
-    cmd = build_ffmpeg_cmd(
-        VIDEO_DEV,
-        args.mic_device or "hw:1,0",
-        RTMP_URL,
-        base_path,
-    )
-    logging.info("FFmpeg command: %s", " ".join(shlex.quote(c) for c in cmd))
-
-    with base_path.with_suffix(".log").open("w") as log_fp:
-        proc = subprocess.Popen(cmd, stdout=log_fp, stderr=log_fp)
-        ret = proc.wait()
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    base_dir = Path(__file__).resolve().parent
+    log_dir = (base_dir / "livestream_logs").resolve()
+    log_dir.mkdir(parents=True, exist_ok=True)
+    out_dir = (base_dir / args.record_dir).resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    record_file = unique_path(out_dir / f"game_{timestamp}.mp4")
+    os.environ["FFREPORT"] = f"file={log_dir}/ffmpeg_{timestamp}.log:level=32"
+    log_file = log_dir / f"stream_{timestamp}.log"
+    ret = retry_matrix(record_file, RTMP_URL, log_file)
     if ret != 0:
-        hint = (
-            "FFmpeg exited non-zero.\n"
-            "Hints:\n"
-            " • Hardware encoder failed; set USE_SW_ENC=1 or PREFERRED_ENCODERS=libx264\n"
-            " • Check devices: v4l2-ctl --list-devices; arecord -l\n"
-            f" • See {base_path.with_suffix('.log')} for details.\n"
-        )
-        logging.error(hint)
         sys.exit(ret)
+    logging.info(f"[done] local record: {record_file}")
     return
 
     global WIDTH, HEIGHT, FPS

--- a/tools/collect_today_logs.sh
+++ b/tools/collect_today_logs.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+ROOT="$HOME/mca-gameday-camera"
+LOGDIR="$ROOT/livestream_logs"
+VIDDIR="$ROOT/video"
+TS=$(date +%Y%m%d_%H%M%S)
+OUT="$ROOT/mca_review_${TS}.tgz"
+
+find "$LOGDIR" -type f -daystart -mtime -0 -print > /dev/null 2>&1 || true
+tar czf "$OUT" \
+  "$LOGDIR"/*.log \
+  $(ls -t "$VIDDIR"/game_*.mp4 2>/dev/null | head -1) \
+  2>/dev/null || true
+
+echo "Packed: $OUT"

--- a/tools/gameday_always_capture.sh
+++ b/tools/gameday_always_capture.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT="$HOME/mca-gameday-camera"
+LOGDIR="$ROOT/livestream_logs"
+VIDDIR="$ROOT/video"
+mkdir -p "$LOGDIR" "$VIDDIR"
+
+# -------- helpers --------
+ts() { date +%Y%m%d-%H%M%S; }
+
+have_audio_alsa() { arecord -l 2>/dev/null | grep -q 'card 1: .* device 0'; }
+default_pulse_src() { pactl get-default-source 2>/dev/null || true; }
+
+run_under_script() {
+  local cmd="$1" out="$2"
+  script -qefc "$cmd" "$out"
+}
+
+# -------- free device + quiet PipeWire grabbing --------
+pkill -9 -f 'ffmpeg.*v4l2' 2>/dev/null || true
+fuser -km /dev/video0 2>/dev/null || true
+systemctl --user stop pipewire pipewire-media-session 2>/dev/null || true
+
+# -------- force camera to H.264 720p30 --------
+v4l2-ctl -d /dev/video0 --set-fmt-video=width=1280,height=720,pixelformat=H264 --set-parm=30 || true
+
+# -------- preflight: prove local write & frames --------
+PRE=/tmp/_preflight_cam.mkv
+ffmpeg -hide_banner -loglevel error -nostdin \
+  -f v4l2 -input_format h264 -framerate 30 -video_size 1280x720 -i /dev/video0 \
+  -t 5 -c copy "$PRE" || true
+
+SZ=$(stat -c%s "$PRE" 2>/dev/null || echo 0)
+if [ "$SZ" -lt 3000000 ]; then
+  echo "[abort] camera preflight didn’t produce usable video ($SZ bytes). Check cable/port/camera mode."
+  exit 1
+fi
+
+# -------- FFmpeg self-report --------
+export FFREPORT="file=$LOGDIR/ffmpeg_$(ts).log:level=32"
+
+# -------- outputs --------
+YOUTUBE="${YOUTUBE_RTMP_URL:-rtmps://a.rtmps.youtube.com/live2/REPLACE_ME}"
+OUT="$VIDDIR/game_$(ts).mp4"
+TEE="[f=flv:onfail=ignore]$YOUTUBE|[f=mp4:movflags=+frag_keyframe+empty_moov+faststart]$OUT"
+TERM="$LOGDIR/terminal_$(ts).log"
+
+# -------- primary pipeline: H.264 copy + ALSA hw:1,0 --------
+CMD1="ffmpeg -hide_banner -loglevel info -nostdin \
+  -thread_queue_size 1024 \
+  -f v4l2 -use_wallclock_as_timestamps 1 \
+  -input_format h264 -framerate 30 -video_size 1280x720 -i /dev/video0 \
+  -thread_queue_size 512 -f alsa -ar 48000 -ac 1 -i hw:1,0 \
+  -fflags +genpts -start_at_zero -reset_timestamps 1 -vsync 1 \
+  -map 0:v:0 -map 1:a:0 \
+  -c:v copy \
+  -c:a aac -b:a 128k -ar 48000 \
+  -f tee \"$TEE\""
+
+set +e
+run_under_script "$CMD1" "$TERM"
+RC=$?
+set -e
+
+# -------- fallback matrix --------
+if [ $RC -ne 0 ] || ! grep -q "frame=" "$TERM"; then
+  echo "[fallback] re-running with Pulse default audio (if present)"
+  PULSE_SRC=$(default_pulse_src)
+  CMD2="ffmpeg -hide_banner -loglevel info -nostdin \
+    -thread_queue_size 1024 \
+    -f v4l2 -use_wallclock_as_timestamps 1 \
+    -input_format h264 -framerate 30 -video_size 1280x720 -i /dev/video0 \
+    -thread_queue_size 512 -f pulse -i \"$PULSE_SRC\" \
+    -fflags +genpts -start_at_zero -reset_timestamps 1 -vsync 1 \
+    -map 0:v:0 -map 1:a:0 \
+    -c:v copy \
+    -c:a aac -b:a 128k -ar 48000 \
+    -f tee \"$TEE\""
+  set +e
+  run_under_script "$CMD2" "$TERM"
+  RC=$?
+  set -e
+fi
+
+if [ $RC -ne 0 ] || ! grep -q "frame=" "$TERM"; then
+  echo "[fallback] re-running video-only (no audio) to guarantee a local file"
+  CMD3="ffmpeg -hide_banner -loglevel info -nostdin \
+    -thread_queue_size 1024 \
+    -f v4l2 -use_wallclock_as_timestamps 1 \
+    -input_format h264 -framerate 30 -video_size 1280x720 -i /dev/video0 \
+    -fflags +genpts -start_at_zero -reset_timestamps 1 -vsync 1 \
+    -map 0:v:0 \
+    -c:v copy \
+    -an \
+    -f tee \"$TEE\""
+  set +e
+  run_under_script "$CMD3" "$TERM"
+  RC=$?
+  set -e
+fi
+
+if [ $RC -ne 0 ] || ! grep -q "frame=" "$TERM"; then
+  echo "[fallback] re-running with MJPEG input → libx264 encode"
+  # if H.264-by-copy is flaky (SPS/PPS/no frame), encode from MJPEG
+  CMD4="ffmpeg -hide_banner -loglevel info -nostdin \
+    -thread_queue_size 1024 \
+    -f v4l2 -use_wallclock_as_timestamps 1 \
+    -input_format mjpeg -framerate 30 -video_size 1280x720 -i /dev/video0 \
+    -fflags +genpts -start_at_zero -reset_timestamps 1 -vsync 1 \
+    -map 0:v:0 \
+    -c:v libx264 -preset veryfast -tune zerolatency -pix_fmt yuv420p \
+    -b:v 3500k -maxrate 4000k -bufsize 6000k -g 60 \
+    -an \
+    -f tee \"$TEE\""
+  set +e
+  run_under_script "$CMD4" "$TERM"
+  RC=$?
+  set -e
+fi
+
+if [ $RC -ne 0 ]; then
+  echo "[fail] All pipelines failed. See: $TERM and $(ls -t $LOGDIR/ffmpeg_*.log | head -1)"
+  exit $RC
+fi
+
+echo "[done] local file: $OUT"
+echo "[done] terminal log: $TERM"
+echo "[done] ffmpeg report: $(ls -t $LOGDIR/ffmpeg_*.log | head -1)"
+echo "# To restore audio services after the game: systemctl --user start pipewire pipewire-media-session"


### PR DESCRIPTION
## Summary
- ensure gameday runs always capture locally and log FFmpeg session
- harden stream_to_youtube with automatic audio/video fallbacks and onfail=ignore tee
- add utility to bundle today's logs and mention usage in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1aeb3f210832dbd302b471c3feac0