### PR TITLE
Add asset verification script

### DIFF
--- a/scripts/verify_assets.sh
+++ b/scripts/verify_assets.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+echo "[verify] environment"
+command -v python >/dev/null || { echo "python missing"; exit 1; }
+
+echo "[verify] pipeline can import"
+python - <<'PY'
+import importlib, json, os, sys
+m = importlib.import_module("analysis.pipeline")
+print("[ok] pipeline import")
+
+# Optional: print default model paths if your code has them
+try:
+    from analysis import classifiers
+    print("[info] classifier defaults:", getattr(classifiers, "DEFAULT_PLAY_CKPT", None), getattr(classifiers, "DEFAULT_FORMATION_CKPT", None))
+except Exception as e:
+    print("[warn] cannot import classifiers:", e)
+PY
+
+echo "[verify] look for weights/labels"
+find models -maxdepth 2 -type f -print || true
+echo "[done]"


### PR DESCRIPTION
## Summary
- add `scripts/verify_assets.sh` to verify environment, pipeline import, and available model assets

## Testing
- `./scripts/verify_assets.sh`
- `pytest tests/test_manifest_integrity.py`


------
https://chatgpt.com/codex/tasks/task_e_68b209185758832d84d0d1893a2b71f2