### PR TITLE
Ensure play classification always emits predictions

### DIFF
--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -163,15 +163,15 @@ def run_pipeline(
                 "snap": float(seg.get("snap", seg["t0"])),
                 "whistle": float(seg.get("whistle", seg["t1"])),
                 "clip_path": "",
-                "formation": det.get("formation", "Unknown"),
+                "formation": det.get("formation") or "",
                 "formation_confidence": float(det.get("formation_confidence", 0.0)),
                 "play_family": det.get("play_family", "Unknown"),
                 "playcall_confidence": float(det.get("playcall_confidence", 0.0)),
                 # Observability fields
                 "clf_top1": det.get("clf_top1", det.get("play_family", "")),
                 "clf_top1_conf": float(det.get("clf_top1_conf", det.get("playcall_confidence", 0.0))),
-                "clf_top3": ";".join(
-                    f"{n}:{s:.2f}" for n, s in det.get("clf_top3", det.get("candidates", []))
+                "clf_top3": "|".join(
+                    f"{n}:{float(s):.3f}" for n, s in det.get("clf_top3", det.get("candidates", []))
                 ),
                 "clf_weak_flag": int(det.get("clf_weak_flag", 0)),
                 "clf_family": det.get("clf_family", ""),

--- a/analysis/play_classifier.py
+++ b/analysis/play_classifier.py
@@ -109,11 +109,9 @@ def _best_matches_from_playbook(
         if formation and (pf or formations):
             pool = [pf, *formations]
             for f in pool:
-                if f and f.lower() in formation.lower() or formation.lower() in f.lower():
+                if f and (f.lower() in formation.lower() or formation.lower() in f.lower()):
                     formation_match = True
                     break
-            if not formation_match:
-                continue
         # Compare the formation text with the play name as a loose proxy for a
         # classifier score.  This keeps the implementation deterministic while
         # still yielding a range of confidences for tests to exercise.
@@ -171,6 +169,8 @@ def classify_plays(
         formation = seg.get("formation", "") or ""
         formations.append(formation)
         cands = _best_matches_from_playbook(formation, playbook, topk=3)
+        if not cands:
+            cands = _best_matches_from_playbook("", playbook, topk=3)
         if seg.get("low_activity"):
             cands = [(n, s * 0.5) for n, s in cands]
         raw_scores.append({n: s for n, s in cands})


### PR DESCRIPTION
## Summary
- Remove formation gating so play classification always considers all plays
- Fallback to generic candidates when none match the detected formation
- Always output top-k predictions and leave formation blank when unknown

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b209447c58832d8bfa533ba41a302f