### PR TITLE
fix: normalize classifier inputs

### DIFF
--- a/highlight_dataset.py
+++ b/highlight_dataset.py
@@ -35,7 +35,8 @@ class HighlightClipDataset(torch.utils.data.Dataset):
         success, frame = cap.read()
         while success and len(frames) < self.clip_len:
             frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-            tensor = torch.from_numpy(frame).permute(2, 0, 1).float()
+            frame = frame.astype("float32") / 255.0
+            tensor = torch.from_numpy(frame).permute(2, 0, 1)
             if self.transform:
                 tensor = self.transform(tensor)
             frames.append(tensor)

--- a/play_classifier.py
+++ b/play_classifier.py
@@ -74,7 +74,8 @@ class PlayClassifier:
             return (-1, -1, -1, -1)
 
         # convert BGR frame to RGB as expected by YOLO
-        img = frame[:, :, ::-1]
+        img = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+        img = img.astype("float32") / 255.0
         results = self.model(img)
         if results is None or len(results.xyxy[0]) == 0:
             return (-1, -1, -1, -1)

--- a/play_inference.py
+++ b/play_inference.py
@@ -1,5 +1,6 @@
 import argparse
 import csv
+import logging
 import os
 import subprocess
 from pathlib import Path
@@ -10,22 +11,15 @@ try:
     import torch
     from torch import nn
     from torchvision import models, transforms
+    from torchvision.transforms import InterpolationMode
 except Exception:  # pragma: no cover - optional dependency
     cv2 = None
     torch = None
 
 
-class ToFloatNormalize(nn.Module):
-    """Convert ``uint8`` tensor to float and normalize to ImageNet stats."""
-
-    def __init__(self) -> None:
-        super().__init__()
-        self.mean = torch.tensor([0.485, 0.456, 0.406]).view(3, 1, 1)
-        self.std = torch.tensor([0.229, 0.224, 0.225]).view(3, 1, 1)
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
-        x = x / 255.0
-        return (x - self.mean) / self.std
+MEAN = [0.485, 0.456, 0.406]
+STD = [0.229, 0.224, 0.225]
+log = logging.getLogger(__name__)
 
 
 def seconds_to_time(secs: float) -> str:
@@ -70,7 +64,8 @@ def read_clip(path: Path, clip_len: int, transform) -> torch.Tensor:
     success, frame = cap.read()
     while success and len(frames) < clip_len:
         frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-        tensor = torch.from_numpy(frame).permute(2, 0, 1).float()
+        frame = frame.astype("float32") / 255.0
+        tensor = torch.from_numpy(frame).permute(2, 0, 1)
         if transform:
             tensor = transform(tensor)
         frames.append(tensor)
@@ -95,16 +90,20 @@ def run_inference(video: str, checkpoint: str, segment_time: int, clips_dir: str
     model, inv_map = load_model(checkpoint, device)
 
     transform = transforms.Compose([
-        transforms.Resize((224, 224)),
-        ToFloatNormalize(),
+        transforms.Resize((224, 224), interpolation=InterpolationMode.BILINEAR),
+        transforms.Normalize(mean=MEAN, std=STD),
     ])
 
     log_rows = []
     clip_files = sorted(clip_dir.glob("clip_*.mp4"))
+    logged_stats = False
     for idx, clip_path in enumerate(clip_files):
         start = idx * segment_time
         end = start + segment_time
         clip = read_clip(clip_path, 16, transform)
+        if not logged_stats:
+            log.info("input clip stats mean=%.4f std=%.4f", clip.mean().item(), clip.std().item())
+            logged_stats = True
         clip = clip.unsqueeze(0).to(device)
         with torch.no_grad():
             out = model(clip)
@@ -123,6 +122,7 @@ def run_inference(video: str, checkpoint: str, segment_time: int, clips_dir: str
 
 
 def main() -> None:
+    logging.basicConfig(level=logging.INFO)
     parser = argparse.ArgumentParser(description="Run play classifier on full game video")
     parser.add_argument("video", help="Full game video file")
     parser.add_argument("--model", required=True, help="Path to trained model checkpoint")

--- a/reclassify_old_clips.py
+++ b/reclassify_old_clips.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import argparse
 import csv
 import json
+import logging
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List
@@ -11,10 +12,13 @@ from typing import Any, Dict, List
 try:
     import torch
     from torchvision import transforms
+    from torchvision.transforms import InterpolationMode
 except Exception:  # pragma: no cover - optional
     torch = None  # type: ignore
 
-from play_inference import ToFloatNormalize, load_model, read_clip
+from play_inference import load_model, read_clip, MEAN, STD
+
+log = logging.getLogger(__name__)
 
 LOG_PATH = Path("logs/learning_log.json")
 
@@ -77,10 +81,14 @@ def reclassify(
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     model_path = find_latest_model(model_dir)
     model, inv_map = load_model(str(model_path), device)
-    transform = transforms.Compose([transforms.Resize((224, 224)), ToFloatNormalize()])
+    transform = transforms.Compose([
+        transforms.Resize((224, 224), interpolation=InterpolationMode.BILINEAR),
+        transforms.Normalize(mean=MEAN, std=STD),
+    ])
 
     dataset_dir = dataset_path.parent
     updated = False
+    logged_stats = False
     for item in entries:
         rel_clip = Path(item["filepath"])
         clip_path = rel_clip if rel_clip.is_absolute() else dataset_dir / rel_clip
@@ -90,6 +98,9 @@ def reclassify(
         time_code = item.get("time", "")
 
         clip = read_clip(clip_path, clip_len, transform)
+        if not logged_stats:
+            log.info("input clip stats mean=%.4f std=%.4f", clip.mean().item(), clip.std().item())
+            logged_stats = True
         clip = clip.unsqueeze(0).to(device)
         with torch.no_grad():
             output = model(clip)
@@ -123,6 +134,7 @@ def reclassify(
 
 
 def main() -> None:
+    logging.basicConfig(level=logging.INFO)
     parser = argparse.ArgumentParser(description="Reclassify highlight clips")
     parser.add_argument(
         "dataset",

--- a/train_play_classifier.py
+++ b/train_play_classifier.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import logging
 from pathlib import Path
 from typing import Dict, List, Tuple
 
@@ -9,21 +10,14 @@ import torch
 from torch import nn
 from torch.utils.data import DataLoader
 from torchvision import models, transforms
+from torchvision.transforms import InterpolationMode
 
 from highlight_dataset import HighlightClipDataset
 
 
-class ToFloatNormalize(torch.nn.Module):
-    """Convert ``uint8`` tensor to float and normalize to ImageNet stats."""
-
-    def __init__(self) -> None:
-        super().__init__()
-        self.mean = torch.tensor([0.485, 0.456, 0.406]).view(3, 1, 1)
-        self.std = torch.tensor([0.229, 0.224, 0.225]).view(3, 1, 1)
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
-        x = x / 255.0
-        return (x - self.mean) / self.std
+MEAN = [0.485, 0.456, 0.406]
+STD = [0.229, 0.224, 0.225]
+log = logging.getLogger(__name__)
 
 
 class PlayVideoDataset(HighlightClipDataset):
@@ -31,8 +25,8 @@ class PlayVideoDataset(HighlightClipDataset):
 
     def __init__(self, csv_file: str | Path, label_map: Dict[str, int], clip_len: int = 16) -> None:
         transform = transforms.Compose([
-            transforms.Resize((224, 224)),
-            ToFloatNormalize(),
+            transforms.Resize((224, 224), interpolation=InterpolationMode.BILINEAR),
+            transforms.Normalize(mean=MEAN, std=STD),
         ])
         super().__init__(csv_file, clip_len=clip_len, transform=transform)
         self.label_map = label_map
@@ -53,7 +47,11 @@ def train_epoch(model: nn.Module, loader: DataLoader, criterion: nn.Module, opti
     running_loss = 0.0
     correct = 0
     total = 0
+    logged_stats = False
     for clips, labels in loader:
+        if not logged_stats:
+            log.info("input batch stats mean=%.4f std=%.4f", clips.mean().item(), clips.std().item())
+            logged_stats = True
         clips = clips.to(device)
         labels = labels.to(device)
         optimizer.zero_grad()
@@ -71,6 +69,7 @@ def train_epoch(model: nn.Module, loader: DataLoader, criterion: nn.Module, opti
 
 
 def main() -> None:
+    logging.basicConfig(level=logging.INFO)
     parser = argparse.ArgumentParser(description="Train play classification model")
     parser.add_argument("csv", help="metadata CSV with filepath and label columns")
     parser.add_argument("--epochs", type=int, default=5)


### PR DESCRIPTION
## Summary
- normalize highlight dataset frames to RGB float32 before transforms
- align inference and training transforms with ImageNet mean/std and log input stats
- update reclassification and YOLO wrappers for consistent color handling

## Testing
- `pytest` *(fails: SyntaxError in analysis/pipeline.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b2123df944832d80e4737371a5bd7f