### PR TITLE
Add classifier health metrics to run report

### DIFF
--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os, sys, json, pathlib, argparse, csv, subprocess, logging, re
+from collections import Counter
 
 try:
     # When executed as module (recommended)
@@ -161,6 +162,8 @@ def run_pipeline(
     # ------------------------------------------------------------------
     validator_warnings: list[str] = []
     unmapped_pb_norms: set[str] = set()
+    missing_in_playbook: list[str] = []
+    missing_in_model: list[str] = []
     model_labels = _load_model_labels(play_ckpt, play_labels)
     if model_labels:
         if hasattr(playbook, "plays"):
@@ -169,7 +172,6 @@ def run_pipeline(
             pb_labels = {p.get("name", "") for p in playbook.get("plays", [])}
         norm_pb = { _norm_label(p): p for p in pb_labels if p }
         norm_model = { _norm_label(m): m for m in model_labels if m }
-        missing_in_playbook: list[str] = []
         for norm, orig in norm_model.items():
             if norm not in norm_pb:
                 missing_in_playbook.append(orig)
@@ -395,6 +397,18 @@ def run_pipeline(
     # Basic HTML report with sanity checks
     # ------------------------------------------------------------------
     if generate_report:
+        seg_count = len(rows)
+        weak_count = sum(r.get("clf_weak_flag", 0) for r in rows)
+        weak_pct = (weak_count / seg_count * 100.0) if seg_count else 0.0
+        avg_conf = (
+            sum(r.get("clf_top1_conf", 0.0) for r in rows) / seg_count if seg_count else 0.0
+        )
+        label_counts = Counter(r.get("clf_top1", "") for r in rows)
+        top_labels = ", ".join(
+            f"{n} ({c})" for n, c in label_counts.most_common(5) if n
+        )
+        unmapped_labels = sorted(set(missing_in_playbook + missing_in_model))
+
         if rows:
             with open(index_path, "w", encoding="utf-8") as f:
                 f.write("<html><head><meta charset='utf-8'><title>Run Report</title></head><body>\n")
@@ -405,15 +419,33 @@ def run_pipeline(
                     f"max_play_length={max_play_length}</li>\n"
                 )
                 if validator_warnings:
-                    for line in validator_warnings:
-                        f.write(f"<li>{line}</li>\n")
+                    f.write("<li><a href='warnings.txt'>Label/playbook mismatches</a></li>\n")
                 else:
                     f.write("<li>No unmapped labels</li>\n")
+                f.write("</ul>\n")
+
+                f.write("<h2>Classifier Health</h2>\n<ul>\n")
+                f.write(f"<li>Segments: {seg_count}</li>\n")
+                f.write(
+                    f"<li>Weak classifications: {weak_count} ({weak_pct:.1f}% weak)</li>\n"
+                )
+                f.write(f"<li>Average top1 confidence: {avg_conf:.3f}</li>\n")
+                if top_labels:
+                    f.write(f"<li>Top predictions: {top_labels}</li>\n")
+                if unmapped_labels:
+                    f.write(
+                        "<li>Unmapped labels: " + ", ".join(unmapped_labels) + "</li>\n"
+                    )
+                if validator_warnings:
+                    f.write("<li><a href='warnings.txt'>warnings.txt</a></li>\n")
                 f.write("</ul>\n</body></html>\n")
         else:
             # Stub report when no segments were detected.
             with open(index_path, "w", encoding="utf-8") as f:
-                f.write("<html><body><p>0 segments detected</p></body></html>")
+                f.write("<html><body><p>0 segments detected</p>")
+                if validator_warnings:
+                    f.write("<p><a href='warnings.txt'>warnings.txt</a></p>")
+                f.write("</body></html>")
 
 
     # Update the "__latest" symlink for this video base

--- a/tests/test_classifier_health_section.py
+++ b/tests/test_classifier_health_section.py
@@ -1,0 +1,41 @@
+import json, os, pathlib, torch
+from analysis import pipeline
+
+
+def test_classifier_health_section(tmp_path, monkeypatch):
+    playbook = {"plays": [{"name": "Rit Sweep", "formation": "Rit"}]}
+    pb_path = tmp_path / "playbook.json"
+    pb_path.write_text(json.dumps(playbook))
+
+    ckpt = tmp_path / "model.pt"
+    torch.save({"label_map": {"Rit Sweep": 0}}, ckpt)
+    monkeypatch.setenv("PLAY_CLASSIFIER_MODEL", str(ckpt))
+
+    def fake_segment_video(video, **kwargs):
+        return [{"t0": 0.0, "t1": 5.0}]
+
+    def fake_classify_plays(segments, playbook, team, **kwargs):
+        return [
+            {
+                "play_family": "Rit Sweep",
+                "playcall_confidence": 0.9,
+                "clf_top1": "Rit Sweep",
+                "clf_top1_conf": 0.9,
+            }
+        ]
+
+    monkeypatch.setattr(pipeline, "segment_video", fake_segment_video)
+    monkeypatch.setattr(pipeline, "classify_plays", fake_classify_plays)
+
+    run_dir = pipeline.run_pipeline(
+        video="dummy.mp4",
+        team="WHITE",
+        playbook_path=str(pb_path),
+        out_dir=str(tmp_path / "out"),
+        generate_report=True,
+    )
+
+    html = (pathlib.Path(run_dir) / "report" / "index.html").read_text()
+    assert "Classifier Health" in html
+    assert "Segments: 1" in html
+    assert "Average top1 confidence: 0.900" in html


### PR DESCRIPTION
## Summary
- Extend pipeline report generation with a 'Classifier Health' section showing segment counts, weak prediction stats, confidence averages, top predicted labels, and any unmapped labels
- Link to `warnings.txt` when label/playbook mismatches exist
- Cover HTML reporting with a unit test exercising the new section

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b21b403274832d82b77479b3655303