### PR TITLE
Add env-aware device selection for play classifier

### DIFF
--- a/play_classifier.py
+++ b/play_classifier.py
@@ -18,6 +18,7 @@ import json
 import shutil
 import csv
 import math
+import logging
 from pathlib import Path
 
 try:
@@ -35,7 +36,7 @@ except Exception:  # pragma: no cover - optional dependency
 class PlayClassifier:
     """Classifies sequences of frames for touchdown-like events."""
 
-    def __init__(self, model_path: str = "yolov5s.pt", device: str = "cpu") -> None:
+    def __init__(self, model_path: str = "yolov5s.pt", device: str | None = None) -> None:
         """Load a YOLOv5 model.
 
         Parameters
@@ -45,11 +46,19 @@ class PlayClassifier:
             to fetch the model if ``model_path`` points to a known name
             like ``yolov5s.pt``.
         device:
-            Device string understood by ``torch`` (e.g. ``"cpu"`` or
-            ``"cuda"``).
+            Optional device string understood by ``torch``. When ``None``,
+            the device is chosen based on CUDA availability.
         """
         if torch is None:
             raise ImportError("PyTorch is required for PlayClassifier")
+
+        if device is None:
+            device = "cuda:0" if torch.cuda.is_available() else "cpu"
+        elif device != "cpu" and not torch.cuda.is_available():
+            logging.info("[classifier] device=%s unavailable, falling back to cpu", device)
+            device = "cpu"
+
+        logging.info("[classifier] device=%s", device)
 
         # load model via torch.hub (from ultralytics) or local path
         self.model = torch.hub.load(

--- a/tests/test_play_classifier_device.py
+++ b/tests/test_play_classifier_device.py
@@ -1,0 +1,40 @@
+import logging
+import play_classifier
+
+class DummyModel:
+    def __init__(self):
+        self.device = None
+    def to(self, device):
+        self.device = device
+        return self
+    def eval(self):
+        pass
+
+class DummyHub:
+    def load(self, *args, **kwargs):
+        return DummyModel()
+
+class DummyCuda:
+    def __init__(self, available: bool):
+        self._available = available
+    def is_available(self):
+        return self._available
+
+class DummyTorch:
+    def __init__(self, available: bool):
+        self.cuda = DummyCuda(available)
+        self.hub = DummyHub()
+
+def test_uses_cpu_when_cuda_unavailable(monkeypatch, caplog):
+    monkeypatch.setattr(play_classifier, "torch", DummyTorch(False))
+    caplog.set_level(logging.INFO)
+    pc = play_classifier.PlayClassifier(model_path="x.pt")
+    assert pc.device == "cpu"
+    assert "[classifier] device=cpu" in caplog.text
+
+def test_uses_cuda_when_available(monkeypatch, caplog):
+    monkeypatch.setattr(play_classifier, "torch", DummyTorch(True))
+    caplog.set_level(logging.INFO)
+    pc = play_classifier.PlayClassifier(model_path="x.pt")
+    assert pc.device == "cuda:0"
+    assert "[classifier] device=cuda:0" in caplog.text


### PR DESCRIPTION
## Summary
- Detect CUDA availability and log chosen device in `PlayClassifier`
- Add tests ensuring GPU/CPU selection does not fail when CUDA missing

## Testing
- `PYTHONDONTWRITEBYTECODE=1 pytest tests/test_play_classifier_device.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b21ce73abc832da85f19f11d3332c4