### PR TITLE
Emit play classifier predictions with softmax and canonical fields

### DIFF
--- a/analysis/harmonizer.py
+++ b/analysis/harmonizer.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+"""Simple label harmonizer.
+
+This module provides a minimal ``harmonize`` helper which normalises a label
+into a canonical form.  The logic is intentionally lightweight – it simply
+strips leading/trailing whitespace, collapses internal whitespace and converts
+text to lower-case.  This mirrors the behaviour of the production harmoniser
+used in the full pipeline.
+"""
+
+import re
+
+
+def harmonize(label: str) -> str:
+    """Return a canonical representation of ``label``.
+
+    Parameters
+    ----------
+    label:
+        Raw label string which may contain inconsistent spacing or casing.
+
+    Returns
+    -------
+    str
+        Normalised label suitable for *_canon fields.  Empty input results in
+        an empty string.
+    """
+
+    if not label:
+        return ""
+    # Collapse whitespace and lower-case the label
+    return re.sub(r"\s+", " ", label).strip().lower()

--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import os, sys, json, pathlib, argparse, csv, subprocess, logging, re
 from collections import Counter
 
+from .harmonizer import harmonize
+
 try:
     # When executed as module (recommended)
     from .segmentation import segment_video
@@ -189,7 +191,6 @@ def run_pipeline(
     # Validate classifier ↔ playbook wiring
     # ------------------------------------------------------------------
     validator_warnings: list[str] = []
-    unmapped_pb_norms: set[str] = set()
     missing_in_playbook: list[str] = []
     missing_in_model: list[str] = []
     if clf is not None:
@@ -205,7 +206,6 @@ def run_pipeline(
                 if norm not in norm_pb:
                     missing_in_playbook.append(orig)
             missing_in_model = [orig for norm, orig in norm_pb.items() if norm not in norm_model]
-            unmapped_pb_norms = { _norm_label(lbl) for lbl in missing_in_model }
             if missing_in_playbook:
                 validator_warnings.append(
                     "Model labels not in playbook: " + ", ".join(sorted(missing_in_playbook))
@@ -281,6 +281,9 @@ def run_pipeline(
     for seg, det in zip(segments, classifications):
         pid = det.get("play_id") or f"PLAY_{len(rows)+1:03d}"
 
+        top1 = det.get("clf_top1", det.get("play_family", ""))
+        top1_conf = float(det.get("clf_top1_conf", det.get("playcall_confidence", 0.0)))
+
         row = {
             "play_id": pid,
             "t0": float(seg["t0"]),
@@ -289,25 +292,27 @@ def run_pipeline(
             "whistle": float(seg.get("whistle", seg["t1"])),
             "clip_path": "",
             "formation": det.get("formation") or "",
+            "formation_canon": harmonize(det.get("formation") or ""),
             "formation_confidence": float(det.get("formation_confidence", 0.0)),
             "play_family": det.get("play_family", "Unknown"),
             "playcall_confidence": float(det.get("playcall_confidence", 0.0)),
             # Observability fields
-            "clf_top1": det.get("clf_top1", det.get("play_family", "")),
-            "clf_top1_conf": float(det.get("clf_top1_conf", det.get("playcall_confidence", 0.0))),
+            "clf_top1": top1,
+            "clf_top1_conf": top1_conf,
+            "clf_top1_canon": harmonize(top1),
             "clf_top3": "|".join(
                 f"{n}:{float(s):.3f}" for n, s in det.get("clf_top3", det.get("candidates", []))
             ),
-            "clf_weak_flag": int(det.get("clf_weak_flag", 0)),
+            "clf_weak_flag": int(top1_conf < 0.35),
             "clf_family": det.get("clf_family", ""),
             "clf_disabled": int(det.get("clf_disabled", 0)),
             "outcome": det.get("outcome") or "",
             "clip_duration": max(0.0, float(seg["t1"]) - float(seg["t0"])),
             "low_activity": int(seg.get("low_activity", 0)),
-            "candidates": ";".join(f"{n}:{s:.2f}" for n, s in det.get("candidates", [])),
+            "candidates": ";".join(
+                f"{n}:{float(s):.3f}" for n, s in det.get("candidates", [])
+            ),
         }
-        if _norm_label(row["clf_top1"]) in unmapped_pb_norms:
-            row["clf_weak_flag"] = 1
         rows.append(row)
 
     csv_header = [
@@ -318,11 +323,13 @@ def run_pipeline(
         "whistle",
         "clip_path",
         "formation",
+        "formation_canon",
         "formation_confidence",
         "play_family",
         "playcall_confidence",
         "clf_top1",
         "clf_top1_conf",
+        "clf_top1_canon",
         "clf_top3",
         "clf_weak_flag",
         "clf_family",

--- a/analysis/play_classifier.py
+++ b/analysis/play_classifier.py
@@ -9,6 +9,7 @@ from the supplied playbook.
 """
 
 from typing import Any, Dict, Iterable, List, Tuple
+import math
 
 # ---------------------------------------------------------------------------
 # Playbook helpers
@@ -177,11 +178,10 @@ def classify_plays(
     for seg in segments:
         formation = seg.get("formation", "") or ""
         formations.append(formation)
-        cands = _best_matches_from_playbook(formation, playbook, topk=3)
+        # Always propose candidates irrespective of formation or activity
+        cands = _best_matches_from_playbook(formation, playbook, topk=5)
         if not cands:
-            cands = _best_matches_from_playbook("", playbook, topk=3)
-        if seg.get("low_activity"):
-            cands = [(n, s * 0.5) for n, s in cands]
+            cands = _best_matches_from_playbook("", playbook, topk=5)
         raw_scores.append({n: s for n, s in cands})
 
     results: List[Dict[str, Any]] = []
@@ -201,11 +201,21 @@ def classify_plays(
             smoothed: Dict[str, float] = {}
             for n in names:
                 smoothed[n] = sum(d.get(n, 0.0) for d in window) / len(window)
-            smoothed_sorted = sorted(smoothed.items(), key=lambda x: x[1], reverse=True)
-            if smoothed_sorted and smoothed_sorted[0][1] > top_score:
+            if smoothed:
+                sorted_cands = sorted(smoothed.items(), key=lambda x: x[1], reverse=True)
                 final_scores = smoothed
-                sorted_cands = smoothed_sorted
-                top_name, top_score = smoothed_sorted[0]
+                top_name, top_score = (sorted_cands[0] if sorted_cands else ("", 0.0))
+
+        # Convert scores to probabilities
+        if final_scores:
+            max_logit = max(final_scores.values())
+            exp_scores = {k: math.exp(v - max_logit) for k, v in final_scores.items()}
+            total = sum(exp_scores.values()) or 1.0
+            probs = {k: v / total for k, v in exp_scores.items()}
+        else:
+            probs = {}
+        sorted_cands = sorted(probs.items(), key=lambda x: x[1], reverse=True)
+        top_name, top_score = (sorted_cands[0] if sorted_cands else ("", 0.0))
 
         # Back off to family-level classification if still weak after smoothing
         if top_score < weak_threshold:
@@ -213,7 +223,7 @@ def classify_plays(
         else:
             clf_family = ""
 
-        weak_flag = 1 if seg.get("low_activity") or top_score < weak_threshold else 0
+        weak_flag = 1 if top_score < weak_threshold else 0
 
         top5 = sorted_cands[:5]
         top3 = sorted_cands[:3]


### PR DESCRIPTION
## Summary
- Always produce play predictions using softmax probabilities
- Record top-3 and top-5 classifier outputs with confidence and weak flag logic
- Harmonize formation and play labels into canonical fields

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b229e7a8a8832da42f4157b41ac8dc