### PR TITLE
Add temporal smoothing option for play classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ for F in "${FILES[@]}"; do
     --out "output" \
     --min-play-gap 1.5 \
     --min-play-length 3.0 \
+    --smooth-frames 4 \
     --report \
     --clips
 done

--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -100,6 +100,7 @@ def run_pipeline(
     min_activity_ratio: float = 0.10,
     preroll: float = 0.75,
     postroll: float = 0.75,
+    smooth_frames: int = 4,
     generate_report: bool = False,
     generate_clips: bool = False,
     debug_weak: bool = False,
@@ -265,6 +266,7 @@ def run_pipeline(
             play_labels=play_labels,
             formation_ckpt=formation_ckpt,
             formation_labels=formation_labels,
+            smooth_frames=smooth_frames,
         )
         for d in classifications:
             d["clf_disabled"] = 0
@@ -312,6 +314,7 @@ def run_pipeline(
             ),
             "clf_weak_flag": int(det.get("clf_weak_flag", 0)),
             "clf_family": det.get("clf_family", ""),
+            "smoothing_applied": int(det.get("smoothing_applied", 0)),
             "clf_disabled": int(det.get("clf_disabled", 0)),
             "outcome": det.get("outcome") or "",
             "clip_duration": max(0.0, float(seg["t1"]) - float(seg["t0"])),
@@ -338,6 +341,7 @@ def run_pipeline(
         "clf_top3",
         "clf_weak_flag",
         "clf_family",
+        "smoothing_applied",
         "clf_disabled",
         "outcome",
         "clip_duration",
@@ -571,6 +575,7 @@ def main(argv=None) -> None:
     p.add_argument("--min-activity-ratio", type=float, default=0.10)
     p.add_argument("--preroll", type=float, default=0.75)
     p.add_argument("--postroll", type=float, default=0.75)
+    p.add_argument("--smooth-frames", type=int, default=4, help="temporal smoothing radius; 0 disables")
     p.add_argument("--generate-report", dest="generate_report", action="store_true", help="write HTML report")
     p.add_argument("--report", dest="generate_report", action="store_true", help=argparse.SUPPRESS)
     p.add_argument("--generate-clips", dest="generate_clips", action="store_true", help="export per-play mp4 clips")
@@ -600,6 +605,7 @@ def main(argv=None) -> None:
         min_activity_ratio=args.min_activity_ratio,
         preroll=args.preroll,
         postroll=args.postroll,
+        smooth_frames=args.smooth_frames,
         generate_report=args.generate_report,
         generate_clips=args.generate_clips,
         debug_weak=args.debug_weak,

--- a/analysis/play_classifier.py
+++ b/analysis/play_classifier.py
@@ -8,6 +8,7 @@ formation information when present and proposes top-N candidate play names
 from the supplied playbook.
 """
 
+import math
 from typing import Any, Dict, Iterable, List, Tuple
 
 # ---------------------------------------------------------------------------
@@ -153,7 +154,7 @@ def classify_plays(
     formation_ckpt: str | None = None,
     formation_labels: str | None = None,
     weak_threshold: float = 0.35,
-    smooth_radius: int = 4,
+    smooth_frames: int = 4,
 ) -> List[Dict[str, Any]]:
     """Classify each segment and propose candidate play names.
 
@@ -184,32 +185,42 @@ def classify_plays(
             cands = [(n, s * 0.5) for n, s in cands]
         raw_scores.append({n: s for n, s in cands})
 
+    def _softmax(d: Dict[str, float]) -> Dict[str, float]:
+        if not d:
+            return {}
+        m = max(d.values())
+        exps = {k: math.exp(v - m) for k, v in d.items()}
+        total = sum(exps.values()) or 1.0
+        return {k: v / total for k, v in exps.items()}
+
     results: List[Dict[str, Any]] = []
     total = len(segments)
     for i, seg in enumerate(segments, 1):
-        scores = raw_scores[i - 1]
-        sorted_cands = sorted(scores.items(), key=lambda x: x[1], reverse=True)
+        logits = raw_scores[i - 1]
+        probs = _softmax(logits)
+        sorted_cands = sorted(probs.items(), key=lambda x: x[1], reverse=True)
         top_name, top_score = (sorted_cands[0] if sorted_cands else ("", 0.0))
-        final_scores = scores
+        final_probs = probs
+        smoothing_applied = 0
 
-        if top_score < weak_threshold:
-            # Temporal smoothing over neighbouring segments
-            start = max(0, (i - 1) - smooth_radius)
-            end = min(total, (i - 1) + smooth_radius + 1)
+        if smooth_frames > 0:
+            start = max(0, (i - 1) - smooth_frames)
+            end = min(total, (i - 1) + smooth_frames + 1)
             window = raw_scores[start:end]
             names = {n for d in window for n in d}
-            smoothed: Dict[str, float] = {}
+            avg_logits: Dict[str, float] = {}
             for n in names:
-                smoothed[n] = sum(d.get(n, 0.0) for d in window) / len(window)
-            smoothed_sorted = sorted(smoothed.items(), key=lambda x: x[1], reverse=True)
+                avg_logits[n] = sum(d.get(n, 0.0) for d in window) / len(window)
+            smoothed_probs = _softmax(avg_logits)
+            smoothed_sorted = sorted(smoothed_probs.items(), key=lambda x: x[1], reverse=True)
             if smoothed_sorted and smoothed_sorted[0][1] > top_score:
-                final_scores = smoothed
+                final_probs = smoothed_probs
                 sorted_cands = smoothed_sorted
                 top_name, top_score = smoothed_sorted[0]
+                smoothing_applied = 1
 
-        # Back off to family-level classification if still weak after smoothing
         if top_score < weak_threshold:
-            clf_family = _best_family_from_playbook(playbook, final_scores)
+            clf_family = _best_family_from_playbook(playbook, final_probs)
         else:
             clf_family = ""
 
@@ -234,6 +245,7 @@ def classify_plays(
                 "clf_top3": top3,
                 "clf_weak_flag": weak_flag,
                 "clf_family": clf_family,
+                "smoothing_applied": smoothing_applied,
             }
         )
     return results

--- a/analysis/reporter.py
+++ b/analysis/reporter.py
@@ -12,6 +12,7 @@ PLAY_INDEX_FIELDS = [
     "clf_top1_conf",
     "clf_top3",
     "clf_weak_flag",
+    "smoothing_applied",
     "low_activity",
 ]
 

--- a/tests/test_pipeline_smoke.py
+++ b/tests/test_pipeline_smoke.py
@@ -1,4 +1,4 @@
-import json, os, pathlib, torch
+import csv, json, os, pathlib, torch
 from analysis import pipeline
 
 
@@ -26,7 +26,8 @@ def test_pipeline_smoke(tmp_path):
     )
 
     run_dir = pathlib.Path(run_dir)
-    assert (run_dir / "plays_index.csv").exists()
+    csv_path = run_dir / "plays_index.csv"
+    assert csv_path.exists()
     assert (run_dir / "report.json").exists()
     index_path = run_dir / "report" / "index.html"
     assert index_path.exists()
@@ -34,3 +35,8 @@ def test_pipeline_smoke(tmp_path):
     assert "0 segments detected" in html
     warnings_path = run_dir / "report" / "warnings.txt"
     assert not warnings_path.exists()
+
+    with csv_path.open() as f:
+        reader = csv.reader(f)
+        header = next(reader)
+    assert "smoothing_applied" in header


### PR DESCRIPTION
## Summary
- add optional temporal smoothing that averages neighboring logits and recomputes softmax
- expose `--smooth-frames` CLI flag and record `smoothing_applied` column in outputs
- document new flag and cover in smoke test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b229f0c524832d8166c990c5ecc71b