### PR TITLE
Add classifier warnings and fail-fast safeguards

### DIFF
--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os, sys, json, pathlib, argparse, csv, subprocess, logging, re
 from collections import Counter
+import html
 
 from .harmonizer import harmonize
 
@@ -34,6 +35,32 @@ def _safe_name(s: str) -> str:
 def _norm_label(label: str) -> str:
     """Return a normalised version of ``label`` for comparison."""
     return re.sub(r"[\s_-]+", "", label).lower()
+
+
+def _write_warnings(
+    report_dir: str,
+    torch_info: str,
+    device_info: str,
+    model_paths: dict[str, str | None],
+    unmapped: Counter[str],
+    warnings: list[str],
+) -> None:
+    """Write a warnings report with environment and model info."""
+    os.makedirs(report_dir, exist_ok=True)
+    path = os.path.join(report_dir, "warnings.txt")
+    with open(path, "w", encoding="utf-8") as wf:
+        wf.write(f"{torch_info}\n")
+        wf.write(f"{device_info}\n")
+        for name, val in model_paths.items():
+            wf.write(f"{name}: {val}\n")
+        if unmapped:
+            wf.write("unmapped labels:\n")
+            for lbl, cnt in sorted(unmapped.items()):
+                wf.write(f"  {lbl}: {cnt}\n")
+        if warnings:
+            wf.write("warnings:\n")
+            for line in warnings:
+                wf.write(f"  {line}\n")
 
 
 def _load_model_labels(
@@ -142,7 +169,33 @@ def run_pipeline(
     run_dir = os.path.join(out_dir, "games", f"{_safe_name(tag)}__{short}")
     report_dir = os.path.join(run_dir, "report")
     os.makedirs(run_dir, exist_ok=True)
+    os.makedirs(report_dir, exist_ok=True)
     run_dir_created = True
+
+    model_paths = {
+        "play_ckpt": play_ckpt,
+        "play_labels": play_labels,
+        "formation_ckpt": formation_ckpt,
+        "formation_labels": formation_labels,
+    }
+
+    warnings: list[str] = []
+
+    try:
+        import torch  # type: ignore
+
+        torch_info = f"torch: {torch.__version__}"
+        if torch.cuda.is_available():
+            device_info = f"device: cuda:{torch.cuda.get_device_name(0)}"
+        else:
+            device_info = "device: cpu"
+    except Exception as e:  # pragma: no cover - best effort
+        torch_info = f"torch: MISSING ({e})"
+        device_info = "device: N/A"
+        warnings.append(f"torch import failed: {e}")
+        if require_classifier:
+            _write_warnings(report_dir, torch_info, device_info, model_paths, Counter(), warnings)
+            raise
 
     # Configure logging to file under the run directory and to stdout
     log_path = os.path.join(run_dir, "pipeline.log")
@@ -163,11 +216,12 @@ def run_pipeline(
     logging.info(f"[pipeline] formation_ckpt: {formation_ckpt}")
     logging.info(f"[pipeline] formation_labels: {formation_labels}")
 
-    if require_classifier:
-        for path in [play_ckpt, play_labels, formation_ckpt, formation_labels]:
-            if path and not os.path.exists(path):
-                logging.error(f"[pipeline] missing required file: {path}")
-                raise FileNotFoundError(f"missing required file: {path}")
+    missing_paths = [name for name, pth in model_paths.items() if pth and not os.path.exists(pth)]
+    if missing_paths and require_classifier:
+        for name in missing_paths:
+            warnings.append(f"missing required file: {model_paths[name]}")
+        _write_warnings(report_dir, torch_info, device_info, model_paths, Counter(), warnings)
+        raise FileNotFoundError(f"missing required file: {model_paths[missing_paths[0]]}")
 
     index_path = os.path.join(report_dir, "index.html")
     if generate_report:
@@ -194,7 +248,9 @@ def run_pipeline(
         )
         clf = load_models(args_obj)
     except Exception as e:
+        warnings.append(str(e))
         if require_classifier:
+            _write_warnings(report_dir, torch_info, device_info, model_paths, Counter(), warnings)
             raise
         else:
             logging.getLogger().warning(f"[classifier] disabled: {e}")
@@ -253,7 +309,7 @@ def run_pipeline(
             seg.get("activity_ratio", 0.0) < min_activity_ratio and not seg.get("has_whistle")
         )
 
-    if clf is not None:
+    if clf is not None and segments:
         global classify_plays
         if classify_plays is None:  # pragma: no cover - lazy import
             from .play_classifier import classify_plays as _classify_plays
@@ -292,8 +348,9 @@ def run_pipeline(
                 }
             )
 
+    unmapped_pb_norms = {_norm_label(lbl) for lbl in missing_in_playbook}
     rows: list[dict] = []
-    unmapped_labels: set[str] = set()
+    unmapped_counts: Counter[str] = Counter()
     for seg, det in zip(segments, classifications):
         pid = det.get("play_id") or f"PLAY_{len(rows)+1:03d}"
 
@@ -349,7 +406,7 @@ def run_pipeline(
         }
 
         if canon_reason == "unmapped":
-            unmapped_labels.add(row["clf_top1"])
+            unmapped_counts[row["clf_top1"]] += 1
         if _norm_label(row["clf_top1"]) in unmapped_pb_norms:
             row["clf_weak_flag"] = 1
 
@@ -390,17 +447,12 @@ def run_pipeline(
         os.makedirs(os.path.join(run_dir, "clips"), exist_ok=True)
         os.makedirs(report_dir, exist_ok=True)
 
-        if unmapped_labels:
-            for lbl in sorted(unmapped_labels):
-                validator_warnings.append(f"Unmapped classifier label: {lbl}")
-        if validator_warnings:
-            warn_path = os.path.join(report_dir, "warnings.txt")
-            with open(warn_path, "w", encoding="utf-8") as wf:
-                for line in validator_warnings:
-                    wf.write(line + "\n")
-            for line in validator_warnings:
-                logging.warning(line)
-                print(f"⚠️ {line}")
+        if unmapped_counts:
+            for lbl, cnt in sorted(unmapped_counts.items()):
+                validator_warnings.append(f"Unmapped classifier label: {lbl} ({cnt})")
+        for line in validator_warnings:
+            logging.warning(line)
+            print(f"⚠️ {line}")
 
         with open(csv_path, "w", newline="") as f:
             w = csv.DictWriter(f, fieldnames=csv_header)
@@ -415,6 +467,9 @@ def run_pipeline(
             except Exception:
                 pass
         raise
+
+    all_warnings = warnings + validator_warnings
+    _write_warnings(report_dir, torch_info, device_info, model_paths, unmapped_counts, all_warnings)
 
     if generate_clips:
         for r in rows:
@@ -529,6 +584,9 @@ def run_pipeline(
         disabled_count = sum(r.get("clf_disabled", 0) for r in rows)
         unmapped_labels = sorted(set(missing_in_playbook + missing_in_model))
 
+        warn_path = os.path.join(report_dir, "warnings.txt")
+        warn_text = pathlib.Path(warn_path).read_text() if os.path.exists(warn_path) else ""
+
         if rows:
             with open(index_path, "w", encoding="utf-8") as f:
                 f.write("<html><head><meta charset='utf-8'><title>Run Report</title></head><body>\n")
@@ -559,13 +617,20 @@ def run_pipeline(
                     )
                 if validator_warnings:
                     f.write("<li><a href='warnings.txt'>warnings.txt</a></li>\n")
-                f.write("</ul>\n</body></html>\n")
+                f.write("</ul>\n")
+                if warn_text:
+                    f.write("<h2>Warnings</h2>\n<pre>\n")
+                    f.write(html.escape(warn_text))
+                    f.write("</pre>\n")
+                f.write("</body></html>\n")
         else:
             # Stub report when no segments were detected.
             with open(index_path, "w", encoding="utf-8") as f:
                 f.write("<html><body><p>0 segments detected</p>")
-                if validator_warnings:
-                    f.write("<p><a href='warnings.txt'>warnings.txt</a></p>")
+                if warn_text:
+                    f.write("<h2>Warnings</h2><pre>")
+                    f.write(html.escape(warn_text))
+                    f.write("</pre>")
                 f.write("</body></html>")
 
 

--- a/tests/test_pipeline_failfast.py
+++ b/tests/test_pipeline_failfast.py
@@ -1,0 +1,28 @@
+import json, pathlib, pytest
+from analysis import pipeline
+
+
+def test_require_classifier_missing_ckpt(tmp_path):
+    pb = {"plays": []}
+    pb_path = tmp_path / "playbook.json"
+    pb_path.write_text(json.dumps(pb))
+
+    out_dir = tmp_path / "out"
+    with pytest.raises(FileNotFoundError):
+        pipeline.run_pipeline(
+            video="dummy.mp4",
+            team="WHITE",
+            playbook_path=str(pb_path),
+            out_dir=str(out_dir),
+            play_ckpt=str(tmp_path / "missing.pt"),
+            generate_report=True,
+            require_classifier=True,
+        )
+    run_dirs = list((out_dir / "games").glob("*"))
+    assert run_dirs
+    warn_path = run_dirs[0] / "report" / "warnings.txt"
+    assert warn_path.exists()
+    warn = warn_path.read_text()
+    assert "missing required file" in warn
+    csv_path = run_dirs[0] / "plays_index.csv"
+    assert not csv_path.exists()

--- a/tests/test_pipeline_label_validator.py
+++ b/tests/test_pipeline_label_validator.py
@@ -28,6 +28,7 @@ def test_pipeline_label_mismatch(tmp_path, monkeypatch):
     assert "Foo" in warn
     html = (run_dir / "report" / "index.html").read_text()
     assert "0 segments detected" in html
+    assert "Warnings" in html
     log_txt = (run_dir / "pipeline.log").read_text()
     assert "loading ckpt" in log_txt
     assert "labels: 2" in log_txt

--- a/tests/test_pipeline_smoke.py
+++ b/tests/test_pipeline_smoke.py
@@ -34,7 +34,10 @@ def test_pipeline_smoke(tmp_path):
     html = index_path.read_text()
     assert "0 segments detected" in html
     warnings_path = run_dir / "report" / "warnings.txt"
-    assert not warnings_path.exists()
+    assert warnings_path.exists()
+    warn_txt = warnings_path.read_text()
+    assert "torch:" in warn_txt
+    assert "Warnings" in html
 
     with csv_path.open() as f:
         reader = csv.reader(f)


### PR DESCRIPTION
## Summary
- Always write `report/warnings.txt` including torch/device info, model paths, and counts of unmapped labels
- Fail fast when required classifier resources or torch are missing, avoiding blank predictions
- Render warnings panel in HTML report and add tests for warning output and fail-fast behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2452b74c4832dad62e99c28e46fbf