### PR TITLE
Add weak segment stats to spot_check script

### DIFF
--- a/scripts/spot_check.sh
+++ b/scripts/spot_check.sh
@@ -23,6 +23,51 @@ for dir in "${run_dirs[@]}"; do
 
   if [[ -f "$dir/plays_index.csv" ]]; then
     head -n 6 "$dir/plays_index.csv" | sed 's/^/  /'
+    awk -F, '
+NR==1 {
+  for (i = 1; i <= NF; i++) {
+    gsub(/"/, "", $i)
+    if ($i == "clf_weak_flag") weak_i = i
+    if ($i == "clf_top1_conf") conf_i = i
+    if (!canon_i && $i ~ /_canon$/) canon_i = i
+  }
+  next
+}
+{
+  N++
+  if (weak_i) weak += $weak_i
+  if (conf_i) conf += $conf_i
+  if (canon_i) {
+    key = $canon_i
+    if (key != "") {
+      canon[key]++
+      canon_non_empty = 1
+    }
+  }
+}
+END {
+  pct = (N ? 100 * weak / N : 0)
+  avg = (N ? conf / N : 0)
+  printf "stats: segments=%d weak=%d (%.1f%%) avg_conf=%.2f\n", N, weak, pct, avg
+  if (canon_i) {
+    if (canon_non_empty) {
+      asorti(canon, idx, "@val_num_desc")
+      printf "top canon plays: "
+      shown = 0
+      for (j = 1; j <= length(idx) && shown < 5; j++) {
+        k = idx[j]
+        printf "%s (%d)", k, canon[k]
+        shown++
+        if (shown < length(idx) && shown < 5) printf ", "
+      }
+      printf "\n"
+    } else {
+      print "no canonical mapping"
+    }
+  } else {
+    print "no canonical mapping"
+  }
+}' "$dir/plays_index.csv" | sed 's/^/  /'
   else
     echo "  missing plays_index.csv"
   fi


### PR DESCRIPTION
## Summary
- Summarize segment count, weak count/percentage, and average confidence from `plays_index.csv`
- Report most common canonical play names or note when none are available

## Testing
- `scripts/spot_check.sh /tmp/scdir`
- `shellcheck scripts/spot_check.sh` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `pytest -q` *(fails: IndentationError: expected an indented block after 'if' statement on line 611)*

------
https://chatgpt.com/codex/tasks/task_e_68b24a666d08832db9c12e18ff5252c8