### PR TITLE
Symlink clip folders with predicted play names

### DIFF
--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -513,6 +513,18 @@ def run_pipeline(
                 )
             r["clip_path"] = mp4
 
+            # Add a symlink with the predicted play name for easier review
+            canon = r.get("clf_top1_canon") or r.get("play_family") or ""
+            safe = _safe_name(canon).replace(" ", "_")
+            if safe:
+                link = os.path.join(run_dir, "clips", f"{pid}__{safe}")
+                try:
+                    if os.path.lexists(link):
+                        os.unlink(link)
+                    os.symlink(pid, link)
+                except Exception:
+                    pass
+
         with open(csv_path, "w", newline="") as f:
             w = csv.DictWriter(f, fieldnames=csv_header)
             w.writeheader()

--- a/tests/test_clip_symlink.py
+++ b/tests/test_clip_symlink.py
@@ -1,0 +1,35 @@
+import os
+import pathlib
+import types
+from analysis import pipeline
+
+def test_clip_symlink(tmp_path, monkeypatch):
+    pb = pathlib.Path("playbooks/mca_5th_playbook.json")
+    monkeypatch.setattr(pipeline, "segment_video", lambda *a, **k: [{"id": "PLAY_001", "t0": 0.0, "t1": 5.0}])
+
+    def fake_classify(segments, playbook, team, *, play_ckpt=None, play_labels=None, formation_ckpt=None, formation_labels=None, weak_threshold=0.35, smooth_frames=4):
+        return [{
+            "play_id": segments[0]["id"],
+            "clf_top1": "Rit Jet Sweep",
+            "clf_top1_conf": 0.9,
+            "clf_top3": [("Rit Jet Sweep", 0.9)],
+            "play_family": "Rit Jet Sweep",
+        }]
+
+    monkeypatch.setattr(pipeline, "classify_plays", fake_classify)
+    monkeypatch.setattr(pipeline, "_ffmpeg", lambda *a, **k: types.SimpleNamespace(returncode=0))
+
+    run_dir = pipeline.run_pipeline(
+        video="dummy.mp4",
+        team="WHITE",
+        playbook_path=str(pb),
+        out_dir=str(tmp_path),
+        generate_clips=True,
+        require_classifier=False,
+    )
+
+    run_dir = pathlib.Path(run_dir)
+    link = run_dir / "clips" / "PLAY_001__Rit_Jet_Sweep"
+    target = run_dir / "clips" / "PLAY_001"
+    assert link.is_symlink()
+    assert link.resolve() == target.resolve()


### PR DESCRIPTION
## Summary
- Create a symlink next to each clip folder pointing to the predicted play name for easier manual review
- Add regression test ensuring clip symlink is created

## Testing
- `pytest tests/test_clip_symlink.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b24b8a5ef0832dad6a37b0911b997c