### PR TITLE
chore: make spot_check.sh portable

### DIFF
--- a/scripts/spot_check.sh
+++ b/scripts/spot_check.sh
@@ -18,7 +18,10 @@ for dir in "${run_dirs[@]}"; do
   echo "$dir"
 
   if [[ -L "$dir" && "$dir" == *__latest ]]; then
-    echo "  -> $(readlink -f "$dir")"
+    python3 - "$dir" <<'PY'
+import os, sys
+print("  -> " + os.path.realpath(sys.argv[1]))
+PY
   fi
 
   CSV="$dir/plays_index.csv"


### PR DESCRIPTION
## Summary
- replace GNU `readlink -f` with Python `os.path.realpath`
- keep Python-based CSV stats computation in `spot_check.sh`

## Testing
- `bash -n scripts/spot_check.sh`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b2a7e42258832db70d7bd971068445