### PR TITLE
Add simple soccer gameday recorder

### DIFF
--- a/README_SOCCER.md
+++ b/README_SOCCER.md
@@ -1,0 +1,54 @@
+# Soccer Gameday Recorder
+
+This repo includes a minimal soccer recording path. Use `./soccerday` to start
+recording from the capture card and microphone.
+
+## Testing checklist
+
+### A) Discover devices
+```bash
+PYTHONPATH=. python3 -m tools.list_av
+# Note the Rode mic Pulse name, e.g.:
+#   alsa_input.usb-R__DE_R__DE_VideoMic_GO_II_XXXX-00.mono-fallback
+```
+
+### B) 10-second smoke test
+```bash
+AUDIO_SRC="alsa_input.usb-R__DE_R__DE_VideoMic_GO_II_XXXX-00.mono-fallback" \
+SOC_TITLE="smoketest" SOC_SEG_MIN=1 \
+./soccerday
+# Let it run ~10s, Ctrl+C
+# Verify: output/soccer/full/ has an mp4, logs/ has a .log, thumbs/ has jpgs
+# (if >10s), meta/ has json
+```
+
+### C) Input format fallback
+```bash
+SOC_INPUT_FORMAT=yuyv422 ./soccerday
+# If your capture card prefers yuyv422
+```
+
+### D) Proxy/on-the-fly assets
+```bash
+SOC_PROXY=1 SOC_TITLE="withproxy" ./soccerday
+# Check output/soccer/proxy for smaller files
+```
+
+### E) Space guard
+```bash
+# Temporarily set require_free_gb to a huge value (e.g., 9999) and confirm that
+# recorder refuses to start with a clear message.
+```
+
+### F) Real match capture
+```bash
+AUDIO_SRC="alsa_input.usb-R__DE_R__DE_VideoMic_GO_II_XXXX-00.mono-fallback" \
+SOC_TITLE="U11_vs_Glenpool_20250903" SOC_SEG_MIN=20 \
+./soccerday
+# Let it roll the entire match. It will create multiple 20-minute parts.
+```
+
+### G) Playback sanity
+Confirm the last segment plays and has audio (quick scrub in VLC).
+Check the log for dropped-source errors.
+Verify thumbs exist at roughly every N seconds for the full span.

--- a/soccer/__init__.py
+++ b/soccer/__init__.py
@@ -1,0 +1,2 @@
+"""Utilities for soccer gameday recording."""
+__all__ = []

--- a/soccer/devices.py
+++ b/soccer/devices.py
@@ -1,0 +1,36 @@
+import os
+import subprocess
+from typing import Optional
+
+
+def guess_video_dev() -> str:
+    """Return a likely v4l2 video device."""
+    if os.path.exists("/dev/video0"):
+        return "/dev/video0"
+    # fall back to first /dev/video* device
+    for i in range(10):
+        dev = f"/dev/video{i}"
+        if os.path.exists(dev):
+            return dev
+    return "/dev/video0"  # best effort
+
+
+def _pactl_list_sources() -> str:
+    try:
+        return subprocess.check_output(
+            ["pactl", "list", "short", "sources"], text=True
+        )
+    except Exception:
+        return ""
+
+
+def guess_pulse_src() -> str:
+    """Return the default PulseAudio source or a Rode mic if present."""
+    sources = _pactl_list_sources().splitlines()
+    # look for Rode VideoMic GO II
+    for line in sources:
+        parts = line.split("\t")
+        if len(parts) >= 2 and "R__DE" in parts[1]:
+            return parts[1]
+    # try to find line marked as `*`?  pactl short doesn't show default; rely on 'default'
+    return "default"

--- a/soccer/recognition_scaffold.py
+++ b/soccer/recognition_scaffold.py
@@ -1,0 +1,30 @@
+import json
+import os
+from pathlib import Path
+from typing import Optional
+from datetime import datetime
+
+
+def prepare_for_recognition(outdir: str, thumbs_dir: str, proxy_dir: Optional[str]) -> None:
+    """Write breadcrumbs for future jersey/player recognition."""
+    out_path = Path(outdir)
+    thumbs = Path(thumbs_dir)
+    meta_dir = out_path / "meta"
+    meta_dir.mkdir(parents=True, exist_ok=True)
+
+    readme_path = out_path / "README_recognition.md"
+    if not readme_path.exists():
+        readme_path.write_text(
+            "# Recognition Scaffold\n\n"
+            "This directory contains assets to support future jersey/player recognition.\n"
+            "Thumbnails are stored in `thumbs/` and proxy videos in `proxy/`.\n"
+            "A mapping of thumbnail filenames to capture timestamps is stored in\n"
+            "`meta/thumb_map.json`.\n"
+        )
+
+    mapping = {}
+    for img in thumbs.glob("*.jpg"):
+        ts = img.stem.split("_")[0]  # extract YYYYMMDD-HHMMSS
+        mapping[img.name] = ts
+
+    (meta_dir / "thumb_map.json").write_text(json.dumps(mapping, indent=2))

--- a/soccer/recorder.py
+++ b/soccer/recorder.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import signal
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import List
+
+from .devices import guess_pulse_src, guess_video_dev
+from .recognition_scaffold import prepare_for_recognition
+from .space_check import require_free_gb
+
+
+class Recorder:
+    def __init__(self, args: argparse.Namespace) -> None:
+        self.args = args
+        self.outdir = Path(args.outdir)
+        self.log_file = None
+        self.procs: List[subprocess.Popen] = []
+
+    def _open_log(self) -> None:
+        log_dir = self.outdir / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        ts = self.base_ts
+        log_path = log_dir / f"{ts}-{self.args.title}.log"
+        self.log_file = open(log_path, "w")
+
+    @property
+    def base_ts(self) -> str:
+        return datetime.now().strftime("%Y%m%d_%H%M%S")
+
+    def _launch(self, cmd: List[str]) -> subprocess.Popen:
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.DEVNULL,
+            stderr=self.log_file,
+        )
+        self.procs.append(proc)
+        return proc
+
+    def build_main_cmd(self, pattern: str) -> List[str]:
+        a = self.args
+        cmd: List[str] = [
+            "ffmpeg",
+            "-hide_banner",
+            "-fflags",
+            "+genpts+discardcorrupt",
+            "-f",
+            "v4l2",
+            "-thread_queue_size",
+            "8192",
+            "-input_format",
+            a.input_format,
+            "-framerate",
+            str(a.framerate),
+            "-video_size",
+            a.resolution,
+            "-i",
+            a.video_dev,
+        ]
+        if a.audio_src.lower() == "none":
+            cmd += [
+                "-f",
+                "lavfi",
+                "-thread_queue_size",
+                "8192",
+                "-i",
+                "anullsrc=r=48000:cl=stereo",
+            ]
+        else:
+            cmd += [
+                "-f",
+                "pulse",
+                "-thread_queue_size",
+                "8192",
+                "-i",
+                a.audio_src,
+            ]
+        cmd += [
+            "-vf",
+            "scale=in_range=full:out_range=tv,format=yuv420p,setpts=PTS-STARTPTS",
+            "-af",
+            "highpass=f=100,acompressor=threshold=-22dB:ratio=3.5:attack=12:release=250,alimiter=limit=0.0dB:attack=5:release=20",
+            "-c:v",
+            "libx264",
+            "-preset",
+            a.preset,
+            "-crf",
+            str(a.crf),
+            "-c:a",
+            "aac",
+            "-b:a",
+            "128k",
+            "-ar",
+            "48000",
+            "-movflags",
+            "+faststart",
+            "-max_muxing_queue_size",
+            "4096",
+            "-f",
+            "segment",
+            "-segment_time",
+            str(a.segment_min * 60),
+            "-reset_timestamps",
+            "1",
+            "-strftime",
+            "1",
+            "-segment_format_options",
+            "movflags=+faststart",
+            pattern,
+        ]
+        return cmd
+
+    def build_proxy_cmd(self, pattern: str) -> List[str]:
+        a = self.args
+        cmd = self.build_main_cmd(pattern)
+        # adjust for proxy quality
+        cmd = cmd.copy()
+        # main build_main_cmd included -crf etc; we want to adjust for proxy before video/audio options? Simplify: Rebuild minimal.
+        cmd = [
+            "ffmpeg",
+            "-hide_banner",
+            "-fflags",
+            "+genpts+discardcorrupt",
+            "-f",
+            "v4l2",
+            "-thread_queue_size",
+            "8192",
+            "-input_format",
+            a.input_format,
+            "-framerate",
+            str(a.framerate),
+            "-video_size",
+            a.resolution,
+            "-i",
+            a.video_dev,
+        ]
+        if a.audio_src.lower() == "none":
+            cmd += [
+                "-f",
+                "lavfi",
+                "-thread_queue_size",
+                "8192",
+                "-i",
+                "anullsrc=r=48000:cl=stereo",
+            ]
+        else:
+            cmd += [
+                "-f",
+                "pulse",
+                "-thread_queue_size",
+                "8192",
+                "-i",
+                a.audio_src,
+            ]
+        cmd += [
+            "-vf",
+            "scale=960:-2,format=yuv420p,setpts=PTS-STARTPTS",
+            "-af",
+            "highpass=f=100,acompressor=threshold=-22dB:ratio=3.5:attack=12:release=250,alimiter=limit=0.0dB:attack=5:release=20",
+            "-c:v",
+            "libx264",
+            "-preset",
+            a.preset,
+            "-crf",
+            "30",
+            "-c:a",
+            "aac",
+            "-b:a",
+            "96k",
+            "-ar",
+            "48000",
+            "-movflags",
+            "+faststart",
+            "-max_muxing_queue_size",
+            "4096",
+            "-f",
+            "segment",
+            "-segment_time",
+            str(a.segment_min * 60),
+            "-reset_timestamps",
+            "1",
+            "-strftime",
+            "1",
+            "-segment_format_options",
+            "movflags=+faststart",
+            pattern,
+        ]
+        return cmd
+
+    def build_thumb_cmd(self, pattern: str) -> List[str]:
+        a = self.args
+        cmd: List[str] = [
+            "ffmpeg",
+            "-hide_banner",
+            "-fflags",
+            "+genpts+discardcorrupt",
+            "-f",
+            "v4l2",
+            "-thread_queue_size",
+            "8192",
+            "-input_format",
+            a.input_format,
+            "-framerate",
+            str(a.framerate),
+            "-video_size",
+            a.resolution,
+            "-i",
+            a.video_dev,
+            "-vf",
+            f"fps=1/{a.thumb_every}",
+            "-q:v",
+            "2",
+            "-an",
+            "-strftime",
+            "1",
+            pattern,
+        ]
+        return cmd
+
+    def run(self) -> int:
+        a = self.args
+        # prepare dirs
+        for sub in ["full", "proxy", "thumbs", "logs", "meta"]:
+            (self.outdir / sub).mkdir(parents=True, exist_ok=True)
+
+        require_free_gb(self.outdir, a.min_free_gb)
+
+        ts = self.base_ts
+        full_pattern = str(self.outdir / "full" / "%Y%m%d-%H%M%S_" + a.title + "_part%03d.mp4")
+        proxy_pattern = str(self.outdir / "proxy" / "%Y%m%d-%H%M%S_" + a.title + "_part%03d.mp4")
+        thumb_pattern = str(self.outdir / "thumbs" / "%Y%m%d-%H%M%S_" + a.title + "_%06d.jpg")
+
+        self._open_log()
+
+        meta_path = self.outdir / "meta" / f"{ts}-{a.title}.json"
+        meta = {
+            "video_dev": a.video_dev,
+            "audio_src": a.audio_src,
+            "resolution": a.resolution,
+            "fps": a.framerate,
+            "start_time": ts,
+            "full_pattern": full_pattern,
+            "proxy_pattern": proxy_pattern if a.proxy else None,
+            "thumb_pattern": thumb_pattern,
+        }
+        meta_path.write_text(json.dumps(meta, indent=2))
+
+        main_cmd = self.build_main_cmd(full_pattern)
+        self._launch(main_cmd)
+        if a.proxy:
+            proxy_cmd = self.build_proxy_cmd(proxy_pattern)
+            self._launch(proxy_cmd)
+        thumb_cmd = self.build_thumb_cmd(thumb_pattern)
+        self._launch(thumb_cmd)
+
+        prepare_for_recognition(a.outdir, str(self.outdir / "thumbs"), str(self.outdir / "proxy"))
+
+        def handle_signal(signum, frame):
+            for p in self.procs:
+                if p.poll() is None:
+                    p.terminate()
+            for p in self.procs:
+                try:
+                    p.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    p.kill()
+
+        signal.signal(signal.SIGINT, handle_signal)
+        signal.signal(signal.SIGTERM, handle_signal)
+
+        codes = []
+        for p in self.procs:
+            codes.append(p.wait())
+        if self.log_file:
+            self.log_file.close()
+
+        return 0 if all(c == 0 for c in codes) else max(codes)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Soccer day recorder")
+    parser.add_argument("--video-dev", default=guess_video_dev())
+    parser.add_argument("--audio-src", default=guess_pulse_src())
+    parser.add_argument("--framerate", type=int, default=30)
+    parser.add_argument("--resolution", default="1280x720")
+    parser.add_argument("--crf", type=int, default=18)
+    parser.add_argument("--preset", default="veryfast")
+    parser.add_argument("--segment-min", type=int, default=15)
+    parser.add_argument("--outdir", default="output/soccer")
+    parser.add_argument("--title", default="soccer")
+    parser.add_argument("--proxy", action="store_true")
+    parser.add_argument("--thumb-every", type=int, default=10)
+    parser.add_argument("--input-format", default="mjpeg")
+    parser.add_argument("--min-free-gb", type=int, default=5)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    try:
+        rec = Recorder(args)
+        rc = rec.run()
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    sys.exit(rc)
+
+
+if __name__ == "__main__":
+    main()

--- a/soccer/space_check.py
+++ b/soccer/space_check.py
@@ -1,0 +1,15 @@
+import shutil
+
+
+def require_free_gb(path: str, min_gb: int = 5) -> None:
+    """Ensure `path` has at least `min_gb` gigabytes free.
+
+    Raises:
+        RuntimeError: If free space is below the threshold.
+    """
+    usage = shutil.disk_usage(path)
+    free_gb = usage.free / (1024 ** 3)
+    if free_gb < min_gb:
+        raise RuntimeError(
+            f"Not enough free space at {path}: {free_gb:.2f} GB available, {min_gb} GB required"
+        )

--- a/soccerday
+++ b/soccerday
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VIDEO_DEV="${VIDEO_DEV:-/dev/video0}"
+AUDIO_SRC="${AUDIO_SRC:-default}"
+SOC_FPS="${SOC_FPS:-30}"
+SOC_RES="${SOC_RES:-1280x720}"
+SOC_CRF="${SOC_CRF:-18}"
+SOC_PRESET="${SOC_PRESET:-veryfast}"
+SOC_OUTDIR="${SOC_OUTDIR:-output/soccer}"
+SOC_SEG_MIN="${SOC_SEG_MIN:-15}"
+SOC_TITLE="${SOC_TITLE:-soccer}"
+SOC_PROXY="${SOC_PROXY:-0}"
+SOC_THUMB_EVERY="${SOC_THUMB_EVERY:-10}"
+SOC_INPUT_FORMAT="${SOC_INPUT_FORMAT:-mjpeg}"
+
+# activate virtual environment if present
+if [[ -d "venv" ]]; then
+  source venv/bin/activate
+elif [[ -d ".venv" ]]; then
+  source .venv/bin/activate
+fi
+
+PYTHONPATH=. python3 -m soccer.recorder \
+  --video-dev "$VIDEO_DEV" \
+  --audio-src "$AUDIO_SRC" \
+  --framerate "$SOC_FPS" \
+  --resolution "$SOC_RES" \
+  --crf "$SOC_CRF" \
+  --preset "$SOC_PRESET" \
+  --segment-min "$SOC_SEG_MIN" \
+  --outdir "$SOC_OUTDIR" \
+  --title "$SOC_TITLE" \
+  --thumb-every "$SOC_THUMB_EVERY" \
+  --input-format "$SOC_INPUT_FORMAT" \
+  $( [ "$SOC_PROXY" = "1" ] && echo --proxy )

--- a/tools/list_av.py
+++ b/tools/list_av.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+import glob
+import subprocess
+
+
+def _run(cmd):
+    try:
+        return subprocess.check_output(cmd, text=True).strip()
+    except Exception:
+        return ""
+
+
+print("Video devices:")
+videos = sorted(glob.glob("/dev/video*"))
+if videos:
+    for v in videos:
+        print(f"  - {v}")
+else:
+    print("  (none)")
+
+print("\nPulse sources:")
+ps = _run(["pactl", "list", "short", "sources"])
+if ps:
+    for line in ps.splitlines():
+        parts = line.split("\t")
+        if len(parts) >= 2:
+            print(f"  - {parts[1]}")
+else:
+    print("  (none)")


### PR DESCRIPTION
## Summary
- Add `soccerday` launcher and `soccer` package with resilient FFmpeg recorder
- Include device guessing, free-space guard, thumbnail and proxy support
- Document usage and provide A/V device lister

## Testing
- `python3 -m soccer.recorder --help`
- `python3 -m tools.list_av`


------
https://chatgpt.com/codex/tasks/task_e_68b2aad88154832d8f8001e52a91985f