### PR TITLE
Default soccerday audio source to analog stereo

### DIFF
--- a/soccerday
+++ b/soccerday
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 VIDEO_DEV="${VIDEO_DEV:-/dev/video0}"
-AUDIO_SRC="${AUDIO_SRC:-default}"
+: "${AUDIO_SRC:=alsa_input.platform-sound.analog-stereo}"  # or "default"
+export AUDIO_SRC
 SOC_FPS="${SOC_FPS:-30}"
 SOC_RES="${SOC_RES:-1280x720}"
 SOC_CRF="${SOC_CRF:-18}"


### PR DESCRIPTION
## Summary
- default soccerday audio source to `alsa_input.platform-sound.analog-stereo` and export it for Python

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2ade9f774832dbc57c3702dd8d64d