### PR TITLE
Add Pulse audio resolver for gameday launcher

### DIFF
--- a/gameday
+++ b/gameday
@@ -18,6 +18,10 @@ OVERRIDE_PULSE_DEV=""
 OVERRIDE_SIZE=""
 OVERRIDE_FPS=""
 
+# NEW: optional regex hint for Pulse source selection
+: "${PULSE_DEV_REGEX:=VideoMic|R.?DE|usb.*mic}"
+export PULSE_DEV_REGEX
+
 usage() {
   cat <<'USAGE'
 Usage: ./gameday [options]
@@ -97,31 +101,22 @@ print(v if v is not None else "")
 PY
 }
 
-# Resolve a configured PulseAudio source name to an actual device.  Handles
-# wildcards like `*` or placeholder `XXXXXXXX` for changing USB serial IDs.
-# If a unique match is found, the resolved name is printed; otherwise the
-# original value is echoed back unchanged so later validation can report an
-# error.
-resolve_pulse_source() {
-  local cfg="$1" sources pattern resolved
-  sources="$(pactl list short sources 2>/dev/null)" || sources=""
-  [[ -z "$sources" ]] && { echo "$cfg"; return; }
-
-  if echo "$sources" | awk '{print $2}' | grep -qxF "$cfg"; then
-    echo "$cfg"
-    return
+resolve_pulse() {
+  # 1) Honor exact PULSE_DEV if it exists and Pulse sees it
+  if [[ -n "${PULSE_DEV:-}" ]]; then
+    if pactl list short sources | awk '{print $2}' | grep -Fxq "$PULSE_DEV"; then
+      echo "$PULSE_DEV"
+      return 0
+    fi
   fi
-
-  pattern="$cfg"
-  pattern="${pattern//XXXXXXXX/.+}"
-  pattern="${pattern//\*/.*}"
-  resolved="$(echo "$sources" | awk '{print $2}' | grep -E "^${pattern}$" | head -n1)"
-  if [[ -n "$resolved" ]]; then
-    log "resolved pulse source '$cfg' -> '$resolved'"
-    echo "$resolved"
-  else
-    echo "$cfg"
+  # 2) Use Python resolver (falls back to best source)
+  local sel
+  sel="$(PYTHONPATH=. python3 -m tools.audio_select || true)"
+  if [[ -n "$sel" ]]; then
+    echo "$sel"
+    return 0
   fi
+  return 1
 }
 
 rtmp_url="$(json_get rtmp_url)"
@@ -137,8 +132,24 @@ fps="$(json_get fps)"
 [[ -n "$OVERRIDE_SIZE"      ]] && video_size="$OVERRIDE_SIZE"
 [[ -n "$OVERRIDE_FPS"       ]] && fps="$OVERRIDE_FPS"
 
-# Attempt to auto-resolve dynamic PulseAudio source names.
-pulse_dev="$(resolve_pulse_source "$pulse_dev")"
+# Allow PULSE_DEV env to reflect configured or overridden name
+if [[ -n "$pulse_dev" ]]; then
+  export PULSE_DEV="$pulse_dev"
+fi
+
+# Resolve Pulse source (may fall back to best source)
+pulse_dev="$(resolve_pulse || true)"
+
+if [[ -z "${pulse_dev:-}" ]]; then
+  log "pulse source not found (regex: ${PULSE_DEV_REGEX}). Available sources:"
+  pactl list short sources | awk '{print "  "$2}'
+  log "Falling back to system default 'alsa_input.platform-sound.analog-stereo' if present."
+  pulse_dev="$(pactl list short sources | awk '{print $2}' | grep -m1 -E '^alsa_input\.platform-.*analog-stereo$' || true)"
+  if [[ -z "${pulse_dev:-}" ]]; then
+    log "ERROR: No usable Pulse source. Exiting."
+    exit 1
+  fi
+fi
 
 log "Launch -> video=${video_dev} ${video_size}@${fps} | pulse=${pulse_dev} | rtmp=$([[ -n "$rtmp_url" ]] && echo set || echo MISSING)"
 

--- a/tools/audio_select.py
+++ b/tools/audio_select.py
@@ -1,0 +1,83 @@
+import json, os, re, subprocess, sys
+
+
+def _load_sources():
+    try:
+        out = subprocess.check_output(["pactl", "-f", "json", "list", "sources"], text=True)
+        return json.loads(out)
+    except Exception as e:
+        print(f"[audio_select] ERROR: cannot list Pulse sources: {e}", file=sys.stderr)
+        return []
+
+
+def _score_source(src):
+    # Favor external USB mics, mono fallback is fine, avoid HDMI/stereo monitors
+    name = src.get("name", "").lower()
+    desc = src.get("description", "").lower()
+    score = 0
+    if "video" in desc or "mic" in desc or "rode" in desc or "usb" in desc:
+        score += 50
+    if "mono" in desc or "mono" in name:
+        score += 10
+    if "monitor" in name or "monitor" in desc:
+        score -= 100  # not a capture device
+    if "hdmi" in name or "hdmi" in desc:
+        score -= 50
+    if "analog-stereo" in name or "analog-stereo" in desc:
+        score += 2
+    return score
+
+
+def _match_regex(sources, pattern):
+    rx = re.compile(pattern, re.I)
+    for s in sources:
+        if rx.search(s.get("name", "")) or rx.search(s.get("description", "")):
+            return s
+    return None
+
+
+def pick_pulse_source():
+    sources = _load_sources()
+    if not sources:
+        return None
+
+    # 1) Exact env override (legacy): PULSE_DEV (exact name)
+    exact = os.environ.get("PULSE_DEV")
+    if exact:
+        for s in sources:
+            if s.get("name") == exact:
+                return s
+
+    # 2) Regex hint: PULSE_DEV_REGEX (e.g., "VideoMic|RØDE|R__DE")
+    hint = os.environ.get("PULSE_DEV_REGEX")
+    if hint:
+        m = _match_regex(sources, hint)
+        if m:
+            return m
+
+    # 3) Known good Rode / external patterns
+    for pat in [r"VideoMic", r"R.?DE", r"usb.*mic", r"mic.*usb"]:
+        m = _match_regex(sources, pat)
+        if m:
+            return m
+
+    # 4) Best-scored non-monitor
+    ranked = sorted(
+        [s for s in sources if "monitor" not in s.get("name", "").lower()],
+        key=_score_source,
+        reverse=True,
+    )
+    return ranked[0] if ranked else None
+
+
+def pulse_name_from_selection(s):
+    return s.get("name") if s else None
+
+
+if __name__ == "__main__":
+    sel = pick_pulse_source()
+    name = pulse_name_from_selection(sel)
+    if not name:
+        print("", end="")
+        sys.exit(1)
+    print(name)


### PR DESCRIPTION
## Summary
- add tools/audio_select.py to pick best PulseAudio source with regex and scoring
- update gameday launcher to resolve audio via new helper and fall back gracefully

## Testing
- `pytest` *(fails: No module named 'torch', 'numpy', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b46dc4d170832d870217bb46436d66