### PR TITLE
Handle classifier flag warnings and fail fast

### DIFF
--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -167,9 +167,6 @@ def run_pipeline(
         )
         & ((1 << 44) - 1)
     )[2:]
-    run_dir = os.path.join(out_dir, "games", f"{_safe_name(tag)}__{short}")
-    report_dir = os.path.join(run_dir, "report")
-    run_dir_created = False
 
     model_paths = {
         "play_ckpt": play_ckpt,
@@ -218,6 +215,7 @@ def run_pipeline(
         else:
             clf = None
             logger.warning("[classifier] disabled (--no-require-classifier)")
+            warnings.append("classifier disabled by flag")
 
         playbook = load_playbook(playbook_path)
         print(f"[playbook] source={playbook_path}")
@@ -397,6 +395,10 @@ def run_pipeline(
     finally:
         root_logger.removeHandler(pre_log_handler)
         pre_log_lines = pre_log_stream.getvalue().splitlines()
+
+    run_dir = os.path.join(out_dir, "games", f"{_safe_name(tag)}__{short}")
+    report_dir = os.path.join(run_dir, "report")
+    run_dir_created = False
 
     csv_header = [
         "play_id",

--- a/tests/test_pipeline_failfast.py
+++ b/tests/test_pipeline_failfast.py
@@ -1,4 +1,18 @@
-import json, pathlib, pytest
+import json, pathlib, pytest, sys, types
+
+sys.modules.setdefault("numpy", types.SimpleNamespace())
+sys.modules.setdefault(
+    "torch",
+    types.SimpleNamespace(
+        save=lambda *a, **k: None,
+        load=lambda *a, **k: {},
+        __version__="0.0",
+        cuda=types.SimpleNamespace(
+            is_available=lambda: False, get_device_name=lambda _i: "cpu"
+        ),
+    ),
+)
+
 from analysis import pipeline
 
 
@@ -20,3 +34,24 @@ def test_require_classifier_missing_ckpt(tmp_path):
         )
     run_dirs = list((out_dir / "games").glob("*"))
     assert not run_dirs
+
+
+def test_disabled_classifier_writes_warning(tmp_path, monkeypatch):
+    pb = {"plays": []}
+    pb_path = tmp_path / "playbook.json"
+    pb_path.write_text(json.dumps(pb))
+
+    out_dir = tmp_path / "out"
+
+    monkeypatch.setattr(pipeline, "segment_video", lambda *a, **k: [])
+
+    run_dir = pipeline.run_pipeline(
+        video="dummy.mp4",
+        team="WHITE",
+        playbook_path=str(pb_path),
+        out_dir=str(out_dir),
+        require_classifier=False,
+    )
+    warn_path = pathlib.Path(run_dir) / "report" / "warnings.txt"
+    assert warn_path.exists(), "warnings file missing"
+    assert "classifier disabled by flag" in warn_path.read_text()

--- a/tests/test_pipeline_failures.py
+++ b/tests/test_pipeline_failures.py
@@ -1,5 +1,37 @@
-import csv, json, os, pathlib, pytest, torch
+import csv, json, os, pathlib, pytest, sys, types
 
+def _dummy_save(obj, path):
+    import pickle
+
+    with open(path, "wb") as fh:
+        pickle.dump(obj, fh)
+
+
+def _dummy_load(path):
+    import pickle
+
+    with open(path, "rb") as fh:
+        return pickle.load(fh)
+
+
+sys.modules["numpy"] = types.SimpleNamespace()
+sys.modules["torch"] = types.SimpleNamespace(
+    save=_dummy_save,
+    load=_dummy_load,
+    __version__="0.0",
+    cuda=types.SimpleNamespace(
+        is_available=lambda: False, get_device_name=lambda _i: "cpu"
+    ),
+)
+
+classifiers_stub = types.ModuleType("analysis.classifiers")
+classifiers_stub.load_models = lambda args: types.SimpleNamespace()
+classifiers_stub._load_ckpt = lambda path: {}
+classifiers_stub._load_labels = lambda path: []
+classifiers_stub.log = types.SimpleNamespace(info=lambda *a, **k: None)
+sys.modules["analysis.classifiers"] = classifiers_stub
+
+import torch  # type: ignore
 from analysis import pipeline
 
 
@@ -54,6 +86,26 @@ def test_pipeline_marks_failed_run(tmp_path, monkeypatch):
 
     monkeypatch.setattr(
         pipeline.csv, "DictWriter", lambda f, fieldnames: BoomWriter(f, fieldnames)
+    )
+
+    monkeypatch.setattr(pipeline, "segment_video", lambda *a, **k: [{"t0": 0.0, "t1": 1.0}])
+
+    monkeypatch.setattr(
+        pipeline,
+        "classify_plays",
+        lambda segments, *args, **kwargs: [
+            {
+                "play_id": seg.get("id", f"PLAY_{i+1:03d}"),
+                "formation": "",
+                "formation_confidence": 0.0,
+                "play_family": "",
+                "playcall_confidence": 0.0,
+                "clf_top1": "",
+                "clf_top1_conf": 0.0,
+                "candidates": [],
+            }
+            for i, seg in enumerate(segments)
+        ],
     )
 
     with pytest.raises(RuntimeError):


### PR DESCRIPTION
## Summary
- Avoid writing run directories until classifier setup succeeds
- Warn when classifier is disabled via flag
- Add coverage for classifier disabled warning

## Testing
- `pytest tests/test_pipeline_failfast.py tests/test_pipeline_failures.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5a1a826a4832d829d462897e77050