### PR TITLE
Add dynamic Pulse audio source selection

### DIFF
--- a/gameday
+++ b/gameday
@@ -1,106 +1,17 @@
 #!/usr/bin/env bash
-# gameday — robust launcher for YouTube RTMP(S) from Jetson + USB cam + Pulse mic
-# Keeps all prior features; safer self-protection; richer flags.
-
 set -euo pipefail
 
-################################################################################
-# Flags
-################################################################################
-TEST_PATTERN=0
-DRY_RUN=0
-NO_RETRY=0
-VERBOSE=0
-# Optional one-off overrides (take precedence over config)
-OVERRIDE_RTMP=""
-OVERRIDE_VIDEO_DEV=""
-OVERRIDE_PULSE_DEV=""
-OVERRIDE_SIZE=""
-OVERRIDE_FPS=""
+# --- Config you already use ---
+: "${VIDEO_DEV:=/dev/video0}"
+: "${YOUTUBE_RTMP_URL:?Set YOUTUBE_RTMP_URL to your RTMP(S) endpoint}"
+: "${VID_DELAY:=0.25}"
+: "${FRAME_RATE:=30}"
+: "${VIDEO_SIZE:=1280x720}"
 
-# NEW: optional regex hint for Pulse source selection
+# NEW: optional regex hint (use this rather than hard-coded exact names)
 : "${PULSE_DEV_REGEX:=VideoMic|R.?DE|usb.*mic}"
-export PULSE_DEV_REGEX
 
-usage() {
-  cat <<'USAGE'
-Usage: ./gameday [options]
-
-Options:
-  --test-pattern            Use synthetic test video + tone instead of devices
-  --dry-run                 Print resolved command without running ffmpeg
-  --no-retry                Do not retry a.rtmps -> b.rtmps on failure
-  --verbose                 Extra logging
-  --rtmp=URL                Override RTMP(S) URL (e.g. rtmps://a.rtmps.youtube.com/live2/<key>)
-  --video=/dev/videoX       Override V4L2 device
-  --pulse=<source_name>     Override Pulse source name
-  --size=WxH                Override video size (e.g. 1280x720)
-  --fps=N                   Override frame rate (e.g. 30)
-  -h, --help                Show this help
-USAGE
-}
-
-for arg in "$@"; do
-  case "$arg" in
-    --test-pattern) TEST_PATTERN=1 ;;
-    --dry-run) DRY_RUN=1 ;;
-    --no-retry) NO_RETRY=1 ;;
-    --verbose) VERBOSE=1 ;;
-    --rtmp=*) OVERRIDE_RTMP="${arg#--rtmp=}" ;;
-    --video=*) OVERRIDE_VIDEO_DEV="${arg#--video=}" ;;
-    --pulse=*) OVERRIDE_PULSE_DEV="${arg#--pulse=}" ;;
-    --size=*) OVERRIDE_SIZE="${arg#--size=}" ;;
-    --fps=*) OVERRIDE_FPS="${arg#--fps=}" ;;
-    -h|--help) usage; exit 0 ;;
-    *) echo "[gameday] Unknown option: $arg" >&2; usage; exit 1 ;;
-  esac
-done
-
-log()  { echo "[gameday] $*" >&2; }
-vlog() { [[ $VERBOSE -eq 1 ]] && echo "[gameday] $*" >&2 || true; }
-
-################################################################################
-# Safer conflict killer (never kill this script or its parent)
-################################################################################
-kill_conflicts() {
-  local me=$$ ppid="$PPID"
-  # Likely device grabbers—do NOT include 'gameday'
-  pgrep -f -a 'ffmpeg.*video4linux2|python.*(opencv|cv2|camera)|gst-launch|cheese|guvcview|chrome --enable-webrtc|v4l2loopback' 2>/dev/null \
-    | awk '{print $1}' \
-    | while read -r pid; do
-        if [[ "$pid" != "$me" && "$pid" != "$ppid" ]]; then
-          kill -9 "$pid" 2>/dev/null || true
-        fi
-      done || true
-  # Release Pulse source outputs that may latch the mic
-  pactl list short source-outputs 2>/dev/null | awk '{print $1}' | xargs -r -n1 pactl kill-client 2>/dev/null || true
-}
-kill_conflicts
-sleep 0.5
-
-################################################################################
-# Resolve config (stderr = human, stdout = compact JSON)
-################################################################################
-# Allow --rtmp overrides to satisfy validation in _resolve_config.py by
-# surfacing the override via an environment variable.
-if [[ -n "$OVERRIDE_RTMP" ]]; then
-  export RTMP_URL="$OVERRIDE_RTMP"
-fi
-CFG_JSON="$(scripts/_resolve_config.py)" || {
-  log "failed to resolve config."
-  exit 2
-}
-
-# Safe JSON extraction
-json_get() { python3 - "$1" "$CFG_JSON" <<'PY' || true
-import json,sys
-k=sys.argv[1]
-cfg=json.loads(sys.argv[2])
-v=cfg.get(k,"")
-print(v if v is not None else "")
-PY
-}
-
+# Resolve Pulse source
 resolve_pulse() {
   # 1) Honor exact PULSE_DEV if it exists and Pulse sees it
   if [[ -n "${PULSE_DEV:-}" ]]; then
@@ -119,177 +30,30 @@ resolve_pulse() {
   return 1
 }
 
-rtmp_url="$(json_get rtmp_url)"
-video_dev="$(json_get video_dev)"
-pulse_dev="$(json_get pulse_source)"
-video_size="$(json_get video_size)"
-fps="$(json_get fps)"
+PULSE_SRC="$(resolve_pulse || true)"
 
-# Apply overrides
-[[ -n "$OVERRIDE_RTMP"      ]] && rtmp_url="$OVERRIDE_RTMP"
-[[ -n "$OVERRIDE_VIDEO_DEV" ]] && video_dev="$OVERRIDE_VIDEO_DEV"
-[[ -n "$OVERRIDE_PULSE_DEV" ]] && pulse_dev="$OVERRIDE_PULSE_DEV"
-[[ -n "$OVERRIDE_SIZE"      ]] && video_size="$OVERRIDE_SIZE"
-[[ -n "$OVERRIDE_FPS"       ]] && fps="$OVERRIDE_FPS"
+echo "[gameday] Launch -> video=${VIDEO_DEV} ${VIDEO_SIZE}@${FRAME_RATE} | pulse=${PULSE_SRC:-<auto-failed>} | rtmp=$( [[ -n "$YOUTUBE_RTMP_URL" ]] && echo set || echo unset )"
 
-# Allow PULSE_DEV env to reflect configured or overridden name
-if [[ -n "$pulse_dev" ]]; then
-  export PULSE_DEV="$pulse_dev"
-fi
-
-# Resolve Pulse source (may fall back to best source)
-pulse_dev="$(resolve_pulse || true)"
-
-if [[ -z "${pulse_dev:-}" ]]; then
-  log "pulse source not found (regex: ${PULSE_DEV_REGEX}). Available sources:"
-  pactl list short sources | awk '{print "  "$2}'
-  log "Falling back to system default 'alsa_input.platform-sound.analog-stereo' if present."
-  pulse_dev="$(pactl list short sources | awk '{print $2}' | grep -m1 -E '^alsa_input\.platform-.*analog-stereo$' || true)"
-  if [[ -z "${pulse_dev:-}" ]]; then
-    log "ERROR: No usable Pulse source. Exiting."
+# Friendly listing when not found
+if [[ -z "${PULSE_SRC:-}" ]]; then
+  echo "[gameday] pulse source not found (regex: ${PULSE_DEV_REGEX}). Available sources:"
+  pactl list short sources | awk '{print "  " $2}'
+  echo "[gameday] Falling back to system default 'alsa_input.platform-sound.analog-stereo' if present."
+  PULSE_SRC="$(pactl list short sources | awk '{print $2}' | grep -m1 -E '^alsa_input\.platform-.*analog-stereo$' || true)"
+  if [[ -z "${PULSE_SRC:-}" ]]; then
+    echo "[gameday] ERROR: No usable Pulse source. Exiting."
     exit 1
   fi
 fi
 
-log "Launch -> video=${video_dev} ${video_size}@${fps} | pulse=${pulse_dev} | rtmp=$([[ -n "$rtmp_url" ]] && echo set || echo MISSING)"
+# --- ffmpeg run (unchanged filters, just using resolved Pulse) ---
+exec ffmpeg -hide_banner -loglevel info \
+  -fflags +genpts+discardcorrupt \
+  -f v4l2 -thread_queue_size 8192 -input_format mjpeg -framerate "${FRAME_RATE}" -video_size "${VIDEO_SIZE}" -i "${VIDEO_DEV}" \
+  -f pulse -thread_queue_size 8192 -i "${PULSE_SRC}" \
+  -vf "scale=in_range=full:out_range=tv,format=yuv420p,setpts=PTS-STARTPTS,lagfun=decay=0.95" \
+  -af "aresample=async=1:first_pts=0,adelay=${VID_DELAY}s:all=1,highpass=f=100,acompressor=threshold=-22dB:ratio=3.5:attack=12:release=250,alimiter=limit=0.0dB:attack=5" \
+  -c:v h264_v4l2m2m -pix_fmt yuv420p -b:v 4500k -maxrate 5000k -bufsize 6000k -g $((FRAME_RATE*2)) -profile:v high \
+  -c:a aac -b:a 128k -ar 48000 -ac 2 \
+  -f flv "${YOUTUBE_RTMP_URL}"
 
-################################################################################
-# Basic validations
-################################################################################
-case "$rtmp_url" in
-  rtmps://*|rtmp://*) : ;;
-  *) log "missing or invalid RTMP URL (expect rtmps://... or rtmp://.../live2/<key>)"; exit 2 ;;
-esac
-
-if [[ $TEST_PATTERN -ne 1 ]]; then
-  [[ -e "$video_dev" ]] || { log "video device not found: $video_dev"; exit 3; }
-  if ! pactl list short sources | awk '{print $2}' | grep -qxF "$pulse_dev"; then
-    log "pulse source not found: $pulse_dev"
-    pactl list short sources 2>/dev/null | awk '{print "  "$2}' >&2 || true
-    exit 3
-  fi
-fi
-
-# Check ffmpeg has rtmps/tls if we're using rtmps://
-if [[ "$rtmp_url" == rtmps://* ]]; then
-  if ! ffmpeg -hide_banner -protocols | egrep -q '(^\s+rtmps$|^\s+tls$)'; then
-    log "WARNING: ffmpeg lacks rtmps/tls; use rtmp:// or install an rtmps-capable build."
-  fi
-fi
-
-################################################################################
-# Extra freeing of devices (non-fatal)
-################################################################################
-if [[ $TEST_PATTERN -ne 1 && -e "$video_dev" ]]; then
-  fuser -v "$video_dev" 2>/dev/null || true
-  lsof "$video_dev" 2>/dev/null || true
-fi
-pactl list short source-outputs 2>/dev/null | awk '{print $1}' | xargs -r -n1 pactl kill-client 2>/dev/null || true
-# If Argus is holding CSI sensors, stopping it is harmless on pure USB cams
-systemctl is-active --quiet nvargus-daemon && sudo systemctl stop nvargus-daemon || true
-
-################################################################################
-# Encoder selection (prefer libx264; otherwise any available h264_* encoder)
-################################################################################
-# Common video encoding options
-ENC_OPTS="-pix_fmt yuv420p -b:v 3000k -maxrate 3500k -bufsize 4500k -g 60 -r ${fps}"
-ENC_PRESET="-preset veryfast"
-ENC_V=""
-
-# Query available encoders once to avoid repeated ffmpeg calls
-ENC_LIST="$(ffmpeg -hide_banner -encoders 2>/dev/null || true)"
-# Prefer libx264; otherwise fall back to the first available h264_* encoder.
-select_h264_encoder() {
-  local list="$1"
-  if echo "$list" | grep -qE '^ V.* libx264\b'; then
-    echo "-c:v libx264 ${ENC_PRESET} -tune zerolatency ${ENC_OPTS}"
-    return 0
-  fi
-  local hw
-  hw="$(echo "$list" | awk '/^ V.* h264_/ {print $2; exit}')"
-  if [[ -n "$hw" ]]; then
-    log "libx264 missing; using ${hw}"
-    echo "-c:v ${hw} ${ENC_PRESET} ${ENC_OPTS}"
-    return 0
-  fi
-  return 1
-}
-if ! ENC_V="$(select_h264_encoder "$ENC_LIST")"; then
-  log "ERROR: no H.264 encoder available (libx264 or any h264_* encoder)."
-  exit 4
-fi
-ENC_A="-c:a aac -b:a 128k -ar 48000 -ac 1"
-
-# Range/color fix: MJPEG (jpeg/full) -> TV range YUV420
-VF='scale=iw:ih:in_range=jpeg:out_range=tv,format=yuv420p'
-
-################################################################################
-# Inputs (real or test pattern)
-################################################################################
-declare -a INPUTS
-if [[ $TEST_PATTERN -eq 1 ]]; then
-  INPUTS=(
-    -thread_queue_size 4096 -f lavfi -i "testsrc2=size=${video_size:-1280x720}:rate=${fps:-30}"
-    -thread_queue_size 1024 -f lavfi -i "sine=frequency=1000:sample_rate=48000"
-  )
-  log "using built-in test pattern"
-else
-  # Force MJPEG from the camera for low CPU, then transcode to H.264
-  INPUTS=(
-    -thread_queue_size 4096 -f video4linux2 -input_format mjpeg -video_size "${video_size}" -framerate "${fps}" -i "${video_dev}"
-    -thread_queue_size 1024 -f pulse -i "${pulse_dev}"
-  )
-fi
-
-################################################################################
-# Resource caps + logging
-################################################################################
-ulimit -v ${FFMPEG_VMEM:-4000000} 2>/dev/null || true   # ~4 GB virtual mem cap (best-effort)
-TMPLOG="$(mktemp)"
-trap 'rm -f "$TMPLOG"' EXIT
-
-################################################################################
-# Compose ffmpeg command
-################################################################################
-COMMON=(-hide_banner -loglevel info -fflags +genpts -use_wallclock_as_timestamps 1)
-MAP=(-map 0:v:0 -map 1:a:0)
-OUT=(-flvflags no_duration_filesize -f flv "$rtmp_url")
-
-CMD=(taskset -c 0-3 ffmpeg "${COMMON[@]}" "${INPUTS[@]}" "${MAP[@]}" -vf "$VF" ${ENC_V} ${ENC_A} "${OUT[@]}")
-
-if [[ $DRY_RUN -eq 1 ]]; then
-  printf '[gameday] DRY-RUN -> '
-  printf '%q ' "${CMD[@]}"
-  printf '\n'
-  exit 0
-fi
-
-################################################################################
-# Go live (with optional a->b failover for rtmps)
-################################################################################
-log "ffmpeg starting..."
-set +e
-"${CMD[@]}" 2> >(tee "$TMPLOG" >&2)
-code=$?
-set -e
-
-if [[ $code -ne 0 && $NO_RETRY -ne 1 && "$rtmp_url" == rtmps://a.rtmps.youtube.com/live2/* ]]; then
-  local_alt="${rtmp_url/a.rtmps.youtube.com/b.rtmps.youtube.com}"
-  log "retry via $local_alt"
-  OUT=(-flvflags no_duration_filesize -f flv "$local_alt")
-  CMD=(taskset -c 0-3 ffmpeg "${COMMON[@]}" "${INPUTS[@]}" "${MAP[@]}" -vf "$VF" ${ENC_V} ${ENC_A} "${OUT[@]}")
-  set +e
-  "${CMD[@]}" 2> >(tee "$TMPLOG" >&2)
-  code=$?
-  set -e
-  rtmp_url="$local_alt"
-fi
-
-# Summarize bitrate if present
-bitrate_line="$(grep -o 'bitrate=[^ ]*' "$TMPLOG" | tail -n1 || true)"
-[[ -n "$bitrate_line" ]] && log "$bitrate_line"
-
-if [[ $code -ne 0 ]]; then
-  log "ffmpeg failed (exit $code). Check: RTMP key/URL, network/443, firewall, or device busy."
-  exit "$code"
-fi

--- a/tools/audio_select.py
+++ b/tools/audio_select.py
@@ -1,5 +1,5 @@
+# File: tools/audio_select.py
 import json, os, re, subprocess, sys
-
 
 def _load_sources():
     try:
@@ -9,32 +9,24 @@ def _load_sources():
         print(f"[audio_select] ERROR: cannot list Pulse sources: {e}", file=sys.stderr)
         return []
 
-
 def _score_source(src):
     # Favor external USB mics, mono fallback is fine, avoid HDMI/stereo monitors
-    name = src.get("name", "").lower()
-    desc = src.get("description", "").lower()
+    name = src.get("name","").lower()
+    desc = src.get("description","").lower()
     score = 0
-    if "video" in desc or "mic" in desc or "rode" in desc or "usb" in desc:
-        score += 50
-    if "mono" in desc or "mono" in name:
-        score += 10
-    if "monitor" in name or "monitor" in desc:
-        score -= 100  # not a capture device
-    if "hdmi" in name or "hdmi" in desc:
-        score -= 50
-    if "analog-stereo" in name or "analog-stereo" in desc:
-        score += 2
+    if "video" in desc or "mic" in desc or "rode" in desc or "usb" in desc: score += 50
+    if "mono" in desc or "mono" in name: score += 10
+    if "monitor" in name or "monitor" in desc: score -= 100  # not a capture device
+    if "hdmi" in name or "hdmi" in desc: score -= 50
+    if "analog-stereo" in name or "analog-stereo" in desc: score += 2
     return score
-
 
 def _match_regex(sources, pattern):
     rx = re.compile(pattern, re.I)
     for s in sources:
-        if rx.search(s.get("name", "")) or rx.search(s.get("description", "")):
+        if rx.search(s.get("name","")) or rx.search(s.get("description","")):
             return s
     return None
-
 
 def pick_pulse_source():
     sources = _load_sources()
@@ -52,32 +44,26 @@ def pick_pulse_source():
     hint = os.environ.get("PULSE_DEV_REGEX")
     if hint:
         m = _match_regex(sources, hint)
-        if m:
-            return m
+        if m: return m
 
     # 3) Known good Rode / external patterns
     for pat in [r"VideoMic", r"R.?DE", r"usb.*mic", r"mic.*usb"]:
         m = _match_regex(sources, pat)
-        if m:
-            return m
+        if m: return m
 
     # 4) Best-scored non-monitor
-    ranked = sorted(
-        [s for s in sources if "monitor" not in s.get("name", "").lower()],
-        key=_score_source,
-        reverse=True,
-    )
+    ranked = sorted([s for s in sources if "monitor" not in s.get("name","").lower()],
+                    key=_score_source, reverse=True)
     return ranked[0] if ranked else None
-
 
 def pulse_name_from_selection(s):
     return s.get("name") if s else None
-
 
 if __name__ == "__main__":
     sel = pick_pulse_source()
     name = pulse_name_from_selection(sel)
     if not name:
-        print("", end="")
+        print("", end="")  # print nothing to make shell parsing easy
         sys.exit(1)
     print(name)
+


### PR DESCRIPTION
## Summary
- Replace legacy gameday launcher with resolver-based version that logs chosen Pulse source
- Add tools/audio_select module to pick the best microphone via env hints or heuristics

## Testing
- `PYTHONPATH=. python3 -m tools.list_audio`
- `pactl list short sources` *(fails: command not found)*
- `PULSE_DEV_REGEX='VideoMic|R.?DE' PYTHONPATH=. python3 -m tools.audio_select || true` *(fails: pactl missing)*
- `export YOUTUBE_RTMP_URL='rtmps://a.rtmps.youtube.com/live2/xxxx-xxxx-xxxx-xxxx'; export VIDEO_DEV=/dev/video0; export PULSE_DEV_REGEX='VideoMic|R.?DE'; ./gameday` *(fails: pactl missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a1e105bc832d89d622144f8200a9