### PR TITLE
Auto-select video codec in gameday

### DIFF
--- a/gameday
+++ b/gameday
@@ -7,6 +7,7 @@ set -euo pipefail
 : "${VID_DELAY:=0.25}"
 : "${FRAME_RATE:=30}"
 : "${VIDEO_SIZE:=1280x720}"
+: "${VIDEO_CODEC:=auto}"     # auto | h264_v4l2m2m | libx264
 
 # NEW: optional regex hint (use this rather than hard-coded exact names)
 : "${PULSE_DEV_REGEX:=VideoMic|R.?DE|usb.*mic}"
@@ -32,7 +33,33 @@ resolve_pulse() {
 
 PULSE_SRC="$(resolve_pulse || true)"
 
-echo "[gameday] Launch -> video=${VIDEO_DEV} ${VIDEO_SIZE}@${FRAME_RATE} | pulse=${PULSE_SRC:-<auto-failed>} | rtmp=$( [[ -n "$YOUTUBE_RTMP_URL" ]] && echo set || echo unset )"
+choose_codec() {
+  # If user forces a codec, honor it.
+  if [[ "$VIDEO_CODEC" != "auto" ]]; then
+    echo "$VIDEO_CODEC"
+    return 0
+  fi
+  # Quick probe: does HW encoder accept a tiny NV12 test?
+  if ffmpeg -v error -f lavfi -i testsrc=size=1280x720:rate=30 -t 1 \
+            -vf format=nv12 -pix_fmt nv12 \
+            -c:v h264_v4l2m2m -f null - >/dev/null 2>&1; then
+    echo "h264_v4l2m2m"
+  else
+    echo "libx264"
+  fi
+}
+
+V_CODEC="$(choose_codec)"
+# Per-codec pixel format / filter chain
+if [[ "$V_CODEC" == "h264_v4l2m2m" ]]; then
+  V_PIXFMT_OPTS=(-vf "scale=in_range=full:out_range=tv,format=nv12,setpts=PTS-STARTPTS,lagfun=decay=0.95" -pix_fmt nv12)
+  V_ENCODER_OPTS=(-c:v h264_v4l2m2m -pix_fmt yuv420p -b:v 4500k -maxrate 5000k -bufsize 6000k -g $((FRAME_RATE*2)) -profile:v high)
+else
+  V_PIXFMT_OPTS=(-vf "scale=in_range=full:out_range=tv,format=yuv420p,setpts=PTS-STARTPTS,lagfun=decay=0.95" -pix_fmt yuv420p)
+  V_ENCODER_OPTS=(-c:v libx264 -preset veryfast -b:v 4500k -maxrate 5000k -bufsize 6000k -g $((FRAME_RATE*2)) -profile:v high)
+fi
+
+echo "[gameday] Launch -> video=${VIDEO_DEV} ${VIDEO_SIZE}@${FRAME_RATE} | pulse=${PULSE_SRC:-<none>} | vcodec=${V_CODEC} | rtmp=$( [[ -n "$YOUTUBE_RTMP_URL" ]] && echo set || echo unset )"
 
 # Friendly listing when not found
 if [[ -z "${PULSE_SRC:-}" ]]; then
@@ -47,13 +74,19 @@ if [[ -z "${PULSE_SRC:-}" ]]; then
 fi
 
 # --- ffmpeg run (unchanged filters, just using resolved Pulse) ---
-exec ffmpeg -hide_banner -loglevel info \
-  -fflags +genpts+discardcorrupt \
-  -f v4l2 -thread_queue_size 8192 -input_format mjpeg -framerate "${FRAME_RATE}" -video_size "${VIDEO_SIZE}" -i "${VIDEO_DEV}" \
-  -f pulse -thread_queue_size 8192 -i "${PULSE_SRC}" \
-  -vf "scale=in_range=full:out_range=tv,format=yuv420p,setpts=PTS-STARTPTS,lagfun=decay=0.95" \
-  -af "aresample=async=1:first_pts=0,adelay=${VID_DELAY}s:all=1,highpass=f=100,acompressor=threshold=-22dB:ratio=3.5:attack=12:release=250,alimiter=limit=0.0dB:attack=5" \
-  -c:v h264_v4l2m2m -pix_fmt yuv420p -b:v 4500k -maxrate 5000k -bufsize 6000k -g $((FRAME_RATE*2)) -profile:v high \
-  -c:a aac -b:a 128k -ar 48000 -ac 2 \
-  -f flv "${YOUTUBE_RTMP_URL}"
+OUT_URL="${YOUTUBE_RTMP_URL}"
+
+run_ffmpeg() {
+  exec ffmpeg -hide_banner -loglevel info \
+    -fflags +genpts+discardcorrupt \
+    -f v4l2 -thread_queue_size 8192 -input_format mjpeg -framerate "${FRAME_RATE}" -video_size "${VIDEO_SIZE}" -i "${VIDEO_DEV}" \
+    -f pulse -thread_queue_size 8192 -i "${PULSE_SRC}" \
+    -af "aresample=async=1:first_pts=0,adelay=${VID_DELAY}s:all=1,highpass=f=100,acompressor=threshold=-22dB:ratio=3.5:attack=12:release=250,alimiter=limit=0.0dB:attack=5" \
+    "${V_PIXFMT_OPTS[@]}" \
+    "${V_ENCODER_OPTS[@]}" \
+    -c:a aac -b:a 128k -ar 48000 -ac 2 \
+    -f flv "${OUT_URL}"
+}
+
+run_ffmpeg
 


### PR DESCRIPTION
## Summary
- Auto-detect hardware vs software encoder with `VIDEO_CODEC` and `choose_codec`
- Print selected codec on launch and build FFmpeg args dynamically

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b5b3e46f1c832dae71dd7793ad604a