### PR TITLE
Auto-load gameday env config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ credentials.json# Google/GCP service account keys (never commit these)
 *service-account*.json
 *credentials*.json
 modular-conduit-*-*.json
+.gameday.env

--- a/gameday
+++ b/gameday
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Auto-load local env if present (kept out of git, holds your stream key)
+if [ -f ".gameday.env" ]; then
+  set -a
+  . ".gameday.env"
+  set +a
+fi
+
 # --- Config you already use ---
 : "${VIDEO_DEV:=/dev/video0}"
 : "${YOUTUBE_RTMP_URL:?Set YOUTUBE_RTMP_URL to your RTMP(S) endpoint}"


### PR DESCRIPTION
## Summary
- Source streaming credentials from optional `.gameday.env` file before runtime defaults
- Ignore `.gameday.env` so local stream keys stay out of git

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for torch, numpy, google; SyntaxError in play_classifier.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b5be66c51c832d988f467323da6e7f