### PR TITLE
Add model preflight, robust checkpoint loading, and upload server

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,27 @@ bash scripts/update_latest_symlinks.sh
 
 Or run `scripts/run_batch.sh` to use this loop.
 
+### Model uploads and classifier flags
 
+Upload or replace model files over the local network:
+
+```bash
+python3 tools/upload_server.py
+```
+
+From another machine, open `http://<jetson-ip>:8000` in a browser, upload the four files to their targets, and verify at `http://<jetson-ip>:8000/ls`.
+
+Run the pipeline without a classifier while models are being copied:
+
+```bash
+python3 -m analysis.pipeline ... --no-require-classifier
+```
+
+Run with classifiers enabled once models are present (default):
+
+```bash
+python3 -m analysis.pipeline ... --require-classifier
+```
 
 ### One-click end-to-end analysis
 

--- a/analysis/classifiers.py
+++ b/analysis/classifiers.py
@@ -1,5 +1,4 @@
 import os
-import hashlib
 import logging
 from typing import Any, List
 
@@ -17,12 +16,13 @@ except Exception as e:  # pragma: no cover - import guard
 log = logging.getLogger("classifier")
 
 
-def _sha256(path: str, n: int = 10) -> str:
-    h = hashlib.sha256()
-    with open(path, "rb") as f:
-        for chunk in iter(lambda: f.read(1 << 20), b""):
-            h.update(chunk)
-    return h.hexdigest()[:n]
+def _ensure_nonempty(path: str, tag: str) -> str:
+    ap = os.path.abspath(path)
+    if not os.path.isfile(ap):
+        raise FileNotFoundError(f"{tag} missing: {ap}")
+    if os.path.getsize(ap) == 0:
+        raise RuntimeError(f"{tag} is empty (0 bytes): {ap}")
+    return ap
 
 
 def _check_file(path: str | os.PathLike[str] | None, label: str) -> str:
@@ -35,58 +35,52 @@ def _check_file(path: str | os.PathLike[str] | None, label: str) -> str:
     return ap
 
 
-def _load_ckpt(path: str) -> Any:
-    ap = os.path.abspath(path)
-    if not os.path.isfile(ap):
-        raise FileNotFoundError(f"checkpoint not found: {ap}")
-    sz = os.path.getsize(ap)
-    log.info(f"[ckpt] {ap} ({sz/1e6:.1f} MB) sha256={_sha256(ap)}")
+def _load_ckpt(path: str):
+    import torch
+    ap = _ensure_nonempty(path, "checkpoint")
 
-    # 1) state_dict w/ weights-only
+    # 1) weights_only (safe) if available
     try:
-        import torch
-
-        obj = torch.load(ap, map_location="cpu", weights_only=True)
-        sd = obj.get("state_dict", obj) if isinstance(obj, dict) else obj
-        if isinstance(sd, dict):
-            log.info("[ckpt] loaded as state_dict (weights_only)")
-            return {"type": "state_dict", "state_dict": sd}
+        ckpt = torch.load(ap, map_location="cpu", weights_only=True)  # torch>=2.0
+        log.info("loaded state_dict via torch.load(weights_only=True): %s", ap)
+        return {"type": "state_dict", "payload": ckpt}
+    except TypeError:
+        pass
     except Exception as e:
-        log.warning(f"[ckpt] weights_only state_dict load failed: {e}")
+        log.warning("weights_only load failed: %s", e)
 
-    # 2) legacy pickle (some older checkpoints need this)
+    # 2) regular pickle load (might include full objects)
     try:
-        import torch
-
-        obj = torch.load(ap, map_location="cpu", weights_only=False)
-        sd = obj.get("state_dict", obj) if isinstance(obj, dict) else obj
-        if isinstance(sd, dict):
-            log.info("[ckpt] loaded as state_dict (pickle)")
-            return {"type": "state_dict", "state_dict": sd}
+        ckpt = torch.load(ap, map_location="cpu")
+        if isinstance(ckpt, dict) and "state_dict" in ckpt:
+            log.info("loaded checkpoint dict with state_dict: %s", ap)
+            return {"type": "checkpoint", "payload": ckpt["state_dict"]}
+        log.info("loaded raw object via pickle torch.load: %s", ap)
+        return {"type": "raw", "payload": ckpt}
     except Exception as e:
-        log.warning(f"[ckpt] pickle state_dict load failed: {e}")
+        log.warning("pickle torch.load failed: %s", e)
 
-    # 3) TorchScript module
+    # 3) TorchScript
     try:
-        import torch
-
         ts = torch.jit.load(ap, map_location="cpu")
-        log.info("[ckpt] loaded as TorchScript module")
-        return {"type": "torchscript", "module": ts}
+        log.info("loaded TorchScript: %s", ap)
+        return {"type": "torchscript", "payload": ts}
     except Exception as e:
-        log.warning(f"[ckpt] torchscript load failed: {e}")
+        log.warning("torchscript load failed: %s", e)
 
-    # 4) safetensors
+    # 4) Safetensors (optional)
     try:
         from safetensors.torch import load_file as st_load
-
         sd = st_load(ap)
-        log.info("[ckpt] loaded as safetensors")
-        return {"type": "state_dict", "state_dict": sd}
+        log.info("loaded safetensors: %s", ap)
+        return {"type": "state_dict", "payload": sd}
     except Exception as e:
-        log.warning(f"[ckpt] safetensors load failed: {e}")
+        log.warning("safetensors load failed or not installed: %s", e)
 
-    raise RuntimeError(f"unsupported or corrupted checkpoint format: {ap}")
+    raise RuntimeError(
+        f"unsupported or corrupted checkpoint format: {ap}. "
+        "If this is a .safetensors file, convert it off-box to a .pt state_dict and retry."
+    )
 
 
 def _load_labels(path: str) -> List[str]:
@@ -126,9 +120,9 @@ def _init_from_ckpt(entry: dict, num_classes: int, builder):
 
     import torch
 
-    if entry["type"] == "state_dict":
+    if entry["type"] in ("state_dict", "checkpoint"):
         model = builder(num_classes)
-        msg = model.load_state_dict(entry["state_dict"], strict=False)
+        msg = model.load_state_dict(entry["payload"], strict=False)
         log.info(
             f"[ckpt] load_state_dict: missing={len(msg.missing_keys)} "
             f"unexpected={len(msg.unexpected_keys)}"
@@ -136,8 +130,13 @@ def _init_from_ckpt(entry: dict, num_classes: int, builder):
         model.eval()
         return model
     elif entry["type"] == "torchscript":
-        ts = entry["module"]
+        ts = entry["payload"]
         return ts.eval()
+    elif entry["type"] == "raw":
+        model = entry["payload"]
+        if hasattr(model, "eval"):
+            model.eval()
+        return model
     else:  # pragma: no cover - defensive
         raise RuntimeError("unknown ckpt entry type")
 

--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -396,6 +396,7 @@ def run_pipeline(
         root_logger.removeHandler(pre_log_handler)
         pre_log_lines = pre_log_stream.getvalue().splitlines()
 
+    # Only create output paths after classifier init succeeds
     run_dir = os.path.join(out_dir, "games", f"{_safe_name(tag)}__{short}")
     report_dir = os.path.join(run_dir, "report")
     run_dir_created = False
@@ -813,13 +814,13 @@ def main(argv=None) -> None:
         "--require-classifier",
         dest="require_classifier",
         action="store_true",
-        help="Require classifier; fail run if torch/models not available.",
+        help="Require classifier to run (default).",
     )
     group.add_argument(
         "--no-require-classifier",
         dest="require_classifier",
         action="store_false",
-        help="Disable classifier; do segmentation/clipping only.",
+        help="Do not require classifier (still produces clips).",
     )
     p.set_defaults(require_classifier=True)
     args = p.parse_args(argv)

--- a/scripts/preflight_models.sh
+++ b/scripts/preflight_models.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+min_bytes=1024
+min_labels=2
+fail=0
+
+check_file() {
+  local p="$1" lbl="$2"
+  if [ ! -f "$p" ]; then echo "❌ $lbl missing: $p"; fail=1; return; fi
+  local sz; sz=$(stat -c %s "$p" || echo 0)
+  if [ "$sz" -lt $min_bytes ]; then
+    echo "❌ $lbl too small ($sz bytes): $p"
+    fail=1
+  else
+    echo "✅ $lbl OK ($sz bytes)"
+  fi
+}
+
+check_labels() {
+  local p="$1" lbl="$2"
+  if [ ! -f "$p" ]; then echo "❌ $lbl missing: $p"; fail=1; return; fi
+  local n; n=$(wc -l < "$p" || echo 0)
+  if [ "$n" -lt $min_labels ]; then
+    echo "❌ $lbl too short ($n lines): $p"
+    fail=1
+  else
+    echo "✅ $lbl OK ($n lines)"
+  fi
+}
+
+check_file   models/play_classifier/latest.pt   play_ckpt
+check_labels models/play_classifier/labels.txt  play_labels
+check_file   models/formation/latest.pt         formation_ckpt
+check_labels models/formation/labels.txt        formation_labels
+
+exit $fail

--- a/scripts/run_batch.sh
+++ b/scripts/run_batch.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
+# Abort early if models/labels are missing or clearly bad
+if [ -x scripts/preflight_models.sh ]; then
+  scripts/preflight_models.sh
+fi
 export PYTHONPATH=.
 FILES=("IMG_4129.MP4" "Scrimmage 2 - Part 1.MP4" "Scrimmage 2 - Part 2.MP4")
 for F in "${FILES[@]}"; do

--- a/scripts/spot_check.sh
+++ b/scripts/spot_check.sh
@@ -25,7 +25,7 @@ PY
   fi
 
   CSV="$dir/plays_index.csv"
-  if [[ -f "$CSV" ]]; then
+  if [ -f "$CSV" ]; then
     head -n 6 "$CSV" | sed 's/^/  /'
     python3 - <<'PY' "$CSV"
 import csv, sys, collections
@@ -34,13 +34,13 @@ rows=list(csv.DictReader(open(p, newline='')))
 n=len(rows)
 if n==0:
     print("  stats: segments=0")
-    raise SystemExit
+    sys.exit(0)
 weak=sum(int((r.get("clf_weak_flag") or "0").strip() or 0) for r in rows)
 try:
     avg=sum(float((r.get("clf_top1_conf") or "0").strip() or 0.0) for r in rows)/n
 except Exception:
     avg=0.0
-top=collections.Counter([(r.get("clf_top1_canon") or r.get("clf_top1") or "").strip() for r in rows])
+top=collections.Counter([ (r.get("clf_top1_canon") or r.get("clf_top1") or "").strip() for r in rows ])
 top.pop("", None)
 best=", ".join(f"{k} ({v})" for k,v in top.most_common(5)) if top else "no canonical mapping"
 print(f"  stats: segments={n} weak={weak} ({(100.0*weak/n):.1f}%) avg_conf={avg:.3f}")

--- a/tools/labels_from_playbook.py
+++ b/tools/labels_from_playbook.py
@@ -1,0 +1,27 @@
+import json, re
+from pathlib import Path
+
+def norm(s): return re.sub(r'\s+', ' ', s.strip())
+
+pb = json.load(open("playbooks/mca_5th_playbook.json"))
+plays = []
+
+def walk(x):
+    if isinstance(x, dict):
+        if "plays" in x and isinstance(x["plays"], list):
+            for p in x["plays"]:
+                pid = p.get("id") or p.get("name") or p.get("title")
+                if isinstance(pid, str): plays.append(norm(pid))
+        for v in x.values(): walk(v)
+    elif isinstance(x, list):
+        for v in x: walk(v)
+
+walk(pb)
+plays = sorted(set([p for p in plays if p]))
+if not plays:
+    raise SystemExit("No plays found in playbook.")
+
+Path("models/play_classifier").mkdir(parents=True, exist_ok=True)
+Path("models/formation").mkdir(parents=True, exist_ok=True)  # if you add formation derivation later
+Path("models/play_classifier/labels.txt").write_text("\n".join(plays) + "\n")
+print(f"wrote models/play_classifier/labels.txt with {len(plays)} labels")

--- a/tools/upload_server.py
+++ b/tools/upload_server.py
@@ -1,27 +1,63 @@
 from http.server import HTTPServer, BaseHTTPRequestHandler
 import os, cgi
-ROOT = "models"
+
+ROOT = "models"  # writes under models/{play_classifier,formation}
+
+HTML = b"""<html><body><h3>Upload models</h3>
+<form method=POST enctype=multipart/form-data>
+Target:
+<select name=target>
+  <option value="play_classifier/latest.pt">play ckpt</option>
+  <option value="formation/latest.pt">formation ckpt</option>
+  <option value="play_classifier/labels.txt">play labels</option>
+  <option value="formation/labels.txt">formation labels</option>
+</select><br><br>
+File: <input type=file name=file><br><br>
+<button type=submit>Upload</button></form>
+<hr>
+<a href="/ls">List installed model files</a>
+</body></html>"""
+
 class Uploader(BaseHTTPRequestHandler):
     def do_GET(self):
+        if self.path == "/ls":
+            self.send_response(200); self.send_header("Content-Type","text/plain"); self.end_headers()
+            for rel in [
+                "play_classifier/latest.pt",
+                "play_classifier/labels.txt",
+                "formation/latest.pt",
+                "formation/labels.txt",
+            ]:
+                p = os.path.join(ROOT, rel)
+                s = os.path.getsize(p) if os.path.exists(p) else -1
+                line = f"{rel}: {s if s>=0 else 'missing'}\n"
+                self.wfile.write(line.encode())
+            return
         self.send_response(200); self.send_header("Content-Type","text/html"); self.end_headers()
-        self.wfile.write(b"""<html><body><h3>Upload models</h3>
-        <form method=POST enctype=multipart/form-data>
-        Target:
-        <select name=target>
-          <option value="play_classifier/latest.pt">play ckpt</option>
-          <option value="formation/latest.pt">formation ckpt</option>
-          <option value="play_classifier/labels.txt">play labels</option>
-          <option value="formation/labels.txt">formation labels</option>
-        </select><br><br>
-        File: <input type=file name=file><br><br>
-        <button type=submit>Upload</button></form></body></html>""")
+        self.wfile.write(HTML)
+
     def do_POST(self):
-        fs = cgi.FieldStorage(fp=self.rfile, headers=self.headers,
-                              environ={'REQUEST_METHOD':'POST','CONTENT_TYPE':self.headers['Content-Type']})
-        target = fs.getvalue('target'); fileitem = fs['file']
-        if not target or not fileitem.filename: self.send_error(400, "Missing target or file"); return
-        out_path = os.path.join(ROOT, target); os.makedirs(os.path.dirname(out_path), exist_ok=True)
-        with open(out_path, 'wb') as f: f.write(fileitem.file.read())
+        ctype = self.headers.get('Content-Type','')
+        clen  = self.headers.get('Content-Length','0')
+        fs = cgi.FieldStorage(
+            fp=self.rfile,
+            headers=self.headers,
+            environ={
+                'REQUEST_METHOD':'POST',
+                'CONTENT_TYPE': ctype,
+                'CONTENT_LENGTH': clen,
+            }
+        )
+        target = fs.getvalue('target')
+        fileitem = fs['file'] if 'file' in fs else None
+        if not target or not fileitem or not getattr(fileitem, "filename", ""):
+            self.send_error(400, "Missing target or file"); return
+        out_path = os.path.join(ROOT, target)
+        os.makedirs(os.path.dirname(out_path), exist_ok=True)
+        data = fileitem.file.read()
+        with open(out_path, 'wb') as f: f.write(data)
         self.send_response(200); self.end_headers()
-        self.wfile.write(f"Saved to {out_path}".encode())
-HTTPServer(("", 8000), Uploader).serve_forever()
+        self.wfile.write(f"Saved {len(data)} bytes to {out_path}".encode())
+
+if __name__ == "__main__":
+    HTTPServer(("", 8000), Uploader).serve_forever()


### PR DESCRIPTION
## Summary
- Add `scripts/preflight_models.sh` to gate empty/tiny checkpoints and short label files
- Harden model loading with size checks and multi-format fallbacks
- Document classifier flags and add browser-based model upload utility
- Integrate preflight into batch runs and simplify spot-check stats

## Testing
- `test -x scripts/preflight_models.sh`
- `python3 tools/upload_server.py` *(terminated after startup)*
- `python3 -m tools.labels_from_playbook || true`
- `pytest` *(fails: invalid decimal literal in play_classifier.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b5bfbcd280832db202d97f5d7ac093