### PR TITLE
Improve model upload server and add bundle installer

### DIFF
--- a/scripts/install_models_bundle.sh
+++ b/scripts/install_models_bundle.sh
@@ -1,32 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
-# Install a models bundle into the repo's models/ directory.
-# Usage: bash scripts/install_models_bundle.sh /path/to/models_bundle.tgz
-B="${1:-models_bundle.tgz}"
-[ -f "$B" ] || { echo "missing bundle: $B"; exit 1; }
-
-TMP="$(mktemp -d)"
+BUNDLE="${1:-}"
+[ -n "$BUNDLE" ] || { echo "usage: $0 models_bundle.tgz"; exit 1; }
+TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
-tar xzf "$B" -C "$TMP"
-
-# optional checksum
-if [ -f "$TMP/models_bundle/SHA256SUMS" ]; then
-  (cd "$TMP/models_bundle" && sha256sum -c SHA256SUMS)
+tar xzf "$BUNDLE" -C "$TMP"
+cd "$TMP"
+# optional checksum verification if SHA256SUMS exists
+if [ -f SHA256SUMS ]; then
+  sha256sum -c SHA256SUMS
 fi
-
-dst="models"
-install -d "$dst"
-rsync -av "$TMP/models_bundle/" "$dst/"
-
-# quick preflight
-bash -c '
-set -e
-minb=1024; minl=2
-for f in models/play_classifier/latest.pt models/formation/latest.pt; do
-  s=$(stat -c %s "$f" || echo 0); [ "$s" -ge "$minb" ] || { echo "❌ $f too small ($s)"; exit 1; }
-done
-for f in models/play_classifier/labels.txt models/formation/labels.txt; do
-  n=$(wc -l < "$f" || echo 0); [ "$n" -ge "$minl" ] || { echo "❌ $f too short ($n lines)"; exit 1; }
-done
-echo "✅ models installed OK"
-'
+rsync -av models_bundle/ ~/mca-gameday-camera/models/
+cd ~/mca-gameday-camera
+scripts/preflight_models.sh
+echo "[ok] models installed."

--- a/tools/upload_server.py
+++ b/tools/upload_server.py
@@ -30,8 +30,7 @@ class Uploader(BaseHTTPRequestHandler):
             ]:
                 p = os.path.join(ROOT, rel)
                 s = os.path.getsize(p) if os.path.exists(p) else -1
-                line = f"{rel}: {s if s>=0 else 'missing'}\n"
-                self.wfile.write(line.encode())
+                self.wfile.write(f"{rel}: {s if s>=0 else 'missing'}\n".encode())
             return
         self.send_response(200); self.send_header("Content-Type","text/html"); self.end_headers()
         self.wfile.write(HTML)
@@ -39,18 +38,11 @@ class Uploader(BaseHTTPRequestHandler):
     def do_POST(self):
         ctype = self.headers.get('Content-Type','')
         clen  = self.headers.get('Content-Length','0')
-        fs = cgi.FieldStorage(
-            fp=self.rfile,
-            headers=self.headers,
-            environ={
-                'REQUEST_METHOD':'POST',
-                'CONTENT_TYPE': ctype,
-                'CONTENT_LENGTH': clen,
-            }
-        )
+        fs = cgi.FieldStorage(fp=self.rfile, headers=self.headers,
+                              environ={'REQUEST_METHOD':'POST','CONTENT_TYPE':ctype,'CONTENT_LENGTH':clen})
         target = fs.getvalue('target')
         fileitem = fs['file'] if 'file' in fs else None
-        if not target or not fileitem or not getattr(fileitem, "filename", ""):
+        if not target or fileitem is None or not getattr(fileitem, "filename", ""):
             self.send_error(400, "Missing target or file"); return
         out_path = os.path.join(ROOT, target)
         os.makedirs(os.path.dirname(out_path), exist_ok=True)


### PR DESCRIPTION
## Summary
- Fix `tools/upload_server.py` to avoid FieldStorage boolean casting errors
- Simplify `scripts/install_models_bundle.sh` and invoke preflight check after installation

## Testing
- `pytest` *(fails: SyntaxError in play_classifier.py and other import errors)*
- `curl -F target=play_classifier/latest.pt -F file=@/tmp/play_ckpt.pt http://127.0.0.1:8000`
- `ls -lh models/play_classifier/latest.pt models/formation/latest.pt`
- `wc -l models/play_classifier/labels.txt models/formation/labels.txt`
- `python3 -m tools.peek_ckpt models/play_classifier/latest.pt`
- `python3 -m tools.peek_ckpt models/formation/latest.pt`
- `scripts/preflight_models.sh`
- `python3 -m analysis.pipeline --video "video/manual_uploads/Scrimmage 2 - Part 1.MP4" --team WHITE --playbook playbooks/mca_5th_playbook.json --out output --min-play-gap 1.5 --min-play-length 3.0 --max-play-length 12.0 --generate-report --generate-clips --smooth-frames 4 --debug-weak --require-classifier --play-ckpt models/play_classifier/latest.pt --play-labels models/play_classifier/labels.txt --formation-ckpt models/formation/latest.pt --formation-labels models/formation/labels.txt` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `scripts/spot_check.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b5c3432d54832db42fbe23220463d3