### PR TITLE
Quote sqft column in rent source debug script

### DIFF
--- a/scripts/debug_rent_sources.sql
+++ b/scripts/debug_rent_sources.sql
@@ -1,0 +1,3 @@
+SELECT
+    (SELECT count(*) FROM leases WHERE rent IS NOT NULL) AS rent,
+    (SELECT count(*) FROM leases WHERE rent_per_sf IS NOT NULL AND "sqft" IS NOT NULL) AS rent_psf;


### PR DESCRIPTION
## Summary
- add debug_rent_sources.sql script and quote the `sqft` column to match case-sensitive schema

## Testing
- `pytest` *(fails: No module named 'torch', 'numpy', 'google')*

------
https://chatgpt.com/codex/tasks/task_e_68b5c6bb5ba4832daee27daecded23a9