### PR TITLE
Add atomic model uploader and blocking run script

### DIFF
--- a/scripts/send_with_curl.sh
+++ b/scripts/send_with_curl.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+JETSON_IP="${1:?usage: $0 <JETSON_IP> <play.pt> <play_labels.txt> <form.pt> <form_labels.txt>}"
+PLAY_PT="${2:?}"; PLAY_LBL="${3:?}"; FORM_PT="${4:?}"; FORM_LBL="${5:?}"
+echo "[send] play ckpt";   curl -F target=play_classifier/latest.pt -F file=@"$PLAY_PT" http://$JETSON_IP:8000
+echo "[send] play labels"; curl -F target=play_classifier/labels.txt -F file=@"$PLAY_LBL" http://$JETSON_IP:8000
+echo "[send] form ckpt";   curl -F target=formation/latest.pt       -F file=@"$FORM_PT" http://$JETSON_IP:8000
+echo "[send] form labels"; curl -F target=formation/labels.txt      -F file=@"$FORM_LBL" http://$JETSON_IP:8000
+echo "[ls]"; curl -s http://$JETSON_IP:8000/ls || true

--- a/scripts/wait_for_models_and_run.sh
+++ b/scripts/wait_for_models_and_run.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Start uploader in background
+pkill -f tools/upload_server.py 2>/dev/null || true
+python3 tools/upload_server.py >/tmp/upload_server.log 2>&1 &
+UP_PID=$!
+trap 'kill $UP_PID 2>/dev/null || true' EXIT
+
+IP=$(hostname -I | awk '{for(i=1;i<=NF;i++) if ($i ~ /^192\.168\./) {print $i; exit}}')
+echo "[info] Upload page: http://$IP:8000    (see /ls for sizes)"
+echo "[info] Waiting for valid checkpoints+labels..."
+
+# Wait until preflight passes
+until scripts/preflight_models.sh >/tmp/preflight.out 2>&1; do
+  echo "[warn] Not ready yet:"
+  sed -n '1,6p' /tmp/preflight.out
+  echo "[hint] From trainer box, open http://$IP:8000 and upload the four files."
+  sleep 3
+done
+
+echo "[ok] Models/labels look good!"
+echo "[ls]"; curl -s "http://$IP:8000/ls" || true
+
+# Run the pipeline with all args passed to this script
+python3 -m analysis.pipeline "$@"
+
+# Spot check
+scripts/spot_check.sh

--- a/tools/upload_server.py
+++ b/tools/upload_server.py
@@ -1,5 +1,6 @@
 from http.server import HTTPServer, BaseHTTPRequestHandler
-import os, cgi
+import os, cgi, tempfile, shutil, time
+
 ROOT = "models"
 
 HTML = b"""<html><body><h3>Upload models</h3>
@@ -16,29 +17,60 @@ File: <input type=file name=file><br><br>
 <hr><a href="/ls">List installed model files</a>
 </body></html>"""
 
+def ls_lines():
+    lines=[]
+    for rel in [
+        "play_classifier/latest.pt",
+        "play_classifier/labels.txt",
+        "formation/latest.pt",
+        "formation/labels.txt",
+    ]:
+        p = os.path.join(ROOT, rel)
+        if os.path.exists(p):
+            sz = os.path.getsize(p)
+            mt = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(os.path.getmtime(p)))
+            lines.append(f"{rel}: {sz} bytes  mtime={mt}")
+        else:
+            lines.append(f"{rel}: missing")
+    return "\n".join(lines) + "\n"
+
 class Uploader(BaseHTTPRequestHandler):
     def do_GET(self):
         if self.path == "/ls":
             self.send_response(200); self.send_header("Content-Type","text/plain"); self.end_headers()
-            for rel in ["play_classifier/latest.pt","play_classifier/labels.txt","formation/latest.pt","formation/labels.txt"]:
-                p = os.path.join(ROOT, rel)
-                s = os.path.getsize(p) if os.path.exists(p) else -1
-                self.wfile.write(f"{rel}: {s if s>=0 else 'missing'}\n".encode())
-            return
+            self.wfile.write(ls_lines().encode()); return
         self.send_response(200); self.send_header("Content-Type","text/html"); self.end_headers()
         self.wfile.write(HTML)
 
     def do_POST(self):
-        ctype = self.headers.get('Content-Type',''); clen  = self.headers.get('Content-Length','0')
+        ctype = self.headers.get('Content-Type','')
+        clen  = int(self.headers.get('Content-Length','0') or 0)
         fs = cgi.FieldStorage(fp=self.rfile, headers=self.headers,
-                              environ={'REQUEST_METHOD':'POST','CONTENT_TYPE':ctype,'CONTENT_LENGTH':clen})
-        target = fs.getvalue('target'); fileitem = fs['file'] if 'file' in fs else None
-        if not target or fileitem is None or not getattr(fileitem, "filename", ""):
+                              environ={'REQUEST_METHOD':'POST','CONTENT_TYPE':ctype,'CONTENT_LENGTH':str(clen)})
+        target = fs.getvalue('target')
+        fileitem = fs['file'] if 'file' in fs else None
+        if not target or not fileitem or not getattr(fileitem, "filename", ""):
             self.send_error(400, "Missing target or file"); return
-        out_path = os.path.join(ROOT, target); os.makedirs(os.path.dirname(out_path), exist_ok=True)
-        data = fileitem.file.read()
-        with open(out_path, 'wb') as f: f.write(data)
-        self.send_response(200); self.end_headers(); self.wfile.write(f"Saved {len(data)} bytes to {out_path}".encode())
+        os.makedirs(os.path.join(ROOT, os.path.dirname(target)), exist_ok=True)
+        final_path = os.path.join(ROOT, target)
+        # atomic write via temp file then rename
+        fd, tmp_path = tempfile.mkstemp(prefix=".upload_", dir=os.path.dirname(final_path))
+        try:
+            with os.fdopen(fd, 'wb') as tmp:
+                # stream copy (handles large files)
+                while True:
+                    chunk = fileitem.file.read(1024 * 1024)
+                    if not chunk: break
+                    tmp.write(chunk)
+                tmp.flush(); os.fsync(tmp.fileno())
+            size = os.path.getsize(tmp_path)
+            shutil.move(tmp_path, final_path)
+        finally:
+            try: os.remove(tmp_path)
+            except FileNotFoundError: pass
+        self.send_response(200); self.end_headers()
+        self.wfile.write(f"Saved {size} bytes to {final_path}\n".encode())
 
 if __name__ == "__main__":
+    print("Uploader: http://0.0.0.0:8000  (use /ls to view sizes)")
     HTTPServer(("", 8000), Uploader).serve_forever()


### PR DESCRIPTION
## Summary
- replace model upload server with atomic-write version and detailed listing
- add wait_for_models_and_run script that blocks until model preflight passes
- add send_with_curl helper for trainer boxes

## Testing
- `pytest` *(fails: SyntaxError in play_classifier.py)*
- `timeout 10 scripts/wait_for_models_and_run.sh --help`
- `timeout 1 python3 -u tools/upload_server.py`

------
https://chatgpt.com/codex/tasks/task_e_68b5c9019228832dbd6e0784a623bde4