### PR TITLE
Enhance gameday streaming resilience and recording efficiency

### DIFF
--- a/gameday
+++ b/gameday
@@ -31,6 +31,11 @@ done
 : "${DYNAUDNORM_OPTS:=f=250:g=15:m=10:s=5:p=0.9}"
 : "${PULSE_VOL:=150%}"
 
+# Audio preflight & auto-switching
+: "${AUDIO_PREFLIGHT_SEC:=2}"          # seconds to meter audio before launch
+: "${AUDIO_SILENCE_THRESHOLD_DB:=-50}" # below this RMS dB, treat as silent
+: "${AUDIO_AUTO_SWITCH:=1}"            # 1: auto-pick loudest non-monitor source if current is silent
+
 # Recording (always on)
 : "${RECORD_DIR:=recordings}"
 : "${RECORD_SEGMENT_SEC:=900}"
@@ -44,6 +49,41 @@ resolve_pulse() {
   sel="$(PYTHONPATH=. python3 -m tools.audio_select || true)"
   if [[ -n "$sel" ]]; then echo "$sel"; return 0; fi
   pactl list short sources | awk '{print $2}' | grep -m1 -E '^alsa_input\.platform-.*analog-stereo$' || true
+}
+
+# Measure RMS level of a pulse source over a short window; prints a number or "-inf"
+rms_db_of_source() {
+  local src="$1"
+  ffmpeg -hide_banner -nostdin -v error -f pulse -i "$src" -t "${AUDIO_PREFLIGHT_SEC}" \
+    -af astats=metadata=1:measure_overall=1:reset=1 -f null - 2>&1 \
+    | awk -F'[: ]+' '/Overall RMS level/ {print $5; exit}' || echo "-inf"
+}
+
+# Optionally pick the loudest non-monitor source if current is silent
+maybe_autoswitch_pulse() {
+  local cur="$1"
+  local cur_rms
+  cur_rms="$(rms_db_of_source "$cur")"
+  if [[ "$cur_rms" != "-inf" ]] && awk "BEGIN{exit !($cur_rms > ${AUDIO_SILENCE_THRESHOLD_DB})}"; then
+    echo "$cur" ; return 0
+  fi
+
+  if [[ "$AUDIO_AUTO_SWITCH" != "1" ]]; then
+    echo "$cur" ; return 0
+  fi
+
+  local best="$cur" best_rms="-inf"
+  while read -r _ name _ ; do
+    # skip monitors by default
+    [[ "$name" =~ monitor ]] && continue
+    local r="$(rms_db_of_source "$name")"
+    # pick first non -inf or the max RMS
+    if [[ "$best_rms" == "-inf" || ( "$r" != "-inf" && $(awk "BEGIN{print ($r > $best_rms)}") -eq 1 ) ]]; then
+      best="$name"; best_rms="$r"
+    fi
+  done < <(pactl list short sources)
+
+  echo "$best"
 }
 
 resolve_video() {
@@ -93,11 +133,14 @@ PULSE_SRC="$(resolve_pulse || true)"
 [[ -z "${VIDEO_DEV:-}" ]] && { echo "[gameday] ERROR: No /dev/video* device found."; exit 1; }
 [[ -z "${PULSE_SRC:-}" ]] && { echo "[gameday] ERROR: No usable Pulse source."; pactl list short sources | awk '{print "  " $2}'; exit 1; }
 
-# Unmute & set Pulse volume
+# Preflight: unmute, set volume, and ensure we’re not silent
 if command -v pactl >/dev/null 2>&1; then
   pactl set-source-mute "$PULSE_SRC" 0 || true
-  pactl set-source-volume "$PULSE_SRC" "$PULSE_VOL" || true
+  pactl set-source-volume "$PULSE_SRC" "${PULSE_VOL:-150%}" || true
 fi
+
+# Meter and maybe auto-switch to a louder source
+PULSE_SRC="$(maybe_autoswitch_pulse "$PULSE_SRC")"
 
 # --- Build video opts ---
 V_CODEC="$(choose_codec)"
@@ -106,10 +149,10 @@ V4L2_INPUT_OPTS=(
   -input_format mjpeg -framerate "${FRAME_RATE}" -video_size "${VIDEO_SIZE}" -i "${VIDEO_DEV}"
 )
 if [[ "$V_CODEC" == "h264_v4l2m2m" ]]; then
-  V_PIXFMT_OPTS=(-vf "scale=in_range=full:out_range=tv,format=nv12,fps=${FRAME_RATE},setpts=PTS-STARTPTS,lagfun=decay=0.95" -pix_fmt nv12)
+  V_PIXFMT_OPTS=(-vf "scale=in_range=full:out_range=tv,format=nv12,setsar=1,fps=${FRAME_RATE},setpts=PTS-STARTPTS,lagfun=decay=0.95" -pix_fmt nv12)
   V_ENCODER_OPTS=(-c:v h264_v4l2m2m -b:v 4500k -maxrate 5000k -bufsize 6000k -g $((FRAME_RATE*2)) -profile:v high)
 else
-  V_PIXFMT_OPTS=(-vf "scale=in_range=full:out_range=tv,format=yuv420p,fps=${FRAME_RATE},setpts=PTS-STARTPTS,lagfun=decay=0.95" -pix_fmt yuv420p)
+  V_PIXFMT_OPTS=(-vf "scale=in_range=full:out_range=tv,format=yuv420p,setsar=1,fps=${FRAME_RATE},setpts=PTS-STARTPTS,lagfun=decay=0.95" -pix_fmt yuv420p)
   V_ENCODER_OPTS=(-c:v libx264 -preset veryfast -tune zerolatency -b:v 4500k -maxrate 5000k -bufsize 6000k -g $((FRAME_RATE*2)) -profile:v high)
 fi
 
@@ -126,9 +169,9 @@ fi
 # --- Output URL (RTMPS preflight & fallback) ---
 OUT_URL="$(preflight_output_url "$YOUTUBE_RTMP_URL")"
 
-# --- Always-on recording via tee (YouTube + local segmented MP4s) ---
+# --- Always-on recording via tee (YouTube + local segmented MKVs) ---
 mkdir -p "$RECORD_DIR"
-TEE_SPEC="[f=flv]${OUT_URL}|[f=segment:segment_time=${RECORD_SEGMENT_SEC}:strftime=1:reset_timestamps=1:segment_format=mp4:segment_format_options=movflags=+faststart]${RECORD_DIR}/%Y%m%d_%H%M%S.mp4"
+TEE_SPEC="[f=flv]${OUT_URL}|[f=segment:segment_time=${RECORD_SEGMENT_SEC}:strftime=1:reset_timestamps=1:segment_format=matroska]${RECORD_DIR}/%Y%m%d_%H%M%S.mkv"
 OUT_MUX=(-f tee "$TEE_SPEC")
 
 echo "[gameday] Launch -> video=${VIDEO_DEV} ${VIDEO_SIZE}@${FRAME_RATE} | pulse=${PULSE_SRC} | vcodec=${V_CODEC} | rtmp=set | record_dir=${RECORD_DIR}"
@@ -146,9 +189,13 @@ run_ffmpeg() {
 }
 
 # --- Retry loop for network hiccups ---
+STOP=0
+trap 'STOP=1; echo "[gameday] Caught interrupt; stopping…"' INT TERM
+
 attempt=1; max_attempts=5
 until run_ffmpeg; do
   rc=$?
+  (( STOP )) && exit "$rc"    # don’t retry if user asked to stop
   echo "[gameday] ffmpeg exited with code $rc (attempt $attempt/$max_attempts)."
   (( attempt++ )); (( attempt > max_attempts )) && exit "$rc"
   sleep 3


### PR DESCRIPTION
## Summary
- Auto-meter and optionally switch to the loudest audio source before streaming
- Force square pixels and segment local recordings as Matroska for faster writes
- Handle interrupts gracefully and avoid retrying when stopped

## Testing
- `bash -n gameday`
- `pytest` *(fails: SyntaxError in play_classifier.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e7a2f27c832d9e7b75ba774a6353