### PR TITLE
Ensure square pixel aspect ratio in ffmpeg filters

### DIFF
--- a/ffmpeg_utils.py
+++ b/ffmpeg_utils.py
@@ -229,7 +229,7 @@ def build_ffmpeg_args(
     if video_codec == "libx264":
         encoder_flags = [
             "-vf",
-            "format=yuv420p",
+            "format=yuv420p,setsar=1",
             "-c:v",
             video_codec,
             "-preset",
@@ -238,7 +238,7 @@ def build_ffmpeg_args(
             "zerolatency",
         ]
     else:
-        encoder_flags = ["-vf", "format=yuv420p", "-c:v", video_codec]
+        encoder_flags = ["-vf", "format=yuv420p,setsar=1", "-c:v", video_codec]
 
     cmd += encoder_flags + [
         "-b:v",

--- a/soccer/recorder.py
+++ b/soccer/recorder.py
@@ -82,7 +82,7 @@ class Recorder:
             ]
         cmd += [
             "-vf",
-            "scale=in_range=full:out_range=tv,format=yuv420p,setpts=PTS-STARTPTS",
+            "scale=in_range=full:out_range=tv,format=yuv420p,setsar=1,setpts=PTS-STARTPTS",
             "-af",
             "highpass=f=100,acompressor=threshold=-22dB:ratio=3.5:attack=12:release=250,alimiter=limit=0.0dB:attack=5:release=20",
             "-c:v",
@@ -159,7 +159,7 @@ class Recorder:
             ]
         cmd += [
             "-vf",
-            "scale=960:-2,format=yuv420p,setpts=PTS-STARTPTS",
+            "scale=960:-2,format=yuv420p,setsar=1,setpts=PTS-STARTPTS",
             "-af",
             "highpass=f=100,acompressor=threshold=-22dB:ratio=3.5:attack=12:release=250,alimiter=limit=0.0dB:attack=5:release=20",
             "-c:v",
@@ -394,7 +394,7 @@ def main():
 
     # ---------- Filters & encoders ----------
     # Stabilize audio timestamps early; then EQ/comp/limiter.
-    v_filters = "scale=in_range=full:out_range=tv,format=yuv420p,setpts=PTS-STARTPTS"
+    v_filters = "scale=in_range=full:out_range=tv,format=yuv420p,setsar=1,setpts=PTS-STARTPTS"
     a_filters = ("aresample=async=1:first_pts=0,asetpts=N/SR/TB,"
                  "highpass=f=100,acompressor=threshold=-22dB:ratio=3.5:attack=12:release=250,"
                  "alimiter=limit=0.0dB:attack=5:release=20")
@@ -438,7 +438,7 @@ def main():
         proxy_common = [
             "-fflags","+genpts+discardcorrupt",
             "-thread_queue_size","8192",
-            "-vf","scale=960:-2,format=yuv420p,setpts=PTS-STARTPTS",
+            "-vf","scale=960:-2,format=yuv420p,setsar=1,setpts=PTS-STARTPTS",
             "-af", a_filters,
             "-c:v","libx264","-preset","veryfast","-crf","30",
             "-c:a","aac","-b:a","96k","-ar","48000",


### PR DESCRIPTION
## Summary
- enforce SAR 1:1 in streaming utility helpers
- ensure soccer recorder outputs square pixels for main and proxy footage

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68b5f046d740832da7d94cb383e8f20e