### PR TITLE
Move explicit stream mapping near option arrays

### DIFF
--- a/gameday
+++ b/gameday
@@ -153,6 +153,8 @@ V4L2_INPUT_OPTS=(
   -f v4l2 -thread_queue_size 8192 -use_wallclock_as_timestamps 1 -rtbufsize 256M
   -input_format mjpeg -framerate "${FRAME_RATE}" -video_size "${VIDEO_SIZE}" -i "${VIDEO_DEV}"
 )
+# Map video from input 0 and audio from input 1 into the tee output
+MAP_OPTS=(-map 0:v:0 -map 1:a:0)
 if [[ "$V_CODEC" == "h264_v4l2m2m" ]]; then
   V_PIXFMT_OPTS=(-vf "scale=in_range=full:out_range=tv,format=nv12,setsar=1,fps=${FRAME_RATE},setpts=PTS-STARTPTS,lagfun=decay=0.95" -pix_fmt nv12)
   V_ENCODER_OPTS=(-c:v h264_v4l2m2m -b:v 4500k -maxrate 5000k -bufsize 6000k -g $((FRAME_RATE*2)) -profile:v high)
@@ -160,9 +162,6 @@ else
   V_PIXFMT_OPTS=(-vf "scale=in_range=full:out_range=tv,format=yuv420p,setsar=1,fps=${FRAME_RATE},setpts=PTS-STARTPTS,lagfun=decay=0.95" -pix_fmt yuv420p)
   V_ENCODER_OPTS=(-c:v libx264 -preset veryfast -tune zerolatency -b:v 4500k -maxrate 5000k -bufsize 6000k -g $((FRAME_RATE*2)) -profile:v high)
 fi
-
-# Map video from input 0 and audio from input 1 into the tee output
-MAP_OPTS=(-map 0:v:0 -map 1:a:0)
 
 # --- Build audio filter (dynamic normalization + limiter + sync) ---
 if [[ "${AUDIO_DYN_ENABLE}" == "1" ]]; then


### PR DESCRIPTION
## Summary
- group explicit input/output mapping with other ffmpeg option arrays

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch'; ModuleNotFoundError: No module named 'numpy'; ModuleNotFoundError: No module named 'google'; SyntaxError in play_classifier.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f23617a8832db036b7e3d655d6be