### PR TITLE
Set RTMP URL in gameday env

### DIFF
--- a/.gameday.env
+++ b/.gameday.env
@@ -1,0 +1,1 @@
+YOUTUBE_RTMP_URL=rtmps://a.rtmps.youtube.com/live2/xcuz-3x1d-9y7v-ghec-2xmh


### PR DESCRIPTION
## Summary
- Add YouTube RTMP endpoint to `.gameday.env` for live streaming

## Testing
- `ffmpeg -hide_banner -f alsa -list_devices true -i dummy 2>&1` *(fails: command not found)*
- `AUDIO_INPUT=alsa ALSA_DEV=plughw:1,0 ./gameday` *(fails: ffmpeg: command not found)*
- `pytest -q` *(fails: missing dependencies such as numpy, torch, google)*

------
https://chatgpt.com/codex/tasks/task_e_68b7061a2adc832d8a54e984536d93c7