### PR TITLE
Add robust ffmpeg launcher with hardware fallback and repo hygiene helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,30 +1,30 @@
-<<<<<<< HEAD
-video/
-=======
 .install/firefox-esr/
 .install/firefox-esr/libxul.so
 firefox-esr/
 .env
 
 # Video recordings
-/video/*.mp4
+recordings/
+video/
 video/*_play_log.csv
 video/uploaded/
 video/manual_uploads/*.mp4
->>>>>>> 3fb8c6c8bd1feab7561579284c161798bd1142cb
+
+# ignore typical video outputs
 *.mp4
+*.mkv
 *.flv
+
 livestream_logs/
 output/
 !output/.gitkeep
+
 config/credentials.json
-credentials.json# Google/GCP service account keys (never commit these)
+credentials.json
+# Google/GCP service account keys (never commit these)
 *.sa.json
 *.gcp.json
 *service-account*.json
 *credentials*.json
 modular-conduit-*-*.json
 .gameday.env
-recordings/
-video/
-video/

--- a/ffmpeg_utils.py
+++ b/ffmpeg_utils.py
@@ -1,6 +1,10 @@
 import logging
 import subprocess
 import threading
+import os
+import shlex
+import time
+from datetime import datetime
 from typing import List, Optional, Tuple
 
 
@@ -281,3 +285,148 @@ def build_ffmpeg_args(
     else:
         cmd += ["-f", "flv", output_url]
     return cmd
+
+def build_stream_command(
+    stream_key: str,
+    *,
+    video_device: str = "/dev/video0",
+    resolution: str = "1280x720",
+    framerate: int = 30,
+    input_format: str = "mjpeg",
+    encoder: str = "h264_v4l2m2m",
+    audio_backend: str = "pulse",
+    record_path: str = "recordings/raw/%Y%m%d_%H%M%S.mkv",
+) -> List[str]:
+    """Build the FFmpeg command for streaming and local recording."""
+    video_in = [
+        "-f",
+        "v4l2",
+        "-thread_queue_size",
+        "8192",
+        "-framerate",
+        str(framerate),
+        "-video_size",
+        resolution,
+        "-input_format",
+        input_format,
+        "-i",
+        video_device,
+    ]
+    if audio_backend == "pulse":
+        audio_in = ["-f", "pulse", "-thread_queue_size", "8192", "-i", "default"]
+    else:
+        audio_in = ["-f", "alsa", "-thread_queue_size", "8192", "-i", "plughw:1,0"]
+    common = [
+        "-filter:a",
+        "aresample=async=1:min_hard_comp=0.100:first_pts=0",
+        "-use_wallclock_as_timestamps",
+        "1",
+        "-fflags",
+        "+genpts",
+        "-map",
+        "0:v:0",
+        "-map",
+        "1:a:0",
+    ]
+    if encoder == "h264_v4l2m2m":
+        v_flags = [
+            "-c:v",
+            "h264_v4l2m2m",
+            "-pix_fmt",
+            "yuv420p",
+            "-b:v",
+            "4500k",
+            "-maxrate",
+            "5000k",
+            "-bufsize",
+            "10000k",
+            "-g",
+            "60",
+            "-sc_threshold",
+            "0",
+        ]
+    else:
+        v_flags = [
+            "-c:v",
+            "libx264",
+            "-preset",
+            "veryfast",
+            "-tune",
+            "zerolatency",
+            "-pix_fmt",
+            "yuv420p",
+            "-b:v",
+            "4500k",
+            "-maxrate",
+            "5000k",
+            "-bufsize",
+            "10000k",
+            "-g",
+            "60",
+            "-x264-params",
+            "keyint=60:min-keyint=60:scenecut=0",
+        ]
+    a_flags = [
+        "-c:a",
+        "aac",
+        "-b:a",
+        "128k",
+        "-ac",
+        "2",
+        "-ar",
+        "48000",
+    ]
+    out_spec = (
+        f"[f=flv:onfail=ignore]rtmps://a.rtmp.youtube.com/live2/{stream_key}"
+        f"|[f=matroska]{record_path}"
+    )
+    return [
+        "ffmpeg",
+        "-hide_banner",
+        "-loglevel",
+        "info",
+        "-stats_period",
+        "2",
+    ] + video_in + audio_in + common + v_flags + a_flags + ["-f", "tee", out_spec]
+
+
+def launch_ffmpeg(stream_key: str, *, dry_run: bool = False) -> subprocess.Popen | None:
+    """Launch FFmpeg with automatic fallbacks.
+
+    Returns the running ``Popen`` instance or ``None`` in ``dry_run`` mode.
+    """
+    attempts = [
+        ("mjpeg", "h264_v4l2m2m", "pulse"),
+        ("mjpeg", "h264_v4l2m2m", "alsa"),
+        ("yuyv422", "h264_v4l2m2m", "pulse"),
+        ("yuyv422", "h264_v4l2m2m", "alsa"),
+        ("mjpeg", "libx264", "pulse"),
+        ("mjpeg", "libx264", "alsa"),
+        ("yuyv422", "libx264", "pulse"),
+        ("yuyv422", "libx264", "alsa"),
+    ]
+    for fmt, enc, audio in attempts:
+        cmd = build_stream_command(stream_key, input_format=fmt, encoder=enc, audio_backend=audio)
+        logging.info("FFmpeg command: %s", shlex.join(cmd))
+        if dry_run:
+            print(shlex.join(cmd))
+            return None
+        process = subprocess.Popen(cmd, stderr=subprocess.PIPE, text=True)
+        last = time.time()
+        try:
+            assert process.stderr is not None
+            for line in process.stderr:
+                logging.error("[ffmpeg] %s", line.rstrip())
+                if "frame=" in line:
+                    last = time.time()
+                if any(err in line for err in ["Device or resource busy", "Input queue full", "Failed to open" ]):
+                    raise RuntimeError("device error")
+                if time.time() - last > 5:
+                    raise RuntimeError("stalled")
+            rc = process.wait()
+            if rc == 0:
+                return process
+        except Exception as exc:
+            process.kill()
+            logging.warning("FFmpeg failed with %s", exc)
+    return None

--- a/tests/test_ffmpeg_builder.py
+++ b/tests/test_ffmpeg_builder.py
@@ -1,0 +1,17 @@
+from ffmpeg_utils import build_stream_command
+
+
+def test_build_stream_command_libx264():
+    cmd = build_stream_command("STREAM", encoder="libx264")
+    # Ensure video and audio inputs are mapped
+    assert cmd.count("-map") == 2
+    v_map_index = cmd.index("-map")
+    assert cmd[v_map_index + 1] == "0:v:0"
+    a_map_index = cmd.index("-map", v_map_index + 2)
+    assert cmd[a_map_index + 1] == "1:a:0"
+    # Encoder selection
+    assert "libx264" in cmd
+    assert "h264_v4l2m2m" not in cmd
+    # Output tee muxer
+    assert "-f" in cmd
+    assert any("rtmps://a.rtmp.youtube.com/live2/STREAM" in part for part in cmd)

--- a/tools/repo_hygiene.sh
+++ b/tools/repo_hygiene.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -euo pipefail
+
+# Ensure required ignore patterns exist
+GITIGNORE=".gitignore"
+for pattern in recordings/ video/ '*.mkv' '*.mp4'; do
+    if ! grep -Fxq "$pattern" "$GITIGNORE"; then
+        echo "$pattern" >> "$GITIGNORE"
+    fi
+done
+
+# Optionally reset filter-repo marker
+if [[ "${1:-}" == "--reset-filter-repo" ]]; then
+    rm -f .git/filter-repo/already_ran
+fi
+
+# Re-add origin remote if missing
+if ! git remote | grep -q '^origin$'; then
+    if [[ -n "${ORIGIN_URL:-}" ]]; then
+        git remote add origin "$ORIGIN_URL"
+    elif [[ -f .git/origin_url ]]; then
+        git remote add origin "$(cat .git/origin_url)"
+    else
+        echo "origin remote missing and ORIGIN_URL not set" >&2
+    fi
+fi


### PR DESCRIPTION
## Summary
- implement `build_stream_command` and `launch_ffmpeg` for Jetson-friendly streaming with automatic MJPEG/YUYV and encoder fallbacks
- add repo_hygiene.sh to enforce .gitignore rules and restore missing origin remotes
- clean .gitignore to ignore recordings and common video formats
- cover command builder via new unit test

## Testing
- `pytest tests/test_ffmpeg_builder.py tests/test_detect_encoder.py -q`
- `python - <<'PY'
import ffmpeg_utils
ffmpeg_utils.launch_ffmpeg('TESTKEY', dry_run=True)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b8772447b0832da0c2181f0e9fe44a