### PR TITLE
feat: add flexible raw recording options

### DIFF
--- a/gameday
+++ b/gameday
@@ -12,9 +12,12 @@ import argparse
 import importlib
 import os
 import pathlib
+import re
 import shlex
 import subprocess
 import sys
+from datetime import datetime
+from pathlib import Path
 from typing import List, Optional
 
 # .env is optional
@@ -96,6 +99,15 @@ def redact_key(k: str) -> str:
     return f"{k[:4]}{'*' * (len(k) - 4)}"
 
 
+def ffmpeg_major_version() -> int:
+    try:
+        out = subprocess.run(["ffmpeg", "-version"], capture_output=True, text=True).stdout
+        m = re.search(r"ffmpeg version\s+(\d+)\.", out)
+        return int(m.group(1)) if m else 4
+    except Exception:
+        return 4
+
+
 def hw_encoder_ok(size: str, fps: int) -> bool:
     """Return True if the V4L2 hardware encoder appears functional."""
 
@@ -124,23 +136,84 @@ def hw_encoder_ok(size: str, fps: int) -> bool:
         return False
 
 
-def build_ffmpeg_cmd(args: argparse.Namespace, encoder: str) -> List[str]:
+def build_ffmpeg_cmd(args: argparse.Namespace, encoder: str) -> tuple[List[str], str]:
     """Build the ffmpeg command according to requirements."""
 
     gop = args.fps * 2
-    out_dir = pathlib.Path(args.out_dir)
 
     pix = "nv12" if encoder == "h264_v4l2m2m" else "yuv420p"
     vf = f"[0:v]settb=AVTB,setpts=PTS-STARTPTS,scale=in_range=pc:out_range=tv,format={pix}[v]"
     af = "[1:a]aresample=async=1:first_pts=0,asetpts=PTS-STARTPTS[a]"
+    ff: List[str] = ["-filter_complex", f"{vf};{af}", "-map", "[v]", "-map", "[a]"]
 
-    segment_sink = (
-        "[f=segment:segment_format=matroska:"
-        f"segment_time={args.segment_seconds}:reset_timestamps=1:strftime=1]"
-        f"{out_dir / '%Y%m%d_%H%M%S.mkv'}"
-    )
-    flv_sink = f"[f=flv:onfail=ignore]rtmps://a.rtmps.youtube.com/live2/{args.stream_key}"
-    tee_url = f"{flv_sink}|{segment_sink}"
+    if encoder == "h264_v4l2m2m":
+        ff += ["-c:v", "h264_v4l2m2m", "-pix_fmt", "nv12"]
+    else:
+        ff += [
+            "-c:v",
+            "libx264",
+            "-preset",
+            "veryfast",
+            "-tune",
+            "zerolatency",
+            "-pix_fmt",
+            "yuv420p",
+        ]
+
+    ff += [
+        "-b:v",
+        args.bitrate,
+        "-maxrate",
+        "4000k",
+        "-bufsize",
+        "6000k",
+        "-g",
+        str(gop),
+        "-c:a",
+        "aac",
+        "-b:a",
+        "128k",
+        "-ar",
+        "48000",
+        "-ac",
+        "2",
+    ]
+
+    yt_sink = f"[f=flv:onfail=ignore]rtmps://a.rtmps.youtube.com/live2/{args.stream_key}"
+
+    major = ffmpeg_major_version()
+    seg_seconds = 0 if args.no_segment else args.segment_seconds
+    raw_dir = Path(args.out_dir)
+    raw_dir.mkdir(parents=True, exist_ok=True)
+
+    if seg_seconds and seg_seconds > 0:
+        if args.raw_container == "mkv":
+            if major < 5:
+                print("[gameday] FFmpeg <5 + tee/segment to Matroska can fail; using MPEG-TS segments instead.")
+                raw_sink = (
+                    f"[f=segment:use_fifo=1:segment_format=mpegts:segment_time={seg_seconds}:"
+                    f"reset_timestamps=1:strftime=1]{raw_dir}/%Y%m%d_%H%M%S.ts"
+                )
+                ext = "ts"
+            else:
+                raw_sink = (
+                    f"[f=segment:use_fifo=1:segment_format=matroska:segment_time={seg_seconds}:"
+                    f"reset_timestamps=1:strftime=1]{raw_dir}/%Y%m%d_%H%M%S.mkv"
+                )
+                ext = "mkv"
+        else:
+            raw_sink = (
+                f"[f=segment:use_fifo=1:segment_format=mpegts:segment_time={seg_seconds}:"
+                f"reset_timestamps=1:strftime=1]{raw_dir}/%Y%m%d_%H%M%S.ts"
+            )
+            ext = "ts"
+    else:
+        stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        raw_sink = f"[f=matroska]{raw_dir}/{stamp}.mkv"
+        ext = "mkv"
+
+    tee_arg = f"{yt_sink}|{raw_sink}"
+    ff += ["-f", "tee", tee_arg]
 
     global_flags = [
         "-fflags",
@@ -172,55 +245,9 @@ def build_ffmpeg_cmd(args: argparse.Namespace, encoder: str) -> List[str]:
         "1024",
         "-i",
         args.alsa_dev,
+        *ff,
     ]
-
-    ff_args: List[str] = [
-        "-filter_complex",
-        f"{vf};{af}",
-        "-map",
-        "[v]",
-        "-map",
-        "[a]",
-    ]
-
-    if encoder == "h264_v4l2m2m":
-        ff_args += ["-c:v", "h264_v4l2m2m"]
-    else:
-        ff_args += [
-            "-c:v",
-            "libx264",
-            "-preset",
-            "veryfast",
-            "-tune",
-            "zerolatency",
-            "-pix_fmt",
-            "yuv420p",
-        ]
-
-    ff_args += [
-        "-b:v",
-        args.bitrate,
-        "-maxrate",
-        "4000k",
-        "-bufsize",
-        "6000k",
-        "-g",
-        str(gop),
-        "-c:a",
-        "aac",
-        "-b:a",
-        "128k",
-        "-ar",
-        "48000",
-        "-ac",
-        "2",
-        "-f",
-        "tee",
-        tee_url,
-    ]
-
-    cmd.extend(ff_args)
-    return cmd
+    return cmd, ext
 
 def run_ffmpeg(cmd: List[str], stream_key: str) -> tuple[int, str]:
     """Run ffmpeg, returning (rc, combined stderr)."""
@@ -239,11 +266,11 @@ def run_ffmpeg(cmd: List[str], stream_key: str) -> tuple[int, str]:
     return rc, "".join(lines)
 
 
-def validate_segment(out_dir: pathlib.Path) -> bool:
+def validate_segment(out_dir: pathlib.Path, ext: str) -> bool:
     """Validate newest local file with ffprobe."""
 
     try:
-        latest = max(out_dir.glob("*.mkv"), key=lambda p: p.stat().st_mtime)
+        latest = max(out_dir.glob(f"*.{ext}"), key=lambda p: p.stat().st_mtime)
     except ValueError:
         print("[gameday] no local segment found", file=sys.stderr)
         return False
@@ -294,11 +321,21 @@ def validate_segment(out_dir: pathlib.Path) -> bool:
 
 
 def main() -> int:
+    epilog = (
+        "Hardware encoder test:\n"
+        "  ffmpeg -hide_banner -loglevel error -f lavfi -i testsrc2=size=1280x720:rate=30 -t 1 -pix_fmt nv12 -c:v h264_v4l2m2m -f null -\n\n"
+        "Matroska single-file test:\n"
+        "  ffmpeg -hide_banner -f lavfi -i testsrc2=size=1280x720:rate=30 -f lavfi -i anullsrc=r=48000:cl=stereo \\\n"
+        "         -c:v libx264 -preset veryfast -g 60 -c:a aac -ar 48000 -b:a 128k \\\n"
+        "         -f matroska recordings/raw/test.mkv\n\n"
+        "Segmented TS test:\n"
+        "  ffmpeg -hide_banner -f lavfi -i testsrc2=size=1280x720:rate=30 -f lavfi -i anullsrc=r=48000:cl=stereo \\\n"
+        "         -c:v libx264 -preset veryfast -g 60 -c:a aac -ar 48000 -b:a 128k \\\n"
+        "         -f segment -segment_format mpegts -segment_time 900 -reset_timestamps 1 \\\n"
+        "         recordings/raw/%Y%m%d_%H%M%S.ts"
+    )
     p = argparse.ArgumentParser(
-        epilog=(
-            "Quick HW encoder test:\n"
-            "  ffmpeg -hide_banner -loglevel error -f lavfi -i testsrc2=size=1280x720:rate=30 -t 1 -pix_fmt nv12 -c:v h264_v4l2m2m -f null -"
-        ),
+        epilog=epilog,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     p.add_argument("--size", default=os.getenv("SIZE", "1280x720"))
@@ -308,6 +345,8 @@ def main() -> int:
     p.add_argument(
         "--segment-seconds", type=int, default=int(os.getenv("SEGMENT_SECONDS", "900"))
     )
+    p.add_argument("--raw-container", choices=["mkv", "mpegts"], default="mkv")
+    p.add_argument("--no-segment", action="store_true", help="force single-file output")
     p.add_argument("--out-dir", default=os.getenv("OUT_DIR", "recordings/raw"))
     p.add_argument(
         "--stream-key",
@@ -344,7 +383,7 @@ def main() -> int:
         f"[gameday] Launch -> size={args.size}@{args.fps} | audio={args.alsa_dev} | encoder={encoder} | raw={args.out_dir} | yt=on (key={safe_key})"
     )
 
-    cmd = build_ffmpeg_cmd(args, encoder)
+    cmd, ext = build_ffmpeg_cmd(args, encoder)
     rc, log = run_ffmpeg(cmd, stream_key)
 
     if "Output #0, tee, to '" not in log:
@@ -354,13 +393,12 @@ def main() -> int:
     if rc != 0:
         first_line = next((l.strip() for l in log.splitlines() if l.strip()), "")
         print(f"[gameday] ffmpeg exited with code {rc}", file=sys.stderr)
-        print(f"[gameday] encoder: {encoder}", file=sys.stderr)
         if first_line:
             print(f"[gameday] first error line: {first_line}", file=sys.stderr)
-        print("[gameday] Try ./gameday --encoder libx264", file=sys.stderr)
+        print("[gameday] Try --no-segment or --raw-container mpegts on FFmpeg 4.4.", file=sys.stderr)
         return rc
 
-    if not validate_segment(out_dir):
+    if not validate_segment(out_dir, ext):
         return 1
 
     return 0


### PR DESCRIPTION
## Summary
- add FFmpeg version detection and CLI options for `--raw-container` and `--no-segment`
- build robust tee pipelines with YouTube and configurable raw sinks
- improve error hints and expand diagnostic help text

## Testing
- `python -m py_compile gameday`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch'; ModuleNotFoundError: No module named 'numpy'; ModuleNotFoundError: No module named 'google'; SyntaxError in play_classifier.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a22b02f8832d84b2123f9de4cc1c