### PR TITLE
feat(stream): centralize YT stream key, harden YouTube publishing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
-YOUTUBE_RTMP_URL=rtmp://a.rtmp.youtube.com/live2/xxxx-xxxx-xxxx-xxxx
+YOUTUBE_STREAM_KEY=
 # Optional camera:
 # VIDEO_INPUT=/dev/video0

--- a/README.md
+++ b/README.md
@@ -81,23 +81,22 @@ rtmps://b.rtmps.youtube.com/live2/<key>
 
 If port 1935 is open and you prefer RTMP:
 
-rtmp://a.rtmp.youtube.com/live2/<key>
+## Stream key and ingest
 
-## Stream key discovery (precedence)
+Create a `.env` file in the repository root with::
 
-`gameday` looks for the YouTube stream key in the following order (first non-empty wins):
+``
+YOUTUBE_STREAM_KEY=your_key_here
+```
 
-1. `--stream-key` CLI argument
-2. Environment: `YT_STREAM_KEY`, `YOUTUBE_STREAM_KEY`, `STREAM_KEY`
-3. `.env` file in the repository root (same keys as above)
-4. Optional modules: `config.py`, `settings.py`, `secrets.py`
-5. Secret file: `~/.config/mca-gameday/yt.key`
+`gameday` resolves the key in this order:
 
-Notes
+1. `--stream-key` flag
+2. `YOUTUBE_STREAM_KEY` environment variable
+3. `.env` file
+4. Backward compatible env names (`YT_STREAM_KEY`, `STREAM_KEY`, `YOUTUBE_RTMP_URL`)
 
-The launcher prints a one-line “Launch -> …” status to stderr and emits JSON config to stdout internally. If it says missing or invalid RTMP URL, fix your key.
-
-If YouTube shows “No data” or a very low bitrate, verify network, try b.rtmps, or switch to rtmp:// if 1935 is open.
+Keys are masked in logs. Use `--yt-ingest a|b` to switch ingest servers. Add `--yt-optional` to keep local recording if YouTube is unreachable.
 
 We avoid aresample min_comp/max_comp entirely for compatibility.
 
@@ -329,7 +328,7 @@ YouTube using `ffmpeg`. Set the `VIDEO_DEVICE` environment variable if you need
 to use a different camera. Place your YouTube stream key in a `.env` file:
 
 ```ini
-YOUTUBE_STREAM_KEY=your_actual_stream_key
+YOUTUBE_STREAM_KEY=your_key_here
 ```
 
 You can also provide the key at runtime with `--stream-key`. Logs are written to the `livestream_logs` folder and the script will
@@ -712,7 +711,7 @@ YouTube using `ffmpeg`. Set the `VIDEO_DEVICE` environment variable if you need
 to use a different camera. Place your YouTube stream key in a `.env` file:
 
 ```ini
-YOUTUBE_STREAM_KEY=your_actual_stream_key
+YOUTUBE_STREAM_KEY=your_key_here
 ```
 
 You can also provide the key at runtime with `--stream-key`. Logs are written to the `livestream_logs` folder and the script will

--- a/config.py
+++ b/config.py
@@ -20,7 +20,7 @@ class StreamConfig:
     fps: int = 30
     mic_device: str = "hw:1,0"
     gain_boost: float = 3.0
-    stream_key: str = "rtmps://a.rtmps.youtube.com/live2/xcuz-3x1d-9y7v-ghec-2xmh"
+    stream_key: str = ""
     encoder: str = "auto"
     preset: str = "veryfast"
     maxrate: str = "3000k"

--- a/config.yaml
+++ b/config.yaml
@@ -2,7 +2,6 @@ resolution: 640x480
 fps: 30
 mic_device: hw:1,0
 gain_boost: 3.0
-stream_key: rtmps://a.rtmps.youtube.com/live2/xcuz-3x1d-9y7v-ghec-2xmh
 encoder: auto
 preset: veryfast
 maxrate: 3000k

--- a/config/gameday.json
+++ b/config/gameday.json
@@ -1,8 +1,0 @@
-{
-  "video_dev": "/dev/video0",
-  "pulse_source": "alsa_input.usb-R__DE_R__DE_VideoMic_GO_II_XXXXXXXX-00.mono-fallback",
-  "video_size": "1280x720",
-  "fps": 30,
-  "rtmp_url": "rtmp://a.rtmp.youtube.com/live2/xcuz-3x1d-9y7v-ghec-2xmh"
-}
-

--- a/env.sample
+++ b/env.sample
@@ -1,5 +1,5 @@
 # Copy to .env and fill in before streaming
-YT_RTMP_URL=rtmps://a.rtmp.youtube.com/live2/xcuz-3x1d-9y7v-ghec-2xmh
+YOUTUBE_STREAM_KEY=
 # (alias: set ``YOUTUBE_RTMP_URL`` if preferred)
 AUDIO_GAIN_DB=8
 AUDIO_MODE=speech

--- a/gameday
+++ b/gameday
@@ -13,44 +13,15 @@ import sys
 from pathlib import Path
 from typing import List, Tuple
 
-
-def load_stream_key(cli_key: str | None) -> str:
-    """Resolve the YouTube stream key from env/file/CLI."""
-    key = os.getenv("YOUTUBE_STREAM_KEY")
-    if not key:
-        env_path = Path(".env")
-        if env_path.exists():
-            for line in env_path.read_text().splitlines():
-                if line.strip().startswith("YOUTUBE_STREAM_KEY="):
-                    key = line.split("=", 1)[1].strip().strip('"').strip("'")
-                    break
-    if not key:
-        sk = Path(".stream_key")
-        if sk.exists():
-            key = sk.read_text().strip()
-    if not key and cli_key:
-        key = cli_key.strip()
-    if not key:
-        print(
-            "[gameday] ERROR: Missing stream key. Set YOUTUBE_STREAM_KEY, create .stream_key, or pass --stream-key."
-        )
-        raise SystemExit(2)
-    return key
-
-
-def mask_stream_key(k: str) -> str:
-    if not k:
-        return ""
-    return k[:4] + "*" * max(0, len(k) - 4)
+from gameday_config import get_stream_key, mask_key
 
 
 def run_ffmpeg(cmd: List[str], stream_key: str | None = None) -> Tuple[int, List[str]]:
     import signal
-    import time
 
     proc = subprocess.Popen(cmd, stderr=subprocess.PIPE, text=True, bufsize=1)
     log: List[str] = []
-    masked = mask_stream_key(stream_key) if stream_key else None
+    masked = mask_key(stream_key) if stream_key else None
     try:
         assert proc.stderr is not None
         for line in proc.stderr:
@@ -117,19 +88,26 @@ def build_cmd(args: argparse.Namespace, encoder: str, stream_key: str | None) ->
     seg_time = max(1, int(args.segment_seconds))
     outputs: List[str] = []
     if not args.no_yt:
-        outputs.append(
-            f"[f=flv:onfail=ignore]rtmps://a.rtmps.youtube.com/live2/{stream_key}"
-        )
-    if not args.no_record:
+        yt_base = f"rtmps://{args.yt_ingest}.rtmps.youtube.com/live2"
+        yt_url = f"{yt_base}/{stream_key}?rtmp_live=1"
+        flv_opts = "f=flv:onfail=ignore" if args.yt_optional else "f=flv"
+        outputs.append(f"[{flv_opts}]{yt_url}")
+    if not args.no_segment:
         out_dir = Path(args.out_dir)
         out_dir.mkdir(parents=True, exist_ok=True)
         outputs.append(
             f"[f=segment:use_fifo=1:segment_format=mpegts:segment_time={seg_time}:reset_timestamps=1:strftime=1]{out_dir}/%Y%m%d_%H%M%S.ts"
         )
     tee_arg = "|".join(outputs)
-
+    loglevel = "verbose" if args.debug else "warning"
     cmd: List[str] = [
         "ffmpeg",
+        "-loglevel",
+        loglevel,
+    ]
+    if args.debug:
+        cmd += ["-report"]
+    cmd += [
         "-fflags",
         "+genpts+igndts+discardcorrupt",
         "-avoid_negative_ts",
@@ -182,6 +160,8 @@ def build_cmd(args: argparse.Namespace, encoder: str, stream_key: str | None) ->
         "48000",
         "-ac",
         "2",
+        "-flvflags",
+        "no_duration_filesize",
         "-f",
         "tee",
         tee_arg,
@@ -212,20 +192,28 @@ def main() -> int:
     p.add_argument("--remux-mp4", action="store_true")
     p.add_argument("--remux-keep-ts", action="store_true")
     p.add_argument("--no-yt", action="store_true")
-    p.add_argument("--no-record", action="store_true")
+    p.add_argument("--no-segment", action="store_true")
+    p.add_argument("--yt-optional", action="store_true")
+    p.add_argument("--yt-ingest", choices=["a", "b"], default="a")
+    p.add_argument("--debug", action="store_true")
+    p.add_argument("--dry-run", action="store_true")
     args = p.parse_args()
 
-    if args.no_yt and args.no_record:
-        print("[gameday] ERROR: both --no-yt and --no-record specified", file=sys.stderr)
+    if args.no_yt and args.no_segment:
+        print("[gameday] ERROR: both --no-yt and --no-segment specified", file=sys.stderr)
         return 2
 
     stream_key = None
     masked_key = ""
     if not args.no_yt:
-        stream_key = load_stream_key(args.stream_key)
-        masked_key = mask_stream_key(stream_key)
+        try:
+            stream_key = get_stream_key(args.stream_key)
+        except RuntimeError as e:
+            print(f"[gameday] ERROR: {e}", file=sys.stderr)
+            return 2
+        masked_key = mask_key(stream_key)
 
-    if args.remux_mp4 and not args.no_record:
+    if args.remux_mp4 and not args.no_segment:
         start_remux_watcher(args.out_dir, args.remux_keep_ts)
 
     encoder = "h264_v4l2m2m"
@@ -233,6 +221,8 @@ def main() -> int:
     sanitized = [c.replace(stream_key, masked_key) if stream_key else c for c in cmd]
     print("[gameday] ffmpeg command:")
     print("[gameday]", " ".join(shlex.quote(x) for x in sanitized))
+    if args.dry_run:
+        return 0
     rc, log = run_ffmpeg(cmd, stream_key)
 
     if need_fallback(rc, log):
@@ -242,7 +232,13 @@ def main() -> int:
         sanitized = [c.replace(stream_key, masked_key) if stream_key else c for c in cmd]
         print("[gameday] ffmpeg command:")
         print("[gameday]", " ".join(shlex.quote(x) for x in sanitized))
+        if args.dry_run:
+            return 0
         rc, log = run_ffmpeg(cmd, stream_key)
+
+    if rc != 0 and args.yt_optional and not args.no_yt:
+        print("[gameday] WARNING: YouTube leg failed; local recording may be incomplete", file=sys.stderr)
+        rc = 0
 
     return rc
 

--- a/gameday_config.py
+++ b/gameday_config.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Optional
+
+from dotenv import load_dotenv
+
+_BACKCOMPAT_VARS = [
+    "YT_STREAM_KEY",
+    "STREAM_KEY",
+    "YOUTUBE_RTMP_URL",
+]
+
+
+def _load_env() -> None:
+    env_path = Path(".env")
+    if env_path.exists():
+        load_dotenv(dotenv_path=env_path)
+
+
+def get_stream_key(cli_value: Optional[str]) -> str:
+    """Return the YouTube stream key using CLI/env/.env resolution."""
+    if cli_value:
+        key = cli_value.strip()
+        if key:
+            return key
+
+    key = os.getenv("YOUTUBE_STREAM_KEY")
+    if not key:
+        _load_env()
+        key = os.getenv("YOUTUBE_STREAM_KEY")
+
+    if not key:
+        for name in _BACKCOMPAT_VARS:
+            val = os.getenv(name)
+            if not val:
+                continue
+            if name == "YOUTUBE_RTMP_URL":
+                val = val.rsplit("/", 1)[-1]
+            key = val.strip()
+            break
+
+    if not key:
+        raise RuntimeError(
+            "Missing stream key. Set YOUTUBE_STREAM_KEY in the environment or .env, or pass --stream-key."
+        )
+    return key
+
+
+def mask_key(k: str) -> str:
+    if len(k) <= 7:
+        return "***"
+    return f"{k[:4]}***{k[-3:]}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+python-dotenv
 ultralytics
 deep_sort_realtime
 easyocr


### PR DESCRIPTION
## Summary
- load YouTube stream key from CLI/env/.env via new config helper and mask in logs
- add ingest/debug/optional flags and fail-loud YouTube leg while keeping local segments resilient
- document `.env` workflow and add python-dotenv dependency

## Testing
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68b9b259e2e8832d819ba156ae687322