### PR TITLE
Avoid split filter when mezzanine is copy or disabled

### DIFF
--- a/gameday
+++ b/gameday
@@ -108,6 +108,18 @@ def build_cmd(
     cmd: List[str] = ["ffmpeg", "-loglevel", loglevel]
     if args.debug:
         cmd += ["-report"]
+    if mezz_mode == "crf":
+        filters = (
+            "[0:v]settb=AVTB,setpts=PTS-STARTPTS[v0];"
+            "[v0]split[v_master][v_stream];"
+            "[v_stream]scale=in_range=pc:out_range=tv,format=yuv420p[v];"
+            "[1:a]aresample=async=1:first_pts=0,asetpts=PTS-STARTPTS[a]"
+        )
+    else:
+        filters = (
+            "[0:v]settb=AVTB,setpts=PTS-STARTPTS,scale=in_range=pc:out_range=tv,format=yuv420p[v];"
+            "[1:a]aresample=async=1:first_pts=0,asetpts=PTS-STARTPTS[a]"
+        )
     cmd += [
         "-fflags",
         "+genpts+igndts+discardcorrupt",
@@ -134,7 +146,7 @@ def build_cmd(
         "-i",
         args.alsa_dev,
         "-filter_complex",
-        "[0:v]settb=AVTB,setpts=PTS-STARTPTS[v0];[v0]split[v_master][v_stream];[v_stream]scale=in_range=pc:out_range=tv,format=yuv420p[v];[1:a]aresample=async=1:first_pts=0,asetpts=PTS-STARTPTS[a]",
+        filters,
     ]
     # Streaming output
     if outputs:

--- a/tests/test_mezzanine_filters.py
+++ b/tests/test_mezzanine_filters.py
@@ -1,0 +1,71 @@
+import importlib.util
+import importlib.machinery
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def _load_gameday():
+    path = Path(__file__).resolve().parent.parent / "gameday"
+    loader = importlib.machinery.SourceFileLoader("gameday_module", str(path))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+def _args(tmp_path, mezz):
+    return SimpleNamespace(
+        segment=True,
+        segment_seconds=1,
+        out_dir=str(tmp_path),
+        no_yt=True,
+        yt_optional=False,
+        yt_ingest="a",
+        debug=False,
+        cam_input_format="mjpeg",
+        fps=30,
+        size="1280x720",
+        bitrate="3500k",
+        cam_dev="/dev/video0",
+        alsa_dev="plughw:2,0",
+        mezzanine=mezz,
+        mezz_dir=str(tmp_path),
+        mezz_segment_seconds=1,
+        mezz_crf=18,
+        mezz_preset="medium",
+        mezz_audio_bitrate="192k",
+        remux_mp4=False,
+        remux_keep_ts=False,
+    )
+
+
+def _filter(cmd):
+    return cmd[cmd.index("-filter_complex") + 1]
+
+
+def test_no_split_when_mezzanine_off(tmp_path):
+    gd = _load_gameday()
+    args = _args(tmp_path, "off")
+    cmd = gd.build_cmd(args, "libx264", None, "off")
+    fc = _filter(cmd)
+    assert "split" not in fc
+    assert "v_master" not in fc
+
+
+def test_no_split_when_mezzanine_copy(tmp_path):
+    gd = _load_gameday()
+    args = _args(tmp_path, "copy")
+    cmd = gd.build_cmd(args, "libx264", None, "copy")
+    fc = _filter(cmd)
+    assert "split" not in fc
+    assert "0:v" in cmd and "1:a" in cmd
+    assert "copy" in cmd
+
+
+def test_split_when_mezzanine_encode(tmp_path):
+    gd = _load_gameday()
+    args = _args(tmp_path, "crf")
+    cmd = gd.build_cmd(args, "libx264", None, "crf")
+    fc = _filter(cmd)
+    assert "split" in fc
+    assert "[v_master]" in cmd


### PR DESCRIPTION
## Summary
- rebuild filter graph based on mezzanine mode, only splitting video when encoding a mezzanine
- cover filter graph behavior for off/copy/encode modes

## Testing
- `pytest tests/test_stream_key_masking.py tests/test_mezzanine_filters.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b9e0ed56c0832da68b6137fcd7bdc8