### PR TITLE
Camera autoprobe + adaptive fallback to avoid V4L2 zero-byte frames

### DIFF
--- a/README-streaming.md
+++ b/README-streaming.md
@@ -29,6 +29,12 @@ encode. A high-quality mezzanine is captured alongside the stream:
 ./gameday --size 1280x720 --fps 30 --bitrate 6M
 ```
 
+### Camera modes
+
+`gameday` auto-probes the camera and USB bus to pick a sustainable mode. On
+USB2 links, raw YUYV 1280×720 is capped at 15 fps to avoid bandwidth
+starvation; use MJPEG to reach 720p30.
+
 By default, segments are written to `recordings/raw/` in 15 minute chunks. Use
 `--mezzanine off` to disable the master leg.
 

--- a/camera_modes.py
+++ b/camera_modes.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import re
+import subprocess
+from dataclasses import dataclass
+from typing import List, Tuple
+
+
+@dataclass
+class Mode:
+    pixfmt: str
+    w: int
+    h: int
+    fps_max: int
+
+
+@dataclass
+class CamMode:
+    pixfmt: str
+    w: int
+    h: int
+    fps: int
+
+
+def parse_v4l2_list_formats_ext(text: str) -> List[Mode]:
+    modes: List[Mode] = []
+    current_fmt: str | None = None
+    current_w: int | None = None
+    current_h: int | None = None
+    current_fps: float | None = None
+
+    fmt_map = {"MJPG": "mjpeg", "YUYV": "yuyv422"}
+    size_re = re.compile(r"Size:\s+Discrete\s+(\d+)x(\d+)")
+    fps_re = re.compile(r"\(([0-9.]+)\s+fps\)")
+
+    for line in text.splitlines():
+        m_fmt = re.search(r"\'([A-Z0-9]{4})\'", line)
+        if m_fmt:
+            fourcc = m_fmt.group(1)
+            current_fmt = fmt_map.get(fourcc)
+            current_w = current_h = None
+            current_fps = None
+            continue
+
+        m_size = size_re.search(line)
+        if m_size and current_fmt:
+            if current_w is not None and current_fps is not None:
+                modes.append(Mode(current_fmt, current_w, current_h, int(current_fps)))
+            current_w = int(m_size.group(1))
+            current_h = int(m_size.group(2))
+            current_fps = 0.0
+            continue
+
+        m_fps = fps_re.search(line)
+        if m_fps and current_fmt and current_w is not None:
+            fps = float(m_fps.group(1))
+            if fps > (current_fps or 0):
+                current_fps = fps
+
+    if current_fmt and current_w is not None and current_fps is not None:
+        modes.append(Mode(current_fmt, current_w, current_h, int(current_fps)))
+
+    return modes
+
+
+def probe_camera_modes(dev: str = "/dev/video0") -> List[Mode]:
+    try:
+        out = subprocess.run(
+            ["v4l2-ctl", f"--device={dev}", "--list-formats-ext"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+    except Exception:
+        return []
+    return parse_v4l2_list_formats_ext(out)
+
+
+def is_usb2(dev: str = "/dev/video0") -> bool:
+    try:
+        out = subprocess.run(["lsusb", "-t"], capture_output=True, text=True, check=True).stdout
+    except Exception:
+        return True
+    if re.search(r"\b(5000|10000)M\b", out):
+        return False
+    return True
+
+
+def select_mode(
+    modes: List[Mode],
+    requested_format: str,
+    requested_size: str | None,
+    requested_fps: int | None,
+    max_fps: int,
+    usb2: bool,
+) -> Tuple[CamMode, List[str]]:
+    warnings: List[str] = []
+
+    def _auto() -> CamMode:
+        # a) MJPEG 1280x720 >=30fps
+        for m in modes:
+            if m.pixfmt == "mjpeg" and m.w == 1280 and m.h == 720 and m.fps_max >= 30:
+                fps = min(m.fps_max, max_fps)
+                if fps >= 30:
+                    return CamMode(m.pixfmt, m.w, m.h, fps)
+        # b) MJPEG highest resolution @ highest fps
+        mjpegs = [m for m in modes if m.pixfmt == "mjpeg"]
+        if mjpegs:
+            m = max(mjpegs, key=lambda x: (x.w * x.h, x.fps_max))
+            fps = min(m.fps_max, max_fps)
+            return CamMode(m.pixfmt, m.w, m.h, fps)
+        # c) YUYV 1280x720
+        yuyv720 = [m for m in modes if m.pixfmt == "yuyv422" and m.w == 1280 and m.h == 720]
+        if yuyv720:
+            m = max(yuyv720, key=lambda x: x.fps_max)
+            fps = min(m.fps_max, max_fps)
+            if usb2:
+                fps = min(fps, 15)
+            return CamMode(m.pixfmt, m.w, m.h, fps)
+        # d) 640x480 @30fps
+        modes640 = [m for m in modes if m.w == 640 and m.h == 480 and m.pixfmt in ("mjpeg", "yuyv422")]
+        if modes640:
+            m = max(modes640, key=lambda x: (x.pixfmt == "yuyv422", x.fps_max))
+            fps = min(30, m.fps_max, max_fps)
+            return CamMode(m.pixfmt, m.w, m.h, fps)
+        raise RuntimeError("no supported camera mode found")
+
+    if requested_format != "auto" and requested_size and requested_fps:
+        w, h = map(int, requested_size.lower().split("x"))
+        mode = next((m for m in modes if m.pixfmt == requested_format and m.w == w and m.h == h), None)
+        if mode:
+            fps = min(mode.fps_max, requested_fps, max_fps)
+            if (
+                requested_format == "yuyv422"
+                and w == 1280
+                and h == 720
+                and usb2
+                and fps > 15
+            ):
+                warnings.append("YUYV 1280x720 on USB2 capped to 15 fps")
+                fps = 15
+            return CamMode(mode.pixfmt, mode.w, mode.h, fps), warnings
+        warnings.append("requested mode unsupported; falling back to auto")
+
+    return _auto(), warnings
+
+
+def next_fallback(mode: CamMode, usb2: bool) -> CamMode | None:
+    if mode.pixfmt == "mjpeg" and mode.w == 1280 and mode.h == 720 and mode.fps >= 30:
+        fps = min(mode.fps, 15 if usb2 else mode.fps)
+        return CamMode("yuyv422", 1280, 720, fps)
+    if mode.pixfmt == "yuyv422" and mode.w == 1280 and mode.h == 720 and mode.fps >= 20:
+        if mode.fps > 15:
+            return CamMode("yuyv422", 1280, 720, 15)
+    if not (mode.w == 640 and mode.h == 480 and mode.fps == 30):
+        return CamMode(mode.pixfmt, 640, 480, 30)
+    return None
+
+
+_use_libv4l2: bool | None = None
+
+
+def has_use_libv4l2() -> bool:
+    global _use_libv4l2
+    if _use_libv4l2 is not None:
+        return _use_libv4l2
+    try:
+        proc = subprocess.run(
+            [
+                "ffmpeg",
+                "-hide_banner",
+                "-loglevel",
+                "quiet",
+                "-f",
+                "v4l2",
+                "-use_libv4l2",
+                "1",
+                "-i",
+                "/dev/null",
+            ],
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        _use_libv4l2 = "Option not found" not in proc.stderr
+    except Exception:
+        _use_libv4l2 = False
+    return _use_libv4l2
+
+
+def format_mode(mode: CamMode) -> str:
+    return f"{mode.pixfmt} {mode.w}x{mode.h}@{mode.fps}"

--- a/gameday
+++ b/gameday
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import List, Tuple
 
 from gameday_config import get_stream_key, mask_key
+import camera_modes
 import re
 
 
@@ -45,16 +46,18 @@ def build_filter_graph() -> str:
 
 
 def run_ffmpeg(
-    args: argparse.Namespace, encoder: str, stream_key: str | None = None
+    args: argparse.Namespace,
+    encoder: str,
+    stream_key: str | None,
+    start_mode: camera_modes.CamMode,
+    usb2: bool,
 ) -> Tuple[int, List[str]]:
     import select
     import signal
     import time
 
     log: List[str] = []
-    requested_if = args.cam_input_format
-    active_if = "mjpeg" if requested_if == "auto" else requested_if
-    did_if_fallback = False
+    active_mode = start_mode
 
     backoffs = [2, 4, 8]
     attempt = 0
@@ -63,21 +66,21 @@ def run_ffmpeg(
 
     while True:
         local_args = argparse.Namespace(**vars(args))
-        local_args.cam_input_format = active_if
+        local_args.cam_input_format = active_mode.pixfmt
+        local_args.fps = active_mode.fps
+        local_args.size = f"{active_mode.w}x{active_mode.h}"
         cmd = build_cmd(local_args, encoder, stream_key, "unused")
         sanitized = [c.replace(stream_key, masked) if stream_key else c for c in cmd]
         print(
-            f"[gameday] input_format={active_if} | hw_encoder={encoder} | tee={tee_display}"
+            f"[gameday] input_format={active_mode.pixfmt} | hw_encoder={encoder} | tee={tee_display}"
         )
         print("[gameday] ffmpeg command:")
         print("[gameday]", " ".join(shlex.quote(x) for x in sanitized))
         proc = subprocess.Popen(cmd, stderr=subprocess.PIPE, text=True, bufsize=1)
 
-        start_time = time.monotonic()
-        last_frame = start_time
+        last_frame = time.monotonic()
         first_frame = None
         frames_out = 0
-        zero_count = 0
         zero_times: deque[float] = deque()
         live_logged = False
         restarting = False
@@ -99,33 +102,24 @@ def run_ffmpeg(
                     log.append(line.rstrip("\n"))
 
                     if zero_re.search(line):
-                        zero_count += 1
                         zero_times.append(now)
-                        while zero_times and now - zero_times[0] > 2:
+                        while zero_times and now - zero_times[0] > 3:
                             zero_times.popleft()
-                        if (
-                            not did_if_fallback
-                            and active_if == "mjpeg"
-                            and requested_if in ("auto", "mjpeg")
-                            and (
-                                (zero_count >= 30 and now - start_time <= 10)
-                                or len(zero_times) >= 8
-                            )
-                        ):
-                            print(
-                                "[gameday] v4l2: too many zero-byte frames; switching to yuyv422"
-                            )
-                            try:
-                                proc.send_signal(signal.SIGINT)
-                                proc.wait(timeout=5)
-                            except subprocess.TimeoutExpired:
-                                proc.kill()
-                                proc.wait()
-                            active_if = "yuyv422"
-                            args.cam_input_format = "yuyv422"
-                            did_if_fallback = True
-                            restarting = True
-                            break
+                        if len(zero_times) > 5:
+                            next_mode = camera_modes.next_fallback(active_mode, usb2)
+                            if next_mode:
+                                print(
+                                    f"[gameday] WARNING: zero-byte frames; switching {camera_modes.format_mode(active_mode)} -> {camera_modes.format_mode(next_mode)}"
+                                )
+                                try:
+                                    proc.send_signal(signal.SIGINT)
+                                    proc.wait(timeout=5)
+                                except subprocess.TimeoutExpired:
+                                    proc.kill()
+                                    proc.wait()
+                                active_mode = next_mode
+                                restarting = True
+                                break
 
                     m = frame_re.search(line)
                     if m:
@@ -142,7 +136,7 @@ def run_ffmpeg(
                                 and now - first_frame >= 3
                             ):
                                 print(
-                                    f"[gameday] LIVE: streaming and recording (encoder={encoder}, input={active_if})"
+                                    f"[gameday] LIVE: streaming and recording (encoder={encoder}, input={active_mode.pixfmt})"
                                 )
                                 live_logged = True
 
@@ -270,6 +264,10 @@ def build_cmd(
         str(args.fps),
         "-video_size",
         args.size,
+    ]
+    if args.cam_input_format == "mjpeg" and camera_modes.has_use_libv4l2():
+        cmd += ["-use_libv4l2", "1"]
+    cmd += [
         "-thread_queue_size",
         "1024",
         "-i",
@@ -330,6 +328,7 @@ def main() -> int:
     p = argparse.ArgumentParser()
     p.add_argument("--size", default="1280x720")
     p.add_argument("--fps", type=int, default=30)
+    p.add_argument("--cam-max-fps", type=int, default=30)
     p.add_argument("--bitrate", default="3500k")
     p.add_argument("--alsa-dev", default="plughw:2,0")
     p.add_argument("--segment", action="store_true", help="also save low-bitrate stream archive")
@@ -387,6 +386,29 @@ def main() -> int:
             print(masked_key)
             return 0
 
+    modes = camera_modes.probe_camera_modes(args.cam_dev)
+    usb2 = camera_modes.is_usb2(args.cam_dev)
+    requested_size = args.size if args.cam_input_format != "auto" else None
+    requested_fps = args.fps if args.cam_input_format != "auto" else None
+    cam_mode, cam_warnings = camera_modes.select_mode(
+        modes,
+        args.cam_input_format,
+        requested_size,
+        requested_fps,
+        args.cam_max_fps,
+        usb2,
+    )
+    args.cam_input_format = cam_mode.pixfmt
+    args.size = f"{cam_mode.w}x{cam_mode.h}"
+    args.fps = cam_mode.fps
+    args._cam_mode = cam_mode
+    args._usb2 = usb2
+    for w in cam_warnings:
+        print(f"[gameday] WARNING: {w}")
+    print(
+        f"[gameday] camera mode: {camera_modes.format_mode(cam_mode)} (usb2={usb2})"
+    )
+
     if args.remux_mp4:
         start_remux_watcher(args.mezz_dir, args.remux_keep_ts)
 
@@ -400,8 +422,6 @@ def main() -> int:
 
     if args.dry_run:
         display_args = argparse.Namespace(**vars(args))
-        if display_args.cam_input_format == "auto":
-            display_args.cam_input_format = "mjpeg"
         tee_display = "yt+segments" if not args.no_yt else "segments"
         print(
             f"[gameday] input_format={display_args.cam_input_format} | hw_encoder={encoder} | tee={tee_display}"
@@ -412,15 +432,13 @@ def main() -> int:
         print("[gameday]", " ".join(shlex.quote(x) for x in sanitized))
         return 0
 
-    rc, log = run_ffmpeg(args, encoder, stream_key)
+    rc, log = run_ffmpeg(args, encoder, stream_key, args._cam_mode, args._usb2)
 
     if need_fallback(rc, log):
         print("[gameday] hw encoder failed; retrying with libx264")
         encoder = "libx264"
         if args.dry_run:
             display_args = argparse.Namespace(**vars(args))
-            if display_args.cam_input_format == "auto":
-                display_args.cam_input_format = "mjpeg"
             tee_display = "yt+segments" if not args.no_yt else "segments"
             print(
                 f"[gameday] input_format={display_args.cam_input_format} | hw_encoder={encoder} | tee={tee_display}"
@@ -430,7 +448,7 @@ def main() -> int:
             print("[gameday] ffmpeg command:")
             print("[gameday]", " ".join(shlex.quote(x) for x in sanitized))
             return 0
-        rc, log = run_ffmpeg(args, encoder, stream_key)
+        rc, log = run_ffmpeg(args, encoder, stream_key, args._cam_mode, args._usb2)
 
 
     if rc != 0 and args.yt_optional and not args.no_yt:

--- a/tests/fixtures/v4l2_list_formats.txt
+++ b/tests/fixtures/v4l2_list_formats.txt
@@ -1,0 +1,13 @@
+ioctl: VIDIOC_ENUM_FMT
+Type: Video Capture
+
+    [0]: 'MJPG' (Motion-JPEG)
+        Size: Discrete 1280x720
+            Interval: Discrete 0.033s (30.000 fps)
+        Size: Discrete 640x480
+            Interval: Discrete 0.033s (30.000 fps)
+    [1]: 'YUYV' (YUYV 4:2:2)
+        Size: Discrete 1280x720
+            Interval: Discrete 0.066s (15.000 fps)
+        Size: Discrete 640x480
+            Interval: Discrete 0.033s (30.000 fps)

--- a/tests/test_camera_modes.py
+++ b/tests/test_camera_modes.py
@@ -1,0 +1,21 @@
+from camera_modes import (
+    CamMode,
+    Mode,
+    next_fallback,
+    parse_v4l2_list_formats_ext,
+)
+from pathlib import Path
+
+
+def test_parse_v4l2_list_formats_ext():
+    text = (Path(__file__).parent / "fixtures" / "v4l2_list_formats.txt").read_text()
+    modes = parse_v4l2_list_formats_ext(text)
+    assert Mode("mjpeg", 1280, 720, 30) in modes
+    assert Mode("yuyv422", 1280, 720, 15) in modes
+    assert Mode("yuyv422", 640, 480, 30) in modes
+
+
+def test_next_fallback_usb2():
+    m = CamMode("mjpeg", 1280, 720, 30)
+    fb = next_fallback(m, usb2=True)
+    assert fb == CamMode("yuyv422", 1280, 720, 15)


### PR DESCRIPTION
## Summary
- auto-detect camera modes via `v4l2-ctl` and choose best sustainable mode
- clamp YUYV 720p to 15 fps on USB2 and restart ffmpeg on repeated zero-byte frames with lower modes
- document USB2 YUYV bandwidth limits and add unit tests for mode parsing/fallback

## Testing
- `pytest tests/test_camera_modes.py tests/test_mezzanine_filters.py tests/test_stream_key_masking.py tests/test_ffmpeg_builder.py` (fails: test_no_split_when_mezzanine_copy, test_split_when_mezzanine_encode)
- `python - <<'PY'
import importlib.util, importlib.machinery, pathlib, sys
import camera_modes

path = pathlib.Path('gameday').resolve()
loader = importlib.machinery.SourceFileLoader('gameday_mod', str(path))
spec = importlib.util.spec_from_loader(loader.name, loader)
gd = importlib.util.module_from_spec(spec)
loader.exec_module(gd)

modes = [camera_modes.Mode('mjpeg',1280,720,30), camera_modes.Mode('yuyv422',1280,720,30)]

def run_case(args_list):
    camera_modes.probe_camera_modes = lambda dev='/dev/video0': modes
    camera_modes.is_usb2 = lambda dev='/dev/video0': True
    sys.argv = ['gameday'] + args_list
    gd.main()

print('--- case a: auto ---')
run_case(['--dry-run','--no-yt'])
print('--- case b: forced yuyv422 30fps ---')
run_case(['--dry-run','--no-yt','--cam-input-format','yuyv422','--fps','30','--size','1280x720'])
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b9fd6d2880832d969b1b8a631e8da5