### PR TITLE
V4L2: default blocking I/O + rw_timeout to avoid zero-byte buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,21 @@ python3 gameday_capture.py --probe-only
 python3 gameday_capture.py --duration 30 --local-only
 ```
 
+### V4L2 I/O and read timeout
+
+`gameday` defaults to the kernel V4L2 driver with blocking I/O and a 2000 ms
+read timeout. This avoids the recurring `Dequeued v4l2 buffer contains
+corrupted data (0 bytes)` warnings that can appear when the device is opened in
+nonblocking mode.
+
+Use `--use-libv4l2` to force libv4l2 nonblocking I/O. Some cameras require
+this shim, but it may surface empty buffers. When enabled, consider increasing
+`--rw-timeout-ms` (accepted values are in milliseconds; 1000–5000 ms are
+typical safe values).
+
+`--rw-timeout-ms` is tunable regardless of libv4l2 usage and is converted to
+microseconds for ffmpeg's `-rw_timeout` demuxer option.
+
 ## Game-day one-liners
 
 ```

--- a/gameday
+++ b/gameday
@@ -58,6 +58,7 @@ def run_ffmpeg(
 
     log: List[str] = []
     active_mode = start_mode
+    warned_zero = False
 
     backoffs = [2, 4, 8]
     attempt = 0
@@ -100,6 +101,16 @@ def run_ffmpeg(
                         line = line.replace(stream_key, masked)
                     sys.stderr.write(line)
                     log.append(line.rstrip("\n"))
+
+                    if (
+                        args.use_libv4l2
+                        and not warned_zero
+                        and "Dequeued v4l2 buffer contains corrupted data (0 bytes)" in line
+                    ):
+                        print(
+                            "[gameday] WARN: zero-byte V4L2 buffers while using libv4l2 (nonblocking). Try rerun without --use-libv4l2."
+                        )
+                        warned_zero = True
 
                     if zero_re.search(line):
                         zero_times.append(now)
@@ -264,8 +275,10 @@ def build_cmd(
         str(args.fps),
         "-video_size",
         args.size,
+        "-rw_timeout",
+        str(args.rw_timeout_ms * 1000),
     ]
-    if args.cam_input_format == "mjpeg" and camera_modes.has_use_libv4l2():
+    if args.use_libv4l2:
         cmd += ["-use_libv4l2", "1"]
     cmd += [
         "-thread_queue_size",
@@ -324,7 +337,7 @@ def need_fallback(rc: int, log: List[str]) -> bool:
     return False
 
 
-def main() -> int:
+def parse_args(argv: List[str] | None = None) -> argparse.Namespace:
     p = argparse.ArgumentParser()
     p.add_argument("--size", default="1280x720")
     p.add_argument("--fps", type=int, default=30)
@@ -367,7 +380,13 @@ def main() -> int:
     p.add_argument("--yt-ingest", choices=["a", "b"], default="a")
     p.add_argument("--debug", action="store_true")
     p.add_argument("--dry-run", action="store_true")
-    args = p.parse_args()
+    p.add_argument("--use-libv4l2", action="store_true", default=False)
+    p.add_argument("--rw-timeout-ms", type=int, default=2000)
+    return p.parse_args(argv)
+
+
+def main() -> int:
+    args = parse_args()
 
 
     stream_key = None
@@ -406,7 +425,7 @@ def main() -> int:
     for w in cam_warnings:
         print(f"[gameday] WARNING: {w}")
     print(
-        f"[gameday] camera mode: {camera_modes.format_mode(cam_mode)} (usb2={usb2})"
+        f"[gameday] camera mode: {cam_mode.pixfmt} {cam_mode.w}x{cam_mode.h}@{cam_mode.fps} (libv4l2={args.use_libv4l2}, rw_timeout={args.rw_timeout_ms}ms)"
     )
 
     if args.remux_mp4:

--- a/tests/test_gameday_cli.py
+++ b/tests/test_gameday_cli.py
@@ -1,0 +1,41 @@
+import importlib.machinery
+import types
+
+
+_loader = importlib.machinery.SourceFileLoader("gameday", "gameday")
+gameday = types.ModuleType("gameday")
+_loader.exec_module(gameday)
+
+parse_args = gameday.parse_args
+build_cmd = gameday.build_cmd
+
+
+def _default_args():
+    # Parse with minimal flags to avoid env dependencies
+    return parse_args(["--no-yt"])
+
+
+def test_arg_defaults():
+    args = _default_args()
+    assert args.use_libv4l2 is False
+    assert args.rw_timeout_ms == 2000
+
+
+def test_builder_rw_timeout_and_libv4l2():
+    args = _default_args()
+    # Populate required fields
+    args.cam_input_format = "mjpeg"
+    args.fps = 30
+    args.size = "1280x720"
+    args.cam_dev = "/dev/video0"
+    args.alsa_dev = "plughw:2,0"
+    cmd = build_cmd(args, "h264_v4l2m2m", None, "unused")
+    assert "-rw_timeout" in cmd
+    idx = cmd.index("-rw_timeout")
+    assert cmd[idx + 1] == "2000000"
+    assert "-use_libv4l2" not in cmd
+
+    args.use_libv4l2 = True
+    cmd = build_cmd(args, "h264_v4l2m2m", None, "unused")
+    uidx = cmd.index("-use_libv4l2")
+    assert cmd[uidx + 1] == "1"


### PR DESCRIPTION
## Summary
- default to kernel V4L2 blocking I/O with rw_timeout to avoid zero-byte buffers
- add optional `--use-libv4l2` toggle for nonblocking mode
- log camera mode including libv4l2 status and warn on zero-byte buffers

## Testing
- `pytest tests/test_gameday_cli.py`

### After merge quick checks
- Default run (no flags) prints `(libv4l2=False, rw_timeout=2000ms)` and avoids “Dequeued … 0 bytes”.
- With `--use-libv4l2`, log shows `(libv4l2=True)` and nonblocking banner may appear again.


------
https://chatgpt.com/codex/tasks/task_e_68ba060df3e0832dbb515273cdc91b22