### PR TITLE
V4L2: remove unsupported -rw_timeout; keep blocking I/O by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,20 +66,17 @@ python3 gameday_capture.py --probe-only
 python3 gameday_capture.py --duration 30 --local-only
 ```
 
-### V4L2 I/O and read timeout
+### Camera capture
 
-`gameday` defaults to the kernel V4L2 driver with blocking I/O and a 2000 ms
-read timeout. This avoids the recurring `Dequeued v4l2 buffer contains
-corrupted data (0 bytes)` warnings that can appear when the device is opened in
-nonblocking mode.
+`gameday` defaults to the kernel V4L2 driver with blocking I/O. This avoids the
+recurring `Dequeued v4l2 buffer contains corrupted data (0 bytes)` warnings that
+can appear when the device is opened in nonblocking mode.
 
-Use `--use-libv4l2` to force libv4l2 nonblocking I/O. Some cameras require
-this shim, but it may surface empty buffers. When enabled, consider increasing
-`--rw-timeout-ms` (accepted values are in milliseconds; 1000–5000 ms are
-typical safe values).
+Use `--use-libv4l2` to force libv4l2 nonblocking I/O. Some cameras require this
+shim, but it may surface empty buffers on others.
 
-`--rw-timeout-ms` is tunable regardless of libv4l2 usage and is converted to
-microseconds for ffmpeg's `-rw_timeout` demuxer option.
+The ffmpeg `-rw_timeout` demuxer option is not used because it is unsupported on
+FFmpeg 4.4.x V4L2.
 
 ## Game-day one-liners
 

--- a/gameday
+++ b/gameday
@@ -275,8 +275,6 @@ def build_cmd(
         str(args.fps),
         "-video_size",
         args.size,
-        "-rw_timeout",
-        str(args.rw_timeout_ms * 1000),
     ]
     if args.use_libv4l2:
         cmd += ["-use_libv4l2", "1"]
@@ -381,7 +379,6 @@ def parse_args(argv: List[str] | None = None) -> argparse.Namespace:
     p.add_argument("--debug", action="store_true")
     p.add_argument("--dry-run", action="store_true")
     p.add_argument("--use-libv4l2", action="store_true", default=False)
-    p.add_argument("--rw-timeout-ms", type=int, default=2000)
     return p.parse_args(argv)
 
 
@@ -425,7 +422,7 @@ def main() -> int:
     for w in cam_warnings:
         print(f"[gameday] WARNING: {w}")
     print(
-        f"[gameday] camera mode: {cam_mode.pixfmt} {cam_mode.w}x{cam_mode.h}@{cam_mode.fps} (libv4l2={args.use_libv4l2}, rw_timeout={args.rw_timeout_ms}ms)"
+        f"[gameday] camera mode: {cam_mode.pixfmt} {cam_mode.w}x{cam_mode.h}@{cam_mode.fps} (libv4l2={args.use_libv4l2})"
     )
 
     if args.remux_mp4:

--- a/scripts/launch_ffmpeg_shared.py
+++ b/scripts/launch_ffmpeg_shared.py
@@ -169,8 +169,6 @@ def build_cmd(args: argparse.Namespace, encoder: str) -> tuple[list[str], str, l
         "1",
         "-reconnect_at_eof",
         "1",
-        "-rw_timeout",
-        "15000000",
         "-f",
         "tee",
         "|".join(outputs),

--- a/tests/test_gameday_cli.py
+++ b/tests/test_gameday_cli.py
@@ -18,10 +18,9 @@ def _default_args():
 def test_arg_defaults():
     args = _default_args()
     assert args.use_libv4l2 is False
-    assert args.rw_timeout_ms == 2000
 
 
-def test_builder_rw_timeout_and_libv4l2():
+def test_builder_video_input_and_libv4l2():
     args = _default_args()
     # Populate required fields
     args.cam_input_format = "mjpeg"
@@ -30,9 +29,15 @@ def test_builder_rw_timeout_and_libv4l2():
     args.cam_dev = "/dev/video0"
     args.alsa_dev = "plughw:2,0"
     cmd = build_cmd(args, "h264_v4l2m2m", None, "unused")
-    assert "-rw_timeout" in cmd
-    idx = cmd.index("-rw_timeout")
-    assert cmd[idx + 1] == "2000000"
+    assert "-f" in cmd
+    assert cmd[cmd.index("-f") + 1] == "v4l2"
+    assert "-input_format" in cmd
+    assert cmd[cmd.index("-input_format") + 1] == "mjpeg"
+    assert "-framerate" in cmd
+    assert cmd[cmd.index("-framerate") + 1] == "30"
+    assert "-video_size" in cmd
+    assert cmd[cmd.index("-video_size") + 1] == "1280x720"
+    assert "-rw_timeout" not in cmd
     assert "-use_libv4l2" not in cmd
 
     args.use_libv4l2 = True


### PR DESCRIPTION
## Summary
- drop `-rw_timeout` handling from V4L2 input and CLI
- document default blocking V4L2 and optional libv4l2 usage
- remove `-rw_timeout` usage from shared ffmpeg launcher

## Testing
- `pytest tests/test_gameday_cli.py -q`
- `./gameday --dry-run --no-yt` *(fails: no supported camera mode found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0c496b40832d854876e6d6b3f65b