### PR TITLE
Stabilize gameday ffmpeg segment tee handling

### DIFF
--- a/gameday
+++ b/gameday
@@ -23,7 +23,7 @@ def warmup(video_dev: str, size: str, fps: int) -> None:
         "ffmpeg", "-loglevel", "error",
         "-f", "v4l2", "-input_format", "h264",
         "-framerate", str(fps), "-video_size", size,
-        "-t", "0.7", "-i", video_dev,
+        "-t", "1.2", "-i", video_dev,
         "-an", "-f", "null", "-"
     ]
     subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
@@ -40,7 +40,7 @@ def build_ffmpeg_copy(video_dev: str, audio_dev: str, size: str, fps: int,
     seg_tmpl = str(seg_dir / "%Y%m%d_%H%M%S.mkv")
     return [
         "ffmpeg", "-hide_banner", "-loglevel", "warning",
-        "-fflags", "+genpts+igndts+discardcorrupt", "-use_wallclock_as_timestamps", "1",
+        "-fflags", "+genpts+discardcorrupt", "-use_wallclock_as_timestamps", "1",
         "-f", "v4l2", "-input_format", "h264", "-framerate", str(fps), "-video_size", size,
         "-thread_queue_size", "4096", "-ts", "mono2abs", "-rtbufsize", "256M", "-i", video_dev,
         "-f", "alsa", "-thread_queue_size", "1024", "-i", audio_dev,
@@ -50,7 +50,13 @@ def build_ffmpeg_copy(video_dev: str, audio_dev: str, size: str, fps: int,
         "-muxpreload", "0", "-muxdelay", "0", "-flvflags", "no_duration_filesize",
         "-f", "tee",
         f"[f=flv:onfail=ignore:use_fifo=1]{yt_url}|"
-        f"[f=segment:use_fifo=1:segment_format=matroska:segment_time={seg_len}:segment_atclocktime=1:strftime=1:reset_timestamps=1]{seg_tmpl}",
+        f"[f=segment:onfail=ignore:use_fifo=1:segment_format=matroska:segment_time={seg_len}:segment_atclocktime=1:strftime=1:reset_timestamps=1]{seg_tmpl}",
+        # (optional) try to help matroska timing on some builds:
+        # If supported by your ffmpeg, you can pass format options like:
+        #   :segment_format_options=video_track_timescale=90000
+        # If unsupported, ffmpeg will ignore it harmlessly.
+        # Example (uncomment if your ffmpeg supports it):
+        # f"[f=segment:onfail=ignore:use_fifo=1:segment_format=matroska:segment_format_options=video_track_timescale=90000:segment_time={seg_len}:segment_atclocktime=1:strftime=1:reset_timestamps=1]{seg_tmpl}",
     ]
 
 def build_ffmpeg_transcode(video_dev: str, audio_dev: str, size: str, fps: int,
@@ -61,7 +67,7 @@ def build_ffmpeg_transcode(video_dev: str, audio_dev: str, size: str, fps: int,
          "[1:a]aresample=async=1:first_pts=0,asetpts=PTS-STARTPTS[a]"
     return [
         "ffmpeg", "-hide_banner", "-loglevel", "warning",
-        "-fflags", "+genpts+igndts+discardcorrupt", "-use_wallclock_as_timestamps", "1",
+        "-fflags", "+genpts+discardcorrupt", "-use_wallclock_as_timestamps", "1",
         "-f", "v4l2", "-input_format", "mjpeg", "-framerate", str(fps), "-video_size", size,
         "-thread_queue_size", "1024", "-i", video_dev,
         "-f", "alsa", "-thread_queue_size", "1024", "-i", audio_dev,
@@ -72,7 +78,7 @@ def build_ffmpeg_transcode(video_dev: str, audio_dev: str, size: str, fps: int,
         "-flvflags", "no_duration_filesize",
         "-f", "tee",
         f"[f=flv:onfail=ignore:use_fifo=1]{yt_url}|"
-        f"[f=segment:use_fifo=1:segment_format=matroska:segment_time={seg_len}:segment_atclocktime=1:strftime=1:reset_timestamps=1]{seg_tmpl}",
+        f"[f=segment:onfail=ignore:use_fifo=1:segment_format=matroska:segment_time={seg_len}:segment_atclocktime=1:strftime=1:reset_timestamps=1]{seg_tmpl}",
     ]
 
 def main(argv=None) -> int:


### PR DESCRIPTION
## Summary
- extend camera warmup to 1.2s
- drop `igndts` and add `onfail=ignore` for tee outputs
- document optional matroska `segment_format_options`

## Testing
- `python -m py_compile gameday`
- `pytest tests/test_ffmpeg_builder.py tests/test_gameday_capture.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb02a13398832da92baae9007f5c4b