### PR TITLE
Add optional clip enhancement step and batch script

### DIFF
--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -23,10 +23,110 @@ except ImportError:  # pragma: no cover - fallback for script execution
 classify_plays = None  # type: ignore
 logger = logging.getLogger(__name__)
 
+# cache for vid.stab availability; probed lazily
+_HAS_VIDSTAB: bool | None = None
+
+
+def _probe_vidstab() -> bool:
+    """Return True if ffmpeg has vid.stab filters available."""
+    global _HAS_VIDSTAB
+    if _HAS_VIDSTAB is None:
+        proc = subprocess.run(
+            ["ffmpeg", "-hide_banner", "-filters"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        data = proc.stdout + proc.stderr
+        _HAS_VIDSTAB = "vidstabdetect" in data and "vidstabtransform" in data
+    return _HAS_VIDSTAB
+
 
 def _ffmpeg(*args: str) -> subprocess.CompletedProcess:
     cmd = ["ffmpeg", "-y", *args]
     return subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
+def enhance_clip(
+    in_path: str,
+    out_path: str,
+    zoom: float = 0.95,
+    stabilize: bool = False,
+    bitrate: str = "10M",
+) -> None:
+    """Enhance a clip using the configured filter chain."""
+
+    filters: list[str] = []
+    trf_path: str | None = None
+    if stabilize:
+        if _probe_vidstab():
+            trf_path = f"{out_path}.trf"
+            _ffmpeg(
+                "-i",
+                in_path,
+                "-vf",
+                f"vidstabdetect=result={trf_path}",
+                "-f",
+                "null",
+                "-",
+            )
+            filters.append(
+                f"vidstabtransform=input={trf_path}:zoom=0:smoothing=30"
+            )
+        else:
+            logger.warning("vid.stab filters not available; skipping stabilization")
+
+    filters.extend(
+        [
+            "zscale=rangein=limited:range=limited",
+            "hqdn3d=0:0:3:3",
+            "unsharp=lx=7:ly=7:la=0.9",
+            "deband",
+            "eq=contrast=1.08:saturation=1.08:gamma=1.02",
+        ]
+    )
+    if 0.5 <= zoom < 1.0:
+        filters.append(
+            f"crop=iw*{zoom}:ih*{zoom}:(iw-iw*{zoom})/2:(ih-ih*{zoom})/2"
+        )
+    filters.extend(["scale=1920:1080:flags=lanczos", "sharpen=0:0.6"])
+    vf = ",".join(filters)
+
+    _ffmpeg(
+        "-i",
+        in_path,
+        "-vf",
+        vf,
+        "-c:v",
+        "h264_v4l2m2m",
+        "-b:v",
+        bitrate,
+        "-maxrate",
+        bitrate,
+        "-bufsize",
+        f"2{bitrate}",
+        "-pix_fmt",
+        "yuv420p",
+        "-r",
+        "30",
+        "-g",
+        "60",
+        "-c:a",
+        "aac",
+        "-b:a",
+        "160k",
+        "-ar",
+        "48000",
+        "-movflags",
+        "+faststart",
+        out_path,
+    )
+
+    if trf_path:
+        try:
+            os.unlink(trf_path)
+        except OSError:
+            pass
 
 
 def _safe_name(s: str) -> str:
@@ -136,6 +236,10 @@ def run_pipeline(
     generate_clips: bool = False,
     debug_weak: bool = False,
     require_classifier: bool = True,
+    enhance: bool = False,
+    enhance_zoom: float = 0.95,
+    enhance_stabilize: bool = False,
+    enhance_bitrate: str = "10M",
 ) -> str:
     video = os.path.abspath(video)
     out_dir = os.path.abspath(out_dir)
@@ -526,6 +630,17 @@ def run_pipeline(
                 )
             r["clip_path"] = mp4
 
+            if enhance:
+                enh_mp4 = os.path.join(pdir, f"{pid}_enh1080p.mp4")
+                enhance_clip(
+                    mp4,
+                    enh_mp4,
+                    zoom=enhance_zoom,
+                    stabilize=enhance_stabilize,
+                    bitrate=enhance_bitrate,
+                )
+                logging.info(f"[enhance] {pid} -> {os.path.basename(enh_mp4)}")
+
             # Add a symlink with the predicted play name for easier review
             canon = r.get("clf_top1_canon") or r.get("play_family") or ""
             safe = _safe_name(canon).replace(" ", "_")
@@ -809,6 +924,21 @@ def main(argv=None) -> None:
     )
     p.add_argument("--debug-weak", action="store_true")
 
+    p.add_argument("--enhance", action="store_true", help="enhance exported clips")
+    p.add_argument(
+        "--enhance-zoom", type=float, default=0.95, help="zoom factor for enhancement"
+    )
+    p.add_argument(
+        "--enhance-stabilize",
+        action="store_true",
+        help="apply stabilization if vid.stab filters are available",
+    )
+    p.add_argument(
+        "--enhance-bitrate",
+        default="10M",
+        help="target bitrate for enhanced clips",
+    )
+
     group = p.add_mutually_exclusive_group()
     group.add_argument(
         "--require-classifier",
@@ -846,6 +976,10 @@ def main(argv=None) -> None:
         generate_clips=args.generate_clips,
         debug_weak=args.debug_weak,
         require_classifier=args.require_classifier,
+        enhance=args.enhance,
+        enhance_zoom=args.enhance_zoom,
+        enhance_stabilize=args.enhance_stabilize,
+        enhance_bitrate=args.enhance_bitrate,
     )
 
 

--- a/docs/enhancement.md
+++ b/docs/enhancement.md
@@ -1,0 +1,30 @@
+# Clip Enhancement
+
+Add-on filters to stabilize, denoise and upscale clips. Works as a batch
+process or as an optional post-step in the analysis pipeline.
+
+## Batch existing clips
+```bash
+chmod +x scripts/enhance_batch.sh
+./scripts/enhance_batch.sh "output/coach_cut_20250906/clips" "output/coach_cut_20250906/enhanced_stab" 0.95 10M
+```
+Fast (no stabilization): set zoom to `1.00`; script auto-skips vidstab if not available.
+
+## Auto-enhance in pipeline
+```bash
+python -m analysis.pipeline \
+  --video path/to/game.mkv \
+  --team "MCA 5th (White)" \
+  --playbook playbooks/mca_5th_playbook.json \
+  --out output/coach_cut_20250906 \
+  --generate-clips \
+  --enhance \
+  --enhance-stabilize \
+  --enhance-zoom 0.95 \
+  --enhance-bitrate 10M
+```
+
+## Troubleshooting
+- "No .mp4 or .mkv files found" → check input directory/glob.
+- Missing `vidstabdetect`/`vidstabtransform` → stabilization step skipped.
+- Use bitrate 10–12M; higher for fewer artifacts.

--- a/scripts/enhance_batch.sh
+++ b/scripts/enhance_batch.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Batch video enhancement script
+# Usage: enhance_batch.sh INDIR OUTDIR ZOOM BITRATE
+# Defaults: INDIR=output/coach_cut_<date>/clips
+#          OUTDIR=output/coach_cut_<date>/enhanced_stab
+#          ZOOM=0.95 BITRATE=10M
+
+TODAY=$(date +%Y%m%d)
+INDIR=${1:-"output/coach_cut_${TODAY}/clips"}
+OUTDIR=${2:-"output/coach_cut_${TODAY}/enhanced_stab"}
+ZOOM=${3:-0.95}
+BITRATE=${4:-10M}
+
+if [ ! -d "$INDIR" ]; then
+    echo "INDIR does not exist: $INDIR" >&2
+    exit 1
+fi
+
+shopt -s nullglob
+FILES=("$INDIR"/*.mp4 "$INDIR"/*.mkv)
+if [ ${#FILES[@]} -eq 0 ]; then
+    echo "No .mp4 or .mkv files found in $INDIR" >&2
+    exit 1
+fi
+mkdir -p "$OUTDIR"
+
+# Detect vid.stab availability
+if ffmpeg -hide_banner -filters 2>/dev/null | grep -q 'vidstabdetect' && \
+   ffmpeg -hide_banner -filters 2>/dev/null | grep -q 'vidstabtransform'; then
+    HAS_VIDSTAB=1
+else
+    HAS_VIDSTAB=0
+fi
+
+COUNT=0
+for SRC in "${FILES[@]}"; do
+    BASE=$(basename "${SRC%.*}")
+    TRF="$OUTDIR/${BASE}.trf"
+    VF=""
+    if [ "$HAS_VIDSTAB" -eq 1 ]; then
+        ffmpeg -hide_banner -y -i "$SRC" -vf "vidstabdetect=result=$TRF" -f null - >/dev/null 2>&1 || true
+        VF="vidstabtransform=input=$TRF:zoom=0:smoothing=30,"
+    fi
+    VF+="zscale=rangein=limited:range=limited,hqdn3d=0:0:3:3,unsharp=lx=7:ly=7:la=0.9,deband,eq=contrast=1.08:saturation=1.08:gamma=1.02"
+    if awk "BEGIN{exit !($ZOOM>=0.5 && $ZOOM<1.0)}"; then
+        VF+=",crop=iw*${ZOOM}:ih*${ZOOM}:(iw-iw*${ZOOM})/2:(ih-ih*${ZOOM})/2"
+    fi
+    VF+=",scale=1920:1080:flags=lanczos,sharpen=0:0.6"
+
+    OUT="$OUTDIR/${BASE}_enh1080p.mp4"
+    ffmpeg -hide_banner -y -i "$SRC" -vf "$VF" \
+        -c:v h264_v4l2m2m -b:v "$BITRATE" -maxrate "$BITRATE" -bufsize "2$BITRATE" \
+        -pix_fmt yuv420p -r 30 -g 60 \
+        -c:a aac -b:a 160k -ar 48000 \
+        -movflags +faststart "$OUT"
+    if [ "$HAS_VIDSTAB" -eq 1 ]; then rm -f "$TRF"; fi
+    echo "enhanced $(basename "$SRC") -> $OUT"
+    COUNT=$((COUNT+1))
+
+done
+
+echo "Processed $COUNT files -> $OUTDIR"


### PR DESCRIPTION
## Summary
- Add portable `scripts/enhance_batch.sh` to stabilize, denoise, sharpen, color-pop, zoom and upscale clips
- Integrate enhancement into `analysis/pipeline.py` with new `--enhance` flags and helper
- Document usage in `docs/enhancement.md`

## Testing
- `pytest -q` *(fails: module 'gameday' has no attribute 'parse_args'; SyntaxError in play_classifier.py)*

------
https://chatgpt.com/codex/tasks/task_e_68bccae4fc84832dacf9408ad821780a