### PR TITLE
Add robust video enhancement and coaches cut tools

### DIFF
--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -62,17 +62,27 @@ def enhance_clip(
         if _probe_vidstab():
             trf_path = f"{out_path}.trf"
             _ffmpeg(
+                "-fflags",
+                "+genpts",
+                "-use_wallclock_as_timestamps",
+                "1",
                 "-i",
                 in_path,
+                "-map",
+                "0:v:0",
+                "-an",
                 "-vf",
-                f"vidstabdetect=result={trf_path}",
+                f"fps=30,format=yuv420p,vidstabdetect=shakiness=5:accuracy=15:result={trf_path}",
+                "-vsync",
+                "1",
                 "-f",
                 "null",
                 "-",
             )
-            filters.append(
-                f"vidstabtransform=input={trf_path}:zoom=0:smoothing=30"
-            )
+            if os.path.exists(trf_path) and os.path.getsize(trf_path) > 0:
+                filters.append(
+                    f"vidstabtransform=input={trf_path}:smoothing=30:zoom=0"
+                )
         else:
             logger.warning("vid.stab filters not available; skipping stabilization")
 
@@ -89,10 +99,10 @@ def enhance_clip(
         filters.append(
             f"crop=iw*{zoom}:ih*{zoom}:(iw-iw*{zoom})/2:(ih-ih*{zoom})/2"
         )
-    filters.extend(["scale=1920:1080:flags=lanczos", "sharpen=0:0.6"])
+    filters.append("scale=1920:1080:flags=lanczos")
     vf = ",".join(filters)
 
-    _ffmpeg(
+    cmd = [
         "-i",
         in_path,
         "-vf",
@@ -104,23 +114,29 @@ def enhance_clip(
         "-maxrate",
         bitrate,
         "-bufsize",
-        f"2{bitrate}",
-        "-pix_fmt",
-        "yuv420p",
-        "-r",
-        "30",
-        "-g",
-        "60",
+        bitrate,
         "-c:a",
-        "aac",
-        "-b:a",
-        "160k",
-        "-ar",
-        "48000",
-        "-movflags",
-        "+faststart",
+        "copy",
         out_path,
-    )
+    ]
+    proc = _ffmpeg(*cmd)
+    if proc.returncode != 0:
+        cmd = [
+            "-i",
+            in_path,
+            "-vf",
+            vf,
+            "-c:v",
+            "libx264",
+            "-preset",
+            "veryfast",
+            "-crf",
+            "18",
+            "-c:a",
+            "copy",
+            out_path,
+        ]
+        _ffmpeg(*cmd)
 
     if trf_path:
         try:
@@ -240,6 +256,7 @@ def run_pipeline(
     enhance_zoom: float = 0.95,
     enhance_stabilize: bool = False,
     enhance_bitrate: str = "10M",
+    enhance_meta_zoom: bool = False,
     auto_zoom: bool = False,
     zoom_max: float = 1.8,
     zoom_min: float = 1.1,
@@ -637,15 +654,26 @@ def run_pipeline(
             r["clip_path"] = mp4
 
             if enhance:
+                zoom_val = enhance_zoom
+                if enhance_meta_zoom:
+                    pf = (r.get("play_family") or "").lower()
+                    if pf == "run":
+                        zoom_val = 0.90
+                    elif pf in {"pass", "punt", "kick"}:
+                        zoom_val = 0.98
+                    else:
+                        zoom_val = 0.95
                 enh_mp4 = os.path.join(pdir, f"{pid}_enh1080p.mp4")
                 enhance_clip(
                     mp4,
                     enh_mp4,
-                    zoom=enhance_zoom,
+                    zoom=zoom_val,
                     stabilize=enhance_stabilize,
                     bitrate=enhance_bitrate,
                 )
-                logging.info(f"[enhance] {pid} -> {os.path.basename(enh_mp4)}")
+                logging.info(
+                    f"[enhance] {pid} zoom={zoom_val:.2f} -> {os.path.basename(enh_mp4)}"
+                )
 
             if auto_zoom:
                 from .autozoom import enhance_clip as autozoom_clip
@@ -961,6 +989,11 @@ def main(argv=None) -> None:
         default="10M",
         help="target bitrate for enhanced clips",
     )
+    p.add_argument(
+        "--enhance-meta-zoom",
+        action="store_true",
+        help="set zoom from clip metadata if available",
+    )
     p.add_argument("--auto-zoom", action="store_true", help="auto crop/zoom clips")
     p.add_argument("--zoom-max", type=float, default=1.8, help="max zoom factor")
     p.add_argument("--zoom-min", type=float, default=1.1, help="min zoom factor")
@@ -1023,6 +1056,7 @@ def main(argv=None) -> None:
         enhance_zoom=args.enhance_zoom,
         enhance_stabilize=args.enhance_stabilize,
         enhance_bitrate=args.enhance_bitrate,
+        enhance_meta_zoom=args.enhance_meta_zoom,
         auto_zoom=args.auto_zoom,
         zoom_max=args.zoom_max,
         zoom_min=args.zoom_min,

--- a/docs/enhancement.md
+++ b/docs/enhancement.md
@@ -1,28 +1,43 @@
-# Clip Enhancement
+# Video Enhancement Tools
 
-Add-on filters to stabilize, denoise and upscale clips. Works as a batch
-process or as an optional post-step in the analysis pipeline.
+This repository provides utilities to stabilise, denoise and upscale game film.
 
-## Setup
+## Batch Enhancement
+
+Use `scripts/enhance_batch.sh` to process a directory of clips.
+
 ```bash
-chmod +x scripts/ai_upscale.sh scripts/stabilize.sh scripts/enhance_batch.sh scripts/install_realesrgan_ncnn.sh
+./scripts/enhance_batch.sh INPUT_DIR OUTPUT_DIR [ZOOM] [BITRATE]
 ```
 
-## Batch existing clips
-```bash
-./scripts/enhance_batch.sh "output/coach_cut_20250906/clips" "output/coach_cut_20250906/enhanced_ai" 18 10M --ai --scale 2 --engine realesrgan --stabilize
-```
-Fast (no stabilization): omit `--stabilize`. If `realesrgan-ncnn-vulkan` is not
-installed the script falls back to FFmpeg upscaling.
+- **ZOOM** – optional center crop (default `0.95`). Values `0.5-1.0` keep the field in view.
+- **BITRATE** – target video bitrate (default `10M`).
+- Hardware encoding uses `h264_v4l2m2m` when available and falls back to `libx264`.
+- Stabilisation via `vid.stab` runs automatically when the filter is present.
 
-## Install Real-ESRGAN (optional)
+Each enhanced clip is written as `*_enh1080p.mp4` in the output directory.
+
+## Coaches Cut
+
+`scripts/make_coaches_cut.sh` enhances today's clips and builds a single
+coaches-cut video.
+
 ```bash
-./scripts/install_realesrgan_ncnn.sh
+./scripts/make_coaches_cut.sh [DATE] [OUTDIR] [MODE]
 ```
-Follow the printed steps; if you skip, the pipeline uses FFmpeg fallback.
+
+- **DATE** – `YYYYMMDD` (defaults to today).
+- **OUTDIR** – destination for the final MP4.
+- **MODE** – `clips`, `raw` or `both` (default `clips`).
+
+Zoom is chosen per clip using play metadata when available
+(`run`→0.90, `pass`→0.98, `punt/kick`→1.00, else 0.95).
 
 ## Troubleshooting
-- "No videos in ..." → check input directory/glob.
-- Missing `realesrgan-ncnn-vulkan` → AI upscaling falls back to FFmpeg.
-- Missing `vidstabdetect`/`vidstabtransform` → stabilization step skipped.
-- Use bitrate 10–12M; higher for fewer artifacts.
+
+- **Missing vid.stab filters** – stabilisation is skipped automatically.
+  Install `ffmpeg` with vid.stab support if required.
+- **Hardware encoder busy** – the scripts retry with `libx264 -preset veryfast -crf 18`.
+- **Truncated files** – files still being written are skipped using a size check and
+  `ffprobe` validation.
+- **Bitrate** – 10–12M works well for 1080p output; increase for higher quality.

--- a/scripts/enhance_batch.sh
+++ b/scripts/enhance_batch.sh
@@ -1,65 +1,97 @@
 #!/usr/bin/env bash
 set -euo pipefail
-# enhance_batch.sh <in_dir> <out_dir> [crf] [bitrate] [--ai] [--scale 2|3|4] [--engine realesrgan|ffmpeg] [--stabilize]
-in_dir="${1:?in_dir}"; out_dir="${2:?out_dir}"
-crf="${3:-23}"
-bitrate="${4:-10M}"
+
+# Usage: enhance_batch.sh INDIR OUTDIR [ZOOM] [BITRATE] [--keep-trf]
+INDIR="${1:-}"
+OUTDIR="${2:-}"
+ZOOM="${3:-0.95}"
+BITRATE="${4:-10M}"
 shift $(( $#>=4 ? 4 : $# )) || true
-
-ai=0
-scale=2
-engine="realesrgan"
-do_stab=0
-
+KEEP_TRF=0
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --ai) ai=1; shift ;;
-    --scale) scale="${2:?}"; shift 2 ;;
-    --engine) engine="${2:?}"; shift 2 ;;
-    --stabilize) do_stab=1; shift ;;
+    --keep-trf) KEEP_TRF=1; shift ;;
     *) echo "[enhance_batch] Unknown arg: $1" >&2; exit 2 ;;
   esac
 done
 
-mkdir -p "$out_dir"
+if [[ -z "$INDIR" || -z "$OUTDIR" ]]; then
+  echo "Usage: $0 INDIR OUTDIR [ZOOM] [BITRATE] [--keep-trf]" >&2
+  exit 1
+fi
 
-shopt -s nullglob
-mapfile -t files < <(find "$in_dir" -maxdepth 1 -type f \( -iname '*.mp4' -o -iname '*.mkv' -o -iname '*.mov' \) | sort)
+mkdir -p "$OUTDIR"
 
-if ((${#files[@]}==0)); then
-  echo "[enhance_batch] No videos in $in_dir"
+FILTERS_OUT=$(ffmpeg -hide_banner -filters 2>/dev/null || true)
+HAS_VIDSTAB=0
+if grep -q vidstabdetect <<<"$FILTERS_OUT" && grep -q vidstabtransform <<<"$FILTERS_OUT"; then
+  HAS_VIDSTAB=1
+fi
+
+HAS_HW=0
+if ffmpeg -hide_banner -encoders 2>/dev/null | grep -q h264_v4l2m2m; then
+  HAS_HW=1
+fi
+
+mapfile -t FILES < <(find "$INDIR" -maxdepth 1 -type f \( -iname '*.mp4' -o -iname '*.mkv' \) | sort)
+if ((${#FILES[@]}==0)); then
+  echo "[enhance_batch] No videos in $INDIR"
   exit 0
 fi
 
-# Ensure helper scripts are executable
-chmod +x "$(dirname "$0")"/ai_upscale.sh "$(dirname "$0")"/stabilize.sh
+for IN in "${FILES[@]}"; do
+  BN="$(basename "$IN")"
+  BASE="${BN%.*}"
+  OUT="$OUTDIR/${BASE}_enh1080p.mp4"
+  TRF="$OUTDIR/${BASE}.trf"
 
-for f in "${files[@]}"; do
-  bn="$(basename "$f")"
-  base="${bn%.*}"
-  tgt="$out_dir/${base}_enh.mp4"
-  tmp="$(mktemp -d)"
-  trap 'rm -rf "$tmp"' EXIT
-
-  src="$f"
-
-  if (( do_stab )); then
-    stab="$tmp/${base}_stab.mp4"
-    "$(dirname "$0")/stabilize.sh" "$src" "$stab"
-    src="$stab"
+  S1=$(stat -c %s "$IN")
+  sleep 3
+  S2=$(stat -c %s "$IN")
+  if [[ "$S1" != "$S2" ]]; then
+    echo "[enhance_batch] Skip $BN (size unstable)"
+    continue
   fi
 
-  if (( ai )); then
-    # AI upscaling
-    up="$tmp/${base}_ai.mp4"
-    "$(dirname "$0")/ai_upscale.sh" "$src" "$up" --scale "$scale" --engine "$engine" --crf 18
-    src="$up"
+  if ! ffprobe -v error -select_streams v:0 -show_entries stream=codec_type -of csv=p=0 "$IN" | grep -q '^video$'; then
+    echo "[enhance_batch] Skip $BN (no video stream)"
+    continue
   fi
 
-  # Final encode stage (bitrate target if provided), keep dimensions produced by previous stage
-  ffmpeg -hide_banner -y -i "$src" \
-    -c:v libx264 -preset veryfast -crf "$crf" -b:v "$bitrate" -pix_fmt yuv420p \
-    -c:a aac -b:a 160k "$tgt"
+  STAB=""
+  if [[ $HAS_VIDSTAB -eq 1 ]]; then
+    ffmpeg -hide_banner -y -fflags +genpts -use_wallclock_as_timestamps 1 -i "$IN" \
+      -map 0:v:0 -an -vf "fps=30,format=yuv420p,vidstabdetect=shakiness=5:accuracy=15:result=$TRF" \
+      -vsync 1 -f null - || true
+    if [[ -s "$TRF" ]]; then
+      STAB="vidstabtransform=input=$TRF:smoothing=30:zoom=0,"
+    fi
+  fi
 
-  echo "[enhance_batch] Wrote: $tgt"
+  CROP=""
+  if awk "BEGIN{exit !($ZOOM>=0.5 && $ZOOM<1.0)}"; then
+    CROP="crop=iw*$ZOOM:ih*$ZOOM:(iw-iw*$ZOOM)/2:(ih-ih*$ZOOM)/2,"
+  fi
+
+  FILTER="${STAB}zscale=rangein=limited:range=limited,hqdn3d=0:0:3:3,unsharp=lx=7:ly=7:la=0.9,deband,eq=contrast=1.08:saturation=1.08:gamma=1.02,${CROP}scale=1920:1080:flags=lanczos"
+
+  CMD=(ffmpeg -hide_banner -y -i "$IN" -vf "$FILTER" -c:a copy)
+  if [[ $HAS_HW -eq 1 ]]; then
+    CMD+=(-c:v h264_v4l2m2m -b:v "$BITRATE" -maxrate "$BITRATE" -bufsize "$BITRATE")
+  else
+    CMD+=(-c:v libx264 -preset veryfast -crf 18)
+  fi
+  CMD+=("$OUT")
+
+  if ! "${CMD[@]}"; then
+    echo "[enhance_batch] HW encode failed for $BN, retrying with libx264"
+    ffmpeg -hide_banner -y -i "$IN" -vf "$FILTER" -c:a copy \
+      -c:v libx264 -preset veryfast -crf 18 "$OUT"
+  fi
+
+  if [[ $KEEP_TRF -ne 1 ]]; then
+    rm -f "$TRF"
+  fi
+
+  echo "[enhance_batch] Wrote $OUT"
 done

--- a/scripts/make_coaches_cut.sh
+++ b/scripts/make_coaches_cut.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DATE="${1:-$(date +%Y%m%d)}"
+CUT_OUTDIR="${2:-output/coach_cut_${DATE}/coaches_cut}"
+MODE="${3:-clips}"
+shift $(( $#>=3 ? 3 : $# )) || true
+KEEP_TMP=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --keep-tmp) KEEP_TMP=1; shift ;;
+    *) echo "[make_coaches_cut] Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+mkdir -p "$CUT_OUTDIR"
+DATE_FMT="$(date -d "$DATE" +%Y-%m-%d)"
+
+clip_dirs=()
+if [[ "$MODE" == "clips" || "$MODE" == "both" ]]; then
+  while IFS= read -r d; do
+    if find "$d" -maxdepth 1 -type f \( -iname '*.mp4' -o -iname '*.mkv' \) \
+         -newermt "$DATE_FMT" ! -newermt "$DATE_FMT +1 day" | grep -q .; then
+      clip_dirs+=("$d")
+    fi
+  done < <(find output -type d -path "*/clips/*" 2>/dev/null | sort -V)
+fi
+
+raw_dirs=()
+if [[ ("$MODE" == "raw" || "$MODE" == "both") && -d recordings/raw ]]; then
+  while IFS= read -r f; do
+    raw_dirs+=("$(dirname "$f")")
+  done < <(find recordings/raw -type f -newermt "$DATE_FMT" ! -newermt "$DATE_FMT +1 day" \
+           \( -iname '*.mp4' -o -iname '*.mkv' \) 2>/dev/null | sort)
+  if ((${#raw_dirs[@]})); then
+    tmp_dirs=$(printf "%s\n" "${raw_dirs[@]}" | sort -u)
+    mapfile -t raw_dirs <<<"$tmp_dirs"
+  fi
+fi
+
+processed=0
+enhanced_files=()
+
+for dir in "${clip_dirs[@]}"; do
+  clip=$(find "$dir" -maxdepth 1 -type f \( -iname '*.mp4' -o -iname '*.mkv' \) | head -n1)
+  zoom=0.95
+  if [[ -n "$clip" ]]; then
+    meta="${clip%.*}.json"
+    if [[ -f "$meta" ]]; then
+      pf=$(python - "$meta" <<'PY'
+import json,sys
+print(json.load(open(sys.argv[1])).get('play_family','').lower())
+PY
+)
+      case "$pf" in
+        run) zoom=0.90 ;;
+        pass) zoom=0.98 ;;
+        punt|kick) zoom=1.00 ;;
+        *) zoom=0.95 ;;
+      esac
+    fi
+  fi
+  outdir="$dir/enhanced_stab"
+  "$SCRIPT_DIR/enhance_batch.sh" "$dir" "$outdir" "$zoom" || true
+  mapfile -t new_files < <(find "$outdir" -maxdepth 1 -type f -name '*_enh1080p.mp4' | sort -V)
+  enhanced_files+=("${new_files[@]}")
+  ((processed++))
+done
+
+if [[ "$MODE" == "raw" || "$MODE" == "both" ]]; then
+  for dir in "${raw_dirs[@]}"; do
+    outdir="$dir/enhanced_stab"
+    "$SCRIPT_DIR/enhance_batch.sh" "$dir" "$outdir" "0.95" || true
+    mapfile -t new_files < <(find "$outdir" -maxdepth 1 -type f -name '*_enh1080p.mp4' | sort -V)
+    enhanced_files+=("${new_files[@]}")
+    ((processed++))
+  done
+fi
+
+if ((${#enhanced_files[@]}==0)); then
+  echo "[make_coaches_cut] No clips found for $DATE"
+  exit 0
+fi
+
+tmp_list=$(mktemp)
+{
+  echo "ffconcat version 1.0"
+  for f in "${enhanced_files[@]}"; do
+    echo "file '$f'"
+  done
+} > "$tmp_list"
+
+output_file="$CUT_OUTDIR/coaches_cut_enh1080p.mp4"
+if ! ffmpeg -hide_banner -y -f concat -safe 0 -i "$tmp_list" -c copy "$output_file"; then
+  echo "[make_coaches_cut] Stream copy failed; re-encoding"
+  if ffmpeg -hide_banner -encoders 2>/dev/null | grep -q h264_v4l2m2m; then
+    if ! ffmpeg -hide_banner -y -f concat -safe 0 -i "$tmp_list" \
+      -c:v h264_v4l2m2m -b:v 10M -maxrate 10M -bufsize 10M -c:a aac -b:a 160k "$output_file"; then
+      ffmpeg -hide_banner -y -f concat -safe 0 -i "$tmp_list" \
+        -c:v libx264 -preset veryfast -crf 18 -c:a aac -b:a 160k "$output_file"
+    fi
+  else
+    ffmpeg -hide_banner -y -f concat -safe 0 -i "$tmp_list" \
+      -c:v libx264 -preset veryfast -crf 18 -c:a aac -b:a 160k "$output_file"
+  fi
+fi
+
+if [[ $KEEP_TMP -eq 0 ]]; then
+  rm -f "$tmp_list"
+else
+  mv "$tmp_list" "$CUT_OUTDIR/concat_list.txt"
+fi
+find "$CUT_OUTDIR" -type f -name '*.trf' -delete 2>/dev/null || true
+
+echo "[make_coaches_cut] Wrote $output_file from ${#enhanced_files[@]} clips"


### PR DESCRIPTION
## Summary
- add `scripts/enhance_batch.sh` with vid.stab detection, encoder fallback and zoom support
- introduce `scripts/make_coaches_cut.sh` orchestrator for building a coaches-cut
- expose optional metadata-based zoom in `analysis/pipeline.py` and document enhancement workflow

## Testing
- `bash -n scripts/enhance_batch.sh`
- `bash -n scripts/make_coaches_cut.sh`
- `python -m py_compile analysis/pipeline.py`
- `pytest tests/test_pipeline_smoke.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd7e9a391c832db1dd70423582b821