### PR TITLE
Implement field homography calibration and yard cropper

### DIFF
--- a/analysis/vision/field_calibration.py
+++ b/analysis/vision/field_calibration.py
@@ -6,24 +6,35 @@ field coordinates.  Calibration is stored as JSON with ``image_points``
 coordinates in yards).  The JSON file can be generated once offline and
 reused for subsequent runs.
 """
+
 from __future__ import annotations
 
 import json
 import os
-from typing import Sequence, Tuple
+from typing import Sequence, Tuple, List, Optional
 
-import cv2
 import numpy as np
 
 Point = Tuple[float, float]
 
 
+FIELD_POINTS: List[Point] = [
+    (0.0, 0.0),
+    (120.0, 0.0),
+    (120.0, 53.3),
+    (0.0, 53.3),
+]
+
+DEFAULT_CALIB_PATH = os.path.join("configs", "field_homography.json")
+
+
 class FieldCalibrator:
     """Load and apply a homography for the playing field."""
 
-    def __init__(self, calib_path: str | None = None) -> None:
+    def __init__(self, calib_path: str | None = None, h: np.ndarray | None = None) -> None:
         self.calib_path = calib_path
-        self.h: np.ndarray | None = None
+        self.h: np.ndarray | None = h
+        self.h_inv: np.ndarray | None = None if h is None else np.linalg.inv(h)
         if calib_path and os.path.exists(calib_path):
             self.load(calib_path)
 
@@ -33,36 +44,112 @@ class FieldCalibrator:
 
         with open(path, "r", encoding="utf-8") as fh:
             data = json.load(fh)
-        src = np.array(data["image_points"], dtype=np.float32)
-        dst = np.array(data["field_points"], dtype=np.float32)
-        self.h, _ = cv2.findHomography(src, dst)
+        if "H" in data:
+            self.h = np.array(data["H"], dtype=np.float64)
+            self.h_inv = np.array(data["H_inv"], dtype=np.float64)
+        else:
+            src = np.array(data["image_points"], dtype=np.float32)
+            dst = np.array(data["field_points"], dtype=np.float32)
+            self.h, self.h_inv = compute_homography(src, dst)
 
     # ------------------------------------------------------------------
     def pixel_to_field(self, pt: Point) -> Point | None:
         if self.h is None:
             return None
         x, y = pt
-        vec = np.array([x, y, 1.0], dtype=np.float32)
+        vec = np.array([x, y, 1.0], dtype=np.float64)
         dst = self.h @ vec
         return float(dst[0] / dst[2]), float(dst[1] / dst[2])
 
     # ------------------------------------------------------------------
     def field_to_pixel(self, pt: Point) -> Point | None:
-        if self.h is None:
+        if self.h_inv is None and self.h is None:
             return None
+        if self.h_inv is None:
+            self.h_inv = np.linalg.inv(self.h)  # type: ignore[arg-type]
         x, y = pt
-        h_inv = np.linalg.inv(self.h)
-        vec = np.array([x, y, 1.0], dtype=np.float32)
-        dst = h_inv @ vec
+        vec = np.array([x, y, 1.0], dtype=np.float64)
+        dst = self.h_inv @ vec
         return float(dst[0] / dst[2]), float(dst[1] / dst[2])
 
 
 def compute_homography(
     image_points: Sequence[Point], field_points: Sequence[Point]
-) -> np.ndarray:
-    """Return a homography matrix for the provided correspondences."""
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Return a homography matrix and its inverse."""
 
-    src = np.array(list(image_points), dtype=np.float32)
-    dst = np.array(list(field_points), dtype=np.float32)
-    h, _ = cv2.findHomography(src, dst)
-    return h
+    src = np.array(list(image_points), dtype=np.float64)
+    dst = np.array(list(field_points), dtype=np.float64)
+    if src.shape != (4, 2) or dst.shape != (4, 2):
+        raise ValueError("Need four source and destination points")
+    A = []
+    for (x, y), (X, Y) in zip(src, dst):
+        A.append([-x, -y, -1, 0, 0, 0, x * X, y * X, X])
+        A.append([0, 0, 0, -x, -y, -1, x * Y, y * Y, Y])
+    A = np.array(A, dtype=np.float64)
+    _, _, Vt = np.linalg.svd(A)
+    h = Vt[-1].reshape(3, 3)
+    h /= h[2, 2]
+    h_inv = np.linalg.inv(h)
+    return h, h_inv
+
+
+def img_to_field(pt: Point, h: np.ndarray) -> Point:
+    x, y = pt
+    vec = np.array([x, y, 1.0], dtype=np.float64)
+    dst = h @ vec
+    return float(dst[0] / dst[2]), float(dst[1] / dst[2])
+
+
+def field_to_img(pt: Point, h_inv: np.ndarray) -> Point:
+    x, y = pt
+    vec = np.array([x, y, 1.0], dtype=np.float64)
+    dst = h_inv @ vec
+    return float(dst[0] / dst[2]), float(dst[1] / dst[2])
+
+
+def calibrate_from_clicks(
+    frame: np.ndarray,
+    save_path: str = DEFAULT_CALIB_PATH,
+    clicks: Optional[Sequence[Point]] = None,
+) -> FieldCalibrator:
+    """Interactively (or programmatically) compute and save a field homography."""
+
+    if clicks is None:
+        import cv2  # Imported lazily to avoid dependency for tests
+
+        pts: List[Point] = []
+
+        def on_click(event, x, y, _flags, _param) -> None:
+            nonlocal pts
+            if event == cv2.EVENT_LBUTTONDOWN and len(pts) < 4:
+                pts.append((float(x), float(y)))
+                cv2.circle(frame, (x, y), 5, (0, 0, 255), -1)
+                cv2.imshow("calibrate", frame)
+
+        clone = frame.copy()
+        cv2.imshow("calibrate", clone)
+        cv2.setMouseCallback("calibrate", on_click)
+        while len(pts) < 4:
+            cv2.waitKey(10)
+        cv2.destroyWindow("calibrate")
+        image_points = pts
+    else:
+        image_points = list(clicks)
+
+    h, h_inv = compute_homography(image_points, FIELD_POINTS)
+
+    data = {
+        "image_points": [list(p) for p in image_points],
+        "field_points": [list(p) for p in FIELD_POINTS],
+        "H": h.tolist(),
+        "H_inv": h_inv.tolist(),
+        "field_dims": {"length": 120.0, "width": 53.3},
+    }
+
+    os.makedirs(os.path.dirname(save_path), exist_ok=True)
+    with open(save_path, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2)
+
+    return FieldCalibrator(calib_path=save_path, h=h)
+

--- a/analysis/vision/yard_cropper.py
+++ b/analysis/vision/yard_cropper.py
@@ -1,59 +1,156 @@
-"""Compute a cropped view centred on the ball.
+"""Crop a view centred on the ball using field homography information.
 
-Given the estimated ball position in pixel coordinates, ``YardCropper``
-produces a crop rectangle that spans ``±N`` yards horizontally around the
-ball (default 20).  When calibration data is available the yard-to-pixel
-conversion is based on the homography; otherwise a simple fraction of the
-frame width is used.  Basic temporal smoothing is applied to avoid
-jarring jumps.
+``YardCropper`` operates in field coordinates (yards) and converts the
+desired window back into image pixel coordinates via the inverse
+homography.  A small amount of temporal smoothing is applied and per
+frame movement is limited to avoid jitter.
 """
+
 from __future__ import annotations
 
-from typing import Tuple
+from dataclasses import dataclass
+from typing import Optional, Tuple
 
-from .field_calibration import FieldCalibrator
+import numpy as np
+
+from .field_calibration import field_to_img
 
 
+@dataclass
 class YardCropper:
-    def __init__(
-        self,
-        calibrator: FieldCalibrator | None,
-        crop_yards: int = 20,
-        smooth: float = 0.8,
-    ) -> None:
-        self.calibrator = calibrator
-        self.crop_yards = crop_yards
-        self.smooth = smooth
-        self.last: Tuple[int, int, int, int] | None = None
+    """Compute a crop rectangle around the ball.
 
-    def _yards_to_pixels(self, yards: float, ref_pt: Tuple[int, int]) -> int:
-        if self.calibrator and self.calibrator.h is not None:
-            fx = self.calibrator.pixel_to_field(ref_pt)
-            if fx is not None:
-                left = self.calibrator.field_to_pixel((fx[0] - yards, fx[1]))
-                right = self.calibrator.field_to_pixel((fx[0] + yards, fx[1]))
-                if left and right:
-                    return int(abs(right[0] - left[0]))
-        # Fallback – assume 10 yards ~ 1/6th of the frame width
-        return int(ref_pt[0] * (yards / 30.0))
+    Parameters
+    ----------
+    H:
+        Homography mapping image pixels to field coordinates.  ``None``
+        disables the calibration behaviour and the full frame is
+        returned.
+    yards_window:
+        Total horizontal span of the crop in yards (default ``40``).
+    aspect:
+        Desired aspect ratio of the crop (default ``16/9``).
+    smooth:
+        Exponential moving average factor for temporal smoothing.
+    max_move:
+        Maximum allowed per frame movement expressed as a fraction of the
+        frame width.
+    timeout:
+        Number of consecutive frames without a ball position before
+        defaulting to a wide "coach" view.
+    """
 
-    def compute(self, frame_shape: Tuple[int, int, int], ball_pt: Tuple[int, int]) -> Tuple[int, int, int, int]:
+    H: Optional[np.ndarray]
+    yards_window: float = 40.0
+    aspect: float = 16 / 9
+    smooth: float = 0.9
+    max_move: float = 0.06
+    timeout: int = 30
+
+    def __post_init__(self) -> None:  # type: ignore[override]
+        self.h_inv: Optional[np.ndarray] = None if self.H is None else np.linalg.inv(self.H)
+        self.last: Optional[Tuple[float, float, float, float]] = None
+        self.missing = 0
+        self.field_width = 53.3
+
+    # ------------------------------------------------------------------
+    def _default_view(self, frame_shape: Tuple[int, int, int]) -> Tuple[float, float, float, float]:
+        h, w = frame_shape[:2]
+        if w >= 3840 and h >= 2160:
+            x = (w - 3840) // 2
+            y = (h - 2160) // 2
+            return float(x), float(y), 3840.0, 2160.0
+        return 0.0, 0.0, float(w), float(h)
+
+    # ------------------------------------------------------------------
+    def _compute_target(
+        self, ball_xy: Optional[Tuple[float, float]], frame_shape: Tuple[int, int, int]
+    ) -> Optional[Tuple[float, float, float, float]]:
+        if ball_xy is None or self.h_inv is None:
+            return None
+
+        x, y = ball_xy
+        half_w = self.yards_window / 2.0
+        x_min = x - half_w
+        x_max = x + half_w
+        height_yards = self.yards_window / self.aspect
+        y_min = y - height_yards / 2.0
+        y_max = y + height_yards / 2.0
+
+        if y_min < 0:
+            y_max = min(self.field_width, y_max - y_min)
+            y_min = 0.0
+        if y_max > self.field_width:
+            y_min = max(0.0, y_min - (y_max - self.field_width))
+            y_max = self.field_width
+
+        field_corners = [
+            (x_min, y_min),
+            (x_max, y_min),
+            (x_max, y_max),
+            (x_min, y_max),
+        ]
+        img_pts = [field_to_img(pt, self.h_inv) for pt in field_corners]
+        xs = [p[0] for p in img_pts]
+        ys = [p[1] for p in img_pts]
+        h_img, w_img = frame_shape[:2]
+        x0 = max(0.0, min(xs))
+        x1 = min(float(w_img), max(xs))
+        y0 = max(0.0, min(ys))
+        y1 = min(float(h_img), max(ys))
+        return x0, y0, x1 - x0, y1 - y0
+
+    # ------------------------------------------------------------------
+    def compute(
+        self, frame_shape: Tuple[int, int, int], ball_xy: Optional[Tuple[float, float]]
+    ) -> Tuple[int, int, int, int]:
         """Return ``(x, y, w, h)`` crop rectangle for the frame."""
 
-        h, w = frame_shape[:2]
-        cx, cy = ball_pt
-        width = self._yards_to_pixels(self.crop_yards * 2, (cx, cy))
-        width = max(1, min(width, w))
-        x = max(0, min(cx - width // 2, w - width))
-        crop = (x, 0, width, h)
-        if self.last is not None:
+        target = self._compute_target(ball_xy, frame_shape)
+        if target is None:
+            self.missing += 1
+            if self.last is None or self.missing > self.timeout:
+                target = self._default_view(frame_shape)
+            else:
+                target = self.last
+        else:
+            self.missing = 0
+
+        if self.last is None:
+            smoothed = target
+        else:
             lx, ly, lw, lh = self.last
-            alpha = self.smooth
-            crop = (
-                int(alpha * lx + (1 - alpha) * crop[0]),
-                0,
-                int(alpha * lw + (1 - alpha) * crop[2]),
-                h,
+            tx, ty, tw, th = target
+            smoothed = (
+                lx * self.smooth + tx * (1 - self.smooth),
+                ly * self.smooth + ty * (1 - self.smooth),
+                lw * self.smooth + tw * (1 - self.smooth),
+                lh * self.smooth + th * (1 - self.smooth),
             )
-        self.last = crop
-        return crop
+
+            max_move_px = frame_shape[1] * self.max_move
+            cx_last = lx + lw / 2.0
+            cy_last = ly + lh / 2.0
+            cx_new = smoothed[0] + smoothed[2] / 2.0
+            cy_new = smoothed[1] + smoothed[3] / 2.0
+            dx = cx_new - cx_last
+            dy = cy_new - cy_last
+            if abs(dx) > max_move_px:
+                cx_new = cx_last + np.sign(dx) * max_move_px
+            if abs(dy) > max_move_px:
+                cy_new = cy_last + np.sign(dy) * max_move_px
+            smoothed = (
+                cx_new - smoothed[2] / 2.0,
+                cy_new - smoothed[3] / 2.0,
+                smoothed[2],
+                smoothed[3],
+            )
+
+        x, y, w, h = smoothed
+        h_img, w_img = frame_shape[:2]
+        x = max(0.0, min(x, w_img - w))
+        y = max(0.0, min(y, h_img - h))
+        rect = (int(x), int(y), int(w), int(h))
+        self.last = rect
+        return rect
+

--- a/tests/test_field_calibration.py
+++ b/tests/test_field_calibration.py
@@ -1,0 +1,43 @@
+"""Tests for field calibration utilities."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import imageio.v3 as iio
+import numpy as np
+
+from analysis.vision.field_calibration import calibrate_from_clicks
+
+
+def test_calibration_round_trip(tmp_path: Path) -> None:
+    img_path = Path("debug_frame.jpg")
+    frame = iio.imread(str(img_path))
+    assert frame is not None
+    h, w = frame.shape[:2]
+    clicks = [(0.0, 0.0), (w - 1.0, 0.0), (w - 1.0, h - 1.0), (0.0, h - 1.0)]
+    save_path = tmp_path / "field_homography.json"
+    calibrator = calibrate_from_clicks(frame, save_path=str(save_path), clicks=clicks)
+
+    assert save_path.exists()
+    with open(save_path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    assert "H" in data and "H_inv" in data
+
+    pts = np.array(
+        [
+            (w * 0.25, h * 0.25),
+            (w * 0.5, h * 0.5),
+            (w * 0.75, h * 0.75),
+        ],
+        dtype=np.float32,
+    )
+    for x, y in pts:
+        field_pt = calibrator.pixel_to_field((float(x), float(y)))
+        assert field_pt is not None
+        back = calibrator.field_to_pixel(field_pt)
+        assert back is not None
+        err = np.hypot(back[0] - x, back[1] - y)
+        assert err < 3.0
+


### PR DESCRIPTION
## Summary
- Add interactive or programmatic field homography calibration utility and helpers
- Introduce yard-based cropper with smoothing, movement limits, and fallbacks
- Test round-trip accuracy of calibration homography

## Testing
- `pytest tests/test_field_calibration.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c035ac1e8c832dab61bd364f5c456e