### PR TITLE
Add simple smoke and latency check scripts

### DIFF
--- a/tools/latency_check.py
+++ b/tools/latency_check.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Measure capture to display latency for a video source."""
+
+import argparse
+import time
+from typing import Union
+
+import cv2
+
+
+def parse_source(src: str) -> Union[int, str]:
+    try:
+        return int(src)
+    except ValueError:
+        return src
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Measure capture to display latency")
+    parser.add_argument("source", nargs="?", default="0", help="Video file or camera index")
+    parser.add_argument("--frames", type=int, default=100, help="Number of frames to sample")
+    args = parser.parse_args()
+
+    source = parse_source(args.source)
+    cap = cv2.VideoCapture(source)
+    if not cap.isOpened():
+        raise RuntimeError(f"Unable to open source: {source}")
+
+    latencies = []
+    for _ in range(args.frames):
+        ret, frame = cap.read()
+        if not ret:
+            break
+        capture_ts = time.time()
+        # dummy processing step
+        _ = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+        cv2.imshow("frame", frame)
+        cv2.waitKey(1)
+        display_ts = time.time()
+        latencies.append((display_ts - capture_ts) * 1000.0)
+    cap.release()
+    cv2.destroyAllWindows()
+
+    assert latencies, "No frames processed"
+
+    avg = sum(latencies) / len(latencies)
+    maximum = max(latencies)
+    print(f"Average latency: {avg:.1f} ms (max {maximum:.1f} ms)")
+    if avg > 250 or maximum > 250:
+        print("WARNING: Latency exceeds 250 ms target")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/smoke_follow_ball.py
+++ b/tools/smoke_follow_ball.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Simple smoke test for ball tracking pipeline."""
+
+import argparse
+import time
+from typing import Union
+
+import cv2
+import numpy as np
+
+from analysis.tracking.ball_tracker import BallTracker
+
+
+def parse_source(src: str) -> Union[int, str]:
+    """Return camera index if ``src`` is numeric otherwise the string."""
+    try:
+        return int(src)
+    except ValueError:
+        return src
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run ball tracking pipeline for a short period")
+    parser.add_argument("source", nargs="?", default="0", help="Video file or camera index")
+    parser.add_argument("--duration", type=float, default=30.0, help="Duration in seconds")
+    args = parser.parse_args()
+
+    source = parse_source(args.source)
+    cap = cv2.VideoCapture(source)
+    if not cap.isOpened():
+        raise RuntimeError(f"Unable to open source: {source}")
+
+    tracker = BallTracker()
+    confidences = []
+    frames = 0
+    start = time.time()
+    while time.time() - start < args.duration:
+        ret, frame = cap.read()
+        if not ret:
+            break
+        frames += 1
+        result = tracker.update(frame)
+        if result:
+            # result is (x, y, w, h, conf, state)
+            confidences.append(result[4])
+    cap.release()
+
+    assert frames > 0, "No frames recorded"
+
+    elapsed = time.time() - start
+    fps = frames / elapsed if elapsed > 0 else 0.0
+    print(f"Processed {frames} frames in {elapsed:.2f}s ({fps:.2f} FPS)")
+
+    if confidences:
+        hist, bins = np.histogram(confidences, bins=10, range=(0.0, 1.0))
+        print("Tracker confidence histogram:")
+        for count, b0, b1 in zip(hist, bins[:-1], bins[1:]):
+            print(f"{b0:.1f}-{b1:.1f}: {count}")
+    else:
+        print("No confidence values recorded")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `smoke_follow_ball.py` to run ball tracking pipeline for a short smoke test and report FPS/confidence histogram
- add `latency_check.py` utility to measure capture-to-display latency and warn when it exceeds 250ms

## Testing
- `python -m py_compile tools/smoke_follow_ball.py tools/latency_check.py`
- `pytest` *(fails: tests/test_ball_tracker.py, tests/test_gameday_cli.py, tests/test_play_classifier_device.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c0521d99cc832d8e6b175091e3399a