### PR TITLE
Add headless field calibration utility

### DIFF
--- a/analysis/vision/field_calibration.py
+++ b/analysis/vision/field_calibration.py
@@ -108,15 +108,67 @@ def field_to_img(pt: Point, h_inv: np.ndarray) -> Point:
     return float(dst[0] / dst[2]), float(dst[1] / dst[2])
 
 
+def parse_points_str(s: str) -> List[Point]:
+    """Parse a space-separated string of ``x,y`` pairs.
+
+    ``s`` should look like ``"x1,y1 x2,y2 x3,y3 x4,y4"``.  Returns a list of
+    four ``(x, y)`` tuples.  Raises ``ValueError`` if the input is malformed.
+    """
+
+    parts = s.strip().split()
+    if len(parts) != 4:
+        raise ValueError("Expected four x,y pairs")
+    pts: List[Point] = []
+    for part in parts:
+        try:
+            x_str, y_str = part.split(",")
+            pts.append((float(x_str), float(y_str)))
+        except Exception as exc:  # pragma: no cover - defensive
+            raise ValueError(f"Invalid point '{part}'") from exc
+    return pts
+
+
 def calibrate_from_clicks(
     frame: np.ndarray,
-    save_path: str = DEFAULT_CALIB_PATH,
-    clicks: Optional[Sequence[Point]] = None,
+    *,
+    headless: bool = False,
+    points: Optional[Sequence[Point]] = None,
+    save_to: str = DEFAULT_CALIB_PATH,
 ) -> FieldCalibrator:
-    """Interactively (or programmatically) compute and save a field homography."""
+    """Compute and save a field homography.
 
-    if clicks is None:
+    ``frame`` is the image to calibrate.  If ``points`` is provided, it must be
+    a list of four ``(x, y)`` pixel coordinates (clockwise starting near the
+    left goal line corner) and no GUI will be shown.  If ``points`` is ``None``
+    and ``headless`` is ``True``, the frame is written to ``configs/calib_frame.jpg``
+    and a ``RuntimeError`` is raised instructing the caller how to proceed.  If
+    neither ``points`` nor ``headless`` are provided, an interactive OpenCV
+    window is used to collect the clicks.
+    """
+
+    image_points: List[Point]
+
+    if points is not None:
+        image_points = list(points)
+    else:
+        if headless:
+            import cv2  # Lazy import to keep tests light
+
+            calib_frame = os.path.join("configs", "calib_frame.jpg")
+            os.makedirs(os.path.dirname(calib_frame), exist_ok=True)
+            cv2.imwrite(calib_frame, frame)
+            raise RuntimeError(
+                "Run with --points 'x1,y1 x2,y2 x3,y3 x4,y4' or copy configs/calib_frame.jpg to a GUI host to click points."
+            )
+
         import cv2  # Imported lazily to avoid dependency for tests
+        import sys
+
+        # If there's no display, OpenCV will fail.  Provide an actionable error
+        if sys.platform != "win32" and os.environ.get("DISPLAY") in (None, ""):
+            raise RuntimeError(
+                "No display available for calibration. Set DISPLAY or run with --headless."
+            )
 
         pts: List[Point] = []
 
@@ -134,8 +186,6 @@ def calibrate_from_clicks(
             cv2.waitKey(10)
         cv2.destroyWindow("calibrate")
         image_points = pts
-    else:
-        image_points = list(clicks)
 
     h, h_inv = compute_homography(image_points, FIELD_POINTS)
 
@@ -147,9 +197,9 @@ def calibrate_from_clicks(
         "field_dims": {"length": 120.0, "width": 53.3},
     }
 
-    os.makedirs(os.path.dirname(save_path), exist_ok=True)
-    with open(save_path, "w", encoding="utf-8") as fh:
+    os.makedirs(os.path.dirname(save_to), exist_ok=True)
+    with open(save_to, "w", encoding="utf-8") as fh:
         json.dump(data, fh, indent=2)
 
-    return FieldCalibrator(calib_path=save_path, h=h)
+    return FieldCalibrator(calib_path=save_to, h=h)
 

--- a/tests/test_field_calibration.py
+++ b/tests/test_field_calibration.py
@@ -18,7 +18,7 @@ def test_calibration_round_trip(tmp_path: Path) -> None:
     h, w = frame.shape[:2]
     clicks = [(0.0, 0.0), (w - 1.0, 0.0), (w - 1.0, h - 1.0), (0.0, h - 1.0)]
     save_path = tmp_path / "field_homography.json"
-    calibrator = calibrate_from_clicks(frame, save_path=str(save_path), clicks=clicks)
+    calibrator = calibrate_from_clicks(frame, points=clicks, save_to=str(save_path))
 
     assert save_path.exists()
     with open(save_path, "r", encoding="utf-8") as fh:

--- a/tools/calibrate_field.py
+++ b/tools/calibrate_field.py
@@ -2,12 +2,15 @@
 
 Grabs a 4K frame from the primary capture device, lets the user click
 four field corners, saves the homography JSON, and overlays yardline
-and hash mark guides for validation.
+and hash mark guides for validation.  It also supports a headless mode
+for remote servers.
 """
 from __future__ import annotations
 
 import argparse
+import json
 import cv2
+import numpy as np
 
 from analysis.camera.capture import FrameCapture
 from analysis.vision import field_calibration
@@ -45,8 +48,14 @@ def _draw_guides(frame, calib: field_calibration.FieldCalibrator) -> None:
 
 # ---------------------------------------------------------------------------
 def main() -> None:
-    p = argparse.ArgumentParser(description="Interactively calibrate the field")
-    p.add_argument("--device", default="/dev/video0", help="Video device or file")
+    p = argparse.ArgumentParser(description="Calibrate the field")
+    p.add_argument("--source", default="/dev/video0", help="Video device or file")
+    p.add_argument("--frame", help="Use an existing image instead of grabbing a frame")
+    p.add_argument("--headless", action="store_true", help="Run without a GUI")
+    p.add_argument(
+        "--points",
+        help="Space separated 'x,y' pixel pairs (clockwise from left goal line)",
+    )
     p.add_argument(
         "--output",
         default=field_calibration.DEFAULT_CALIB_PATH,
@@ -54,23 +63,57 @@ def main() -> None:
     )
     args = p.parse_args()
 
-    cam = FrameCapture(args.device)
-    cam.warmup(0.5)
-    frame, _ = cam.read()
-    cam.release()
-    if frame is None:
-        raise RuntimeError("Failed to capture frame")
+    if args.frame:
+        frame = cv2.imread(args.frame)
+        if frame is None:
+            raise RuntimeError(f"Failed to read frame from {args.frame}")
+    else:
+        cam = FrameCapture(args.source)
+        cam.warmup(0.5)
+        frame, _ = cam.read()
+        cam.release()
+        if frame is None:
+            raise RuntimeError("Failed to capture frame")
 
-    calibrator = field_calibration.calibrate_from_clicks(
-        frame,
-        save_path=args.output,
-    )
+    pts = None
+    if args.points:
+        try:
+            pts = field_calibration.parse_points_str(args.points)
+        except ValueError as exc:
+            raise SystemExit(f"Invalid --points value: {exc}")
 
-    _draw_guides(frame, calibrator)
-    cv2.imshow("calibration", frame)
-    cv2.waitKey(0)
-    cv2.destroyAllWindows()
-    print(f"Saved calibration to {args.output}")
+    try:
+        calibrator = field_calibration.calibrate_from_clicks(
+            frame,
+            headless=args.headless and pts is None,
+            points=pts,
+            save_to=args.output,
+        )
+    except RuntimeError as exc:
+        print(exc)
+        return
+
+    with open(args.output, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    image_points = [tuple(map(float, p)) for p in data["image_points"]]
+
+    errs = []
+    for x, y in image_points:
+        field_pt = calibrator.pixel_to_field((x, y))
+        if field_pt is None:
+            continue
+        back = calibrator.field_to_pixel(field_pt)
+        if back is not None:
+            errs.append(np.hypot(back[0] - x, back[1] - y))
+    avg_err = float(np.mean(errs)) if errs else 0.0
+
+    if not args.headless and args.points is None:
+        _draw_guides(frame, calibrator)
+        cv2.imshow("calibration", frame)
+        cv2.waitKey(0)
+        cv2.destroyAllWindows()
+
+    print(f"Saved calibration to {args.output} (avg error {avg_err:.6f} px)")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Extend field calibration to run without a GUI and parse point strings
- Add `--headless`, `--points`, and `--frame` options to calibration tool
- Update tests for new calibration API

## Testing
- `pytest tests/test_field_calibration.py -q`
- `python -m tools.calibrate_field --headless --frame debug_frame.jpg` *(fails: ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68c0544eade4832db1f10df44ed4b7f9