### PR TITLE
Gracefully handle missing OpenCV display

### DIFF
--- a/analysis/vision/field_calibration.py
+++ b/analysis/vision/field_calibration.py
@@ -11,9 +11,12 @@ from __future__ import annotations
 
 import json
 import os
+import logging
 from typing import Sequence, Tuple, List, Optional
 
 import numpy as np
+
+log = logging.getLogger(__name__)
 
 Point = Tuple[float, float]
 
@@ -128,6 +131,16 @@ def calibrate_from_clicks(
                 cv2.imshow("calibrate", frame)
 
         clone = frame.copy()
+        if not os.environ.get("DISPLAY"):
+            log.warning("DISPLAY not set; OpenCV GUI may be unavailable")
+        try:
+            cv2.namedWindow("calibrate", cv2.WINDOW_NORMAL)
+        except cv2.error as e:
+            raise RuntimeError(
+                "OpenCV GUI not available. Try headless mode "
+                "(`python -m tools.calibrate_field --headless`) or run via xvfb "
+                "(`xvfb-run -a python -m tools.calibrate_field`)."
+            ) from e
         cv2.imshow("calibrate", clone)
         cv2.setMouseCallback("calibrate", on_click)
         while len(pts) < 4:

--- a/tools/calibrate_field.py
+++ b/tools/calibrate_field.py
@@ -7,10 +7,15 @@ and hash mark guides for validation.
 from __future__ import annotations
 
 import argparse
+import logging
+import os
+
 import cv2
 
 from analysis.camera.capture import FrameCapture
 from analysis.vision import field_calibration
+
+log = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -67,6 +72,16 @@ def main() -> None:
     )
 
     _draw_guides(frame, calibrator)
+    if not os.environ.get("DISPLAY"):
+        log.warning("DISPLAY not set; OpenCV GUI may be unavailable")
+    try:
+        cv2.namedWindow("calibration", cv2.WINDOW_NORMAL)
+    except cv2.error as e:
+        raise RuntimeError(
+            "OpenCV GUI not available. Try headless mode "
+            "(`python -m tools.calibrate_field --headless`) or run via xvfb "
+            "(`xvfb-run -a python -m tools.calibrate_field`)."
+        ) from e
     cv2.imshow("calibration", frame)
     cv2.waitKey(0)
     cv2.destroyAllWindows()

--- a/tools/latency_check.py
+++ b/tools/latency_check.py
@@ -2,10 +2,14 @@
 """Measure capture to display latency for a video source."""
 
 import argparse
+import logging
+import os
 import time
 from typing import Union
 
 import cv2
+
+log = logging.getLogger(__name__)
 
 
 def parse_source(src: str) -> Union[int, str]:
@@ -25,6 +29,16 @@ def main() -> None:
     cap = cv2.VideoCapture(source)
     if not cap.isOpened():
         raise RuntimeError(f"Unable to open source: {source}")
+
+    if not os.environ.get("DISPLAY"):
+        log.warning("DISPLAY not set; OpenCV GUI may be unavailable")
+    try:
+        cv2.namedWindow("frame", cv2.WINDOW_NORMAL)
+    except cv2.error as e:
+        raise RuntimeError(
+            "OpenCV GUI not available. Run via xvfb "
+            "(`xvfb-run -a python -m tools.latency_check`)."
+        ) from e
 
     latencies = []
     for _ in range(args.frames):


### PR DESCRIPTION
## Summary
- Warn when DISPLAY is unset and fail with a friendly message if OpenCV GUI is unavailable
- Suggest headless or xvfb alternatives for calibration utilities

## Testing
- `pytest` *(fails: SyntaxError in tests/test_ball_tracker.py, AttributeError in tests/test_gameday_cli.py, ImportError for cv2)*

------
https://chatgpt.com/codex/tasks/task_e_68c054a8cef8832db9354ee8d4737ad6