### PR TITLE
Make headless-safe field calibration

### DIFF
--- a/analysis/vision/field_calibration.py
+++ b/analysis/vision/field_calibration.py
@@ -132,87 +132,89 @@ def parse_points_str(s: str) -> List[Point]:
 
 
 def calibrate_from_clicks(
-    frame: np.ndarray,
+    frame: np.ndarray | None = None,
     *,
     headless: bool = False,
     points: Optional[Sequence[Point]] = None,
     save_to: str = DEFAULT_CALIB_PATH,
-) -> FieldCalibrator:
+) -> dict:
     """Compute and save a field homography.
 
-    ``frame`` is the image to calibrate.  If ``points`` is provided, it must be
-    a list of four ``(x, y)`` pixel coordinates (clockwise starting near the
-    left goal line corner) and no GUI will be shown.  If ``points`` is ``None``
-    and ``headless`` is ``True``, the frame is written to ``configs/calib_frame.jpg``
-    and a ``RuntimeError`` is raised instructing the caller how to proceed.  If
-    neither ``points`` nor ``headless`` are provided, an interactive OpenCV
-    window is used to collect the clicks.
+    If ``points`` are supplied, they must be four pixel coordinates in
+    clockwise order starting at the goal-line corner.  In this case no GUI is
+    shown and the homography is computed directly.  When ``headless`` is
+    ``True`` but ``points`` are not provided, a ``RuntimeError`` is raised.  If
+    neither ``headless`` nor ``points`` are specified, an interactive OpenCV
+    window is used to collect the four clicks.  ``frame`` must contain the
+    image for interactive calibration; this function never attempts to open a
+    camera itself.
     """
 
-    image_points: List[Point]
+    import cv2  # Lazy import inside function
+
+    image_points: np.ndarray
 
     if points is not None:
-        image_points = list(points)
+        image_points = np.array(points, dtype=np.float32)
     else:
         if headless:
-            import cv2  # Lazy import to keep tests light
-
-            calib_frame = os.path.join("configs", "calib_frame.jpg")
-            os.makedirs(os.path.dirname(calib_frame), exist_ok=True)
-            cv2.imwrite(calib_frame, frame)
+            if frame is not None:
+                calib_frame = os.path.join("configs", "calib_frame.jpg")
+                os.makedirs(os.path.dirname(calib_frame), exist_ok=True)
+                cv2.imwrite(calib_frame, frame)
             raise RuntimeError(
-                "Run with --points 'x1,y1 x2,y2 x3,y3 x4,y4' or copy configs/calib_frame.jpg to a GUI host to click points."
+                "Headless calibration requires --points or a pre-saved calib_frame.jpg + manual point extraction."
             )
-
-        import cv2  # Imported lazily to avoid dependency for tests
-        import sys
-
-        # If there's no display, OpenCV will fail.  Provide an actionable error
-        if sys.platform != "win32" and os.environ.get("DISPLAY") in (None, ""):
-            raise RuntimeError(
-                "No display available for calibration. Set DISPLAY or run with --headless."
-            )
+        if frame is None:
+            raise ValueError("frame is required for interactive calibration")
 
         pts: List[Point] = []
 
         def on_click(event, x, y, _flags, _param) -> None:
-            nonlocal pts
             if event == cv2.EVENT_LBUTTONDOWN and len(pts) < 4:
                 pts.append((float(x), float(y)))
                 cv2.circle(frame, (x, y), 5, (0, 0, 255), -1)
-                cv2.imshow("calibrate", frame)
+                try:
+                    cv2.imshow("calibrate", frame)
+                except cv2.error as e:  # pragma: no cover - GUI failure
+                    raise RuntimeError(
+                        "OpenCV GUI not available—use --headless or xvfb."
+                    ) from e
 
-        clone = frame.copy()
-        if not os.environ.get("DISPLAY"):
-            log.warning("DISPLAY not set; OpenCV GUI may be unavailable")
         try:
             cv2.namedWindow("calibrate", cv2.WINDOW_NORMAL)
-        except cv2.error as e:
+            cv2.imshow("calibrate", frame.copy())
+        except cv2.error as e:  # pragma: no cover - GUI failure
             raise RuntimeError(
-                "OpenCV GUI not available. Try headless mode "
-                "(`python -m tools.calibrate_field --headless`) or run via xvfb "
-                "(`xvfb-run -a python -m tools.calibrate_field`)."
+                "OpenCV GUI not available—use --headless or xvfb."
             ) from e
-        cv2.imshow("calibrate", clone)
         cv2.setMouseCallback("calibrate", on_click)
         while len(pts) < 4:
             cv2.waitKey(10)
         cv2.destroyWindow("calibrate")
-        image_points = pts
+        image_points = np.array(pts, dtype=np.float32)
 
-    h, h_inv = compute_homography(image_points, FIELD_POINTS)
+    field_points = np.array(FIELD_POINTS, dtype=np.float32)
+    h, _ = cv2.findHomography(image_points, field_points)
+    if h is None:
+        raise RuntimeError("cv2.findHomography failed")
+    h_inv, _ = cv2.findHomography(field_points, image_points)
+    if h_inv is None:
+        raise RuntimeError("cv2.findHomography failed for inverse")
+
+    proj = cv2.perspectiveTransform(image_points.reshape(-1, 1, 2), h).reshape(-1, 2)
+    err = proj - field_points
+    rms = float(np.sqrt((err ** 2).sum(axis=1).mean()))
 
     data = {
-        "image_points": [list(p) for p in image_points],
-        "field_points": [list(p) for p in FIELD_POINTS],
         "H": h.tolist(),
         "H_inv": h_inv.tolist(),
-        "field_dims": {"length": 120.0, "width": 53.3},
+        "field": {"length": 120.0, "width": 53.3},
     }
 
     os.makedirs(os.path.dirname(save_to), exist_ok=True)
     with open(save_to, "w", encoding="utf-8") as fh:
         json.dump(data, fh, indent=2)
 
-    return FieldCalibrator(calib_path=save_to, h=h)
+    return {"H": h, "H_inv": h_inv, "rms": rms}
 

--- a/tests/test_field_calibration.py
+++ b/tests/test_field_calibration.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import imageio.v3 as iio
 import numpy as np
 
-from analysis.vision.field_calibration import calibrate_from_clicks
+from analysis.vision.field_calibration import FieldCalibrator, calibrate_from_clicks
 
 
 def test_calibration_round_trip(tmp_path: Path) -> None:
@@ -18,7 +18,9 @@ def test_calibration_round_trip(tmp_path: Path) -> None:
     h, w = frame.shape[:2]
     clicks = [(0.0, 0.0), (w - 1.0, 0.0), (w - 1.0, h - 1.0), (0.0, h - 1.0)]
     save_path = tmp_path / "field_homography.json"
-    calibrator = calibrate_from_clicks(frame, points=clicks, save_to=str(save_path))
+    result = calibrate_from_clicks(frame, points=clicks, save_to=str(save_path))
+
+    calibrator = FieldCalibrator(h=result["H"])
 
     assert save_path.exists()
     with open(save_path, "r", encoding="utf-8") as fh:

--- a/tools/calibrate_field.py
+++ b/tools/calibrate_field.py
@@ -92,14 +92,14 @@ def main() -> None:
             points = field_calibration.parse_points_str(args.points)
         except ValueError as exc:
             raise SystemExit(f"Invalid --points value: {exc}")
-        calibrator = field_calibration.calibrate_from_clicks(
+        result = field_calibration.calibrate_from_clicks(
             frame=None, headless=True, points=points, save_to=args.save_to
         )
-        with open(args.save_to, "r", encoding="utf-8") as fh:
-            data = json.load(fh)
-        image_points = [tuple(map(float, p)) for p in data["image_points"]]
-        avg_err = _reprojection_error(calibrator, image_points)
-        print(f"Saved calibration to {args.save_to} (avg error {avg_err:.6f} px)")
+        calibrator = field_calibration.FieldCalibrator(h=result["H"])
+        avg_err = result.get("rms", 0.0)
+        print(
+            f"Saved calibration to {args.save_to} (avg error {avg_err:.6f} px)"
+        )
         return
 
     # ------------------------------------------------------------------
@@ -133,13 +133,11 @@ def main() -> None:
             "OpenCV GUI not available. Try headless mode or run via xvfb-run."
         ) from e
 
-    calibrator = field_calibration.calibrate_from_clicks(
+    result = field_calibration.calibrate_from_clicks(
         frame, headless=False, points=None, save_to=args.save_to
     )
-    with open(args.save_to, "r", encoding="utf-8") as fh:
-        data = json.load(fh)
-    image_points = [tuple(map(float, p)) for p in data["image_points"]]
-    avg_err = _reprojection_error(calibrator, image_points)
+    calibrator = field_calibration.FieldCalibrator(h=result["H"])
+    avg_err = result.get("rms", 0.0)
 
     _draw_guides(frame, calibrator)
     cv2.imshow("calibration", frame)


### PR DESCRIPTION
## Summary
- Refactor `calibrate_from_clicks` for headless-friendly homography computation
- Save only homography matrices and canonical field dimensions
- Update calibration tool and tests for new API

## Testing
- `pytest tests/test_field_calibration.py -q` *(fails: ImportError: libGL.so.1)*


------
https://chatgpt.com/codex/tasks/task_e_68c0595f77b4832daf4436e8b20d974b