### PR TITLE
Use path kwarg for FrameToFFmpeg in live pipeline

### DIFF
--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -329,15 +329,16 @@ def run_live(
         out_w -= out_w % 2
         out_h -= out_h % 2
         streamer = FrameToFFmpeg(
-            out_file=record_out,
-            rtmp_url=rtmp_url if stream else None,
-            rtmp_key=rtmp_key,
+            path=record_out,
             width=out_w,
             height=out_h,
             fps=enc_fps,
             encoder=encoder,
             bitrate=bitrate,
             keyint=keyint,
+            stream=stream,
+            rtmp_url=rtmp_url,
+            rtmp_key=rtmp_key,
         )
 
     last_crop = (0, 0, in_w, in_h)


### PR DESCRIPTION
## Summary
- call `FrameToFFmpeg` with `path` instead of deprecated `out_file`
- forward stream options directly when running live pipeline

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file, AttributeError: module 'gameday' has no attribute 'parse_args', SyntaxError in play_classifier.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c18dac48dc832d98dc60054f080572