### PR TITLE
Add fragmented MP4 and container selection

### DIFF
--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -279,6 +279,7 @@ def run_live(
     rtmp_url: str | None = None,
     rtmp_key: str | None = None,
     record_out: str | None = None,
+    fragmented_mp4: bool = True,
     encoder: str = "h264_v4l2m2m",
     bitrate: str = "12000k",
     keyint: int = 60,
@@ -340,6 +341,7 @@ def run_live(
             stream=stream,
             rtmp_url=rtmp_url,
             rtmp_key=rtmp_key,
+            fragmented_mp4=fragmented_mp4,
         )
 
     last_crop = (0, 0, in_w, in_h)
@@ -493,6 +495,12 @@ def _build_live_parser() -> argparse.ArgumentParser:
     p.add_argument("--rtmp-url")
     p.add_argument("--rtmp-key")
     p.add_argument("--record-out")
+    p.add_argument(
+        "--fragmented-mp4",
+        action="store_true",
+        default=True,
+        help="Write fragmented MP4 (safer if interrupted).",
+    )
     p.add_argument("--encoder", default="h264_v4l2m2m")
     p.add_argument("--bitrate", default="12000k")
     p.add_argument("--keyint", type=int, default=60)
@@ -1253,6 +1261,7 @@ def main(argv=None) -> None:
             rtmp_url=args.rtmp_url,
             rtmp_key=args.rtmp_key,
             record_out=args.record_out,
+            fragmented_mp4=args.fragmented_mp4,
             encoder=args.encoder,
             bitrate=args.bitrate,
             keyint=args.keyint,

--- a/analysis/stream/streamer.py
+++ b/analysis/stream/streamer.py
@@ -23,6 +23,7 @@ class FrameToFFmpeg:
         stream: bool = False,
         rtmp_url: str | None = None,
         rtmp_key: str | None = None,
+        fragmented_mp4: bool = True,
     ) -> None:
         self.path = path or out_file or "out.mp4"
         self.width = int(width) - (int(width) % 2)
@@ -34,6 +35,7 @@ class FrameToFFmpeg:
         self.stream = bool(stream)
         self.rtmp_url = rtmp_url
         self.rtmp_key = rtmp_key
+        self.fragmented_mp4 = bool(fragmented_mp4)
 
         os.makedirs(os.path.dirname(self.path or "output"), exist_ok=True)
         self._proc: Optional[subprocess.Popen[bytes]] = None
@@ -74,9 +76,18 @@ class FrameToFFmpeg:
             "-g",
             str(self.keyint),
         ]
+        ext = (os.path.splitext(self.path)[1] if self.path else "").lower()
         if self.stream:
             assert self.rtmp_url and self.rtmp_key, "RTMP url/key required"
             out = ["-f", "flv", f"{self.rtmp_url}/{self.rtmp_key}"]
+        elif ext == ".mkv":
+            out = ["-f", "matroska", self.path]
+        elif ext == ".mp4" and self.fragmented_mp4:
+            out = [
+                "-movflags",
+                "+frag_keyframe+empty_moov+separate_moof+default_base_moof",
+                self.path,
+            ]
         else:
             out = ["-movflags", "+faststart", self.path]
         return base_in + enc + out


### PR DESCRIPTION
## Summary
- select ffmpeg container based on output extension
- support fragmented MP4 recording for crash tolerance
- add `--fragmented-mp4` CLI flag to analysis pipeline

## Testing
- `python -m py_compile analysis/stream/streamer.py analysis/pipeline.py`
- `pytest` *(fails: SyntaxError in tests/test_ball_tracker.py; ImportError for cv2; AttributeError in tests/test_gameday_cli.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c19805171c832db63176bb4d80a5c9