### PR TITLE
Graceful shutdown and FFmpeg finalization

### DIFF
--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -1250,30 +1250,43 @@ def main(argv=None) -> None:
         lp = _build_live_parser()
         args = lp.parse_args(argv)
         width, height = [int(v) for v in args.resolution.lower().split("x")]
-        run_live(
-            source=args.source,
-            resolution=(width, height),
-            fps=args.fps,
-            follow_ball=args.follow_ball,
-            crop_yards=args.crop_yards,
-            calib=args.calib,
-            stream=args.stream,
-            rtmp_url=args.rtmp_url,
-            rtmp_key=args.rtmp_key,
-            record_out=args.record_out,
-            fragmented_mp4=args.fragmented_mp4,
-            encoder=args.encoder,
-            bitrate=args.bitrate,
-            keyint=args.keyint,
-            out_width=args.out_width,
-            out_height=args.out_height,
-            keep_aspect=args.keep_aspect,
-            out_fps=args.out_fps,
-            preroll=args.preroll,
-            postroll=args.postroll,
-            debug_overlay=args.debug_overlay,
-            cap_backend=args.cap_backend,
-        )
+        streamer = cap = None
+        try:
+            run_live(
+                source=args.source,
+                resolution=(width, height),
+                fps=args.fps,
+                follow_ball=args.follow_ball,
+                crop_yards=args.crop_yards,
+                calib=args.calib,
+                stream=args.stream,
+                rtmp_url=args.rtmp_url,
+                rtmp_key=args.rtmp_key,
+                record_out=args.record_out,
+                fragmented_mp4=args.fragmented_mp4,
+                encoder=args.encoder,
+                bitrate=args.bitrate,
+                keyint=args.keyint,
+                out_width=args.out_width,
+                out_height=args.out_height,
+                keep_aspect=args.keep_aspect,
+                out_fps=args.out_fps,
+                preroll=args.preroll,
+                postroll=args.postroll,
+                debug_overlay=args.debug_overlay,
+                cap_backend=args.cap_backend,
+            )
+        except KeyboardInterrupt:
+            print("[pipeline] interrupted; shutting down…")
+        finally:
+            try:
+                streamer.close()
+            except Exception:
+                pass
+            try:
+                cap.close()
+            except Exception:
+                pass
         return
 
     p = argparse.ArgumentParser()

--- a/analysis/stream/streamer.py
+++ b/analysis/stream/streamer.py
@@ -136,23 +136,27 @@ class FrameToFFmpeg:
 
     # ------------------------------------------------------------------
     def close(self) -> None:
-        if self._proc is None:
+        proc = self._proc
+        self._proc = None
+        if proc is None:
             return
+        if proc.stdin:
+            try:
+                proc.stdin.flush()
+            finally:
+                proc.stdin.close()
         try:
-            if self._proc.stdin:
+            proc.wait(timeout=3)
+        except subprocess.TimeoutExpired:
+            try:
+                proc.terminate()
+                proc.wait(timeout=1)
+            except subprocess.TimeoutExpired:
+                proc.kill()
                 try:
-                    self._proc.stdin.flush()
+                    proc.wait(timeout=1)
                 except Exception:
                     pass
-                self._proc.stdin.close()
-            self._proc.wait(timeout=3)
-        except Exception:
-            try:
-                self._proc.kill()
-            except Exception:
-                pass
-        finally:
-            self._proc = None
 
 
 # Backwards compatibility


### PR DESCRIPTION
## Summary
- Wrap live pipeline execution in KeyboardInterrupt handler and always attempt to close streamer and capture
- Flush and close FFmpeg stdin and terminate or kill on shutdown

## Testing
- `python -m pytest tests/test_pipeline_smoke.py tests/test_rtmps_fallback.py -q` *(fails: AttributeError: module 'gameday' has no attribute 'run_ffmpeg')*


------
https://chatgpt.com/codex/tasks/task_e_68c199dd6f5c832da057f2d44a52c1d1