### PR TITLE
Add optional segmenter for local recordings

### DIFF
--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -280,6 +280,7 @@ def run_live(
     rtmp_key: str | None = None,
     record_out: str | None = None,
     fragmented_mp4: bool = True,
+    segment_seconds: int = 0,
     encoder: str = "h264_v4l2m2m",
     bitrate: str = "12000k",
     keyint: int = 60,
@@ -330,6 +331,11 @@ def run_live(
         out_w -= out_w % 2
         out_h -= out_h % 2
         record_out_path = record_out
+        if record_out and segment_seconds > 0:
+            base_dir = record_out
+            if os.path.splitext(record_out)[1]:
+                base_dir = os.path.dirname(record_out) or "."
+            record_out_path = os.path.join(base_dir, "%Y%m%d_%H%M%S_segment.mp4")
         streamer = FrameToFFmpeg(
             path=record_out_path,
             width=out_w,
@@ -342,6 +348,7 @@ def run_live(
             rtmp_url=rtmp_url,
             rtmp_key=rtmp_key,
             fragmented_mp4=fragmented_mp4,
+            segment_seconds=segment_seconds,
         )
 
     last_crop = (0, 0, in_w, in_h)
@@ -495,6 +502,12 @@ def _build_live_parser() -> argparse.ArgumentParser:
     p.add_argument("--rtmp-url")
     p.add_argument("--rtmp-key")
     p.add_argument("--record-out")
+    p.add_argument(
+        "--segment-seconds",
+        type=int,
+        default=0,
+        help="roll files every N seconds; 0 disables",
+    )
     p.add_argument(
         "--fragmented-mp4",
         action="store_true",
@@ -1264,6 +1277,7 @@ def main(argv=None) -> None:
                 rtmp_key=args.rtmp_key,
                 record_out=args.record_out,
                 fragmented_mp4=args.fragmented_mp4,
+                segment_seconds=args.segment_seconds,
                 encoder=args.encoder,
                 bitrate=args.bitrate,
                 keyint=args.keyint,

--- a/analysis/stream/streamer.py
+++ b/analysis/stream/streamer.py
@@ -24,6 +24,7 @@ class FrameToFFmpeg:
         rtmp_url: str | None = None,
         rtmp_key: str | None = None,
         fragmented_mp4: bool = True,
+        segment_seconds: int = 0,
     ) -> None:
         self.path = path or out_file or "out.mp4"
         self.width = int(width) - (int(width) % 2)
@@ -36,6 +37,7 @@ class FrameToFFmpeg:
         self.rtmp_url = rtmp_url
         self.rtmp_key = rtmp_key
         self.fragmented_mp4 = bool(fragmented_mp4)
+        self.segment_seconds = int(segment_seconds)
 
         os.makedirs(os.path.dirname(self.path or "output"), exist_ok=True)
         self._proc: Optional[subprocess.Popen[bytes]] = None
@@ -80,6 +82,25 @@ class FrameToFFmpeg:
         if self.stream:
             assert self.rtmp_url and self.rtmp_key, "RTMP url/key required"
             out = ["-f", "flv", f"{self.rtmp_url}/{self.rtmp_key}"]
+        elif self.segment_seconds > 0:
+            movflags = (
+                "+frag_keyframe+empty_moov+separate_moof+default_base_moof"
+                if self.fragmented_mp4
+                else "+faststart"
+            )
+            out = [
+                "-movflags",
+                movflags,
+                "-f",
+                "segment",
+                "-segment_time",
+                str(self.segment_seconds),
+                "-reset_timestamps",
+                "1",
+                "-strftime",
+                "1",
+                self.path,
+            ]
         elif ext == ".mkv":
             out = ["-f", "matroska", self.path]
         elif ext == ".mp4" and self.fragmented_mp4:

--- a/tests/test_pipeline_cli_flags.py
+++ b/tests/test_pipeline_cli_flags.py
@@ -35,3 +35,9 @@ def test_flag_and_val_mutually_exclusive(args):
     parser = pipeline._build_live_parser()
     with pytest.raises(SystemExit):
         parser.parse_args(["--source", "dummy", *args])
+
+
+def test_segment_seconds_parsing():
+    parser = pipeline._build_live_parser()
+    ns = parser.parse_args(["--source", "dummy", "--segment-seconds", "30"])
+    assert ns.segment_seconds == 30


### PR DESCRIPTION
## Summary
- support rolling local recordings with --segment-seconds
- wire segmenter through live pipeline and streamer
- cover CLI flag in tests

## Testing
- `pytest` *(fails: SyntaxError in tests/test_ball_tracker.py and ImportError on cv2)*
- `pytest tests/test_pipeline_cli_flags.py::test_segment_seconds_parsing -q`


------
https://chatgpt.com/codex/tasks/task_e_68c19bf283b8832d8032fe43a9af105b