### PR TITLE
Gracefully handle live pipeline interrupts and document ffmpeg safe flags

### DIFF
--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -1295,11 +1295,11 @@ def main(argv=None) -> None:
         finally:
             try:
                 streamer.close()
-            except Exception:
+            except:
                 pass
             try:
                 cap.close()
-            except Exception:
+            except:
                 pass
         return
 

--- a/analysis/stream/streamer.py
+++ b/analysis/stream/streamer.py
@@ -50,8 +50,8 @@ class FrameToFFmpeg:
             "-hide_banner",
             "-loglevel",
             "error",
-            "-nostdin",
-            "-y",
+            "-y",        # overwrite output files
+            "-nostdin",  # avoid blocking on stdin
             "-f",
             "rawvideo",
             "-pix_fmt",


### PR DESCRIPTION
## Summary
- ensure live pipeline closes resources on `KeyboardInterrupt`
- clarify ffmpeg invocation uses `-y -nostdin` and container-safe flags

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1 missing; AttributeError in gameday CLI; SyntaxError in play_classifier)*

------
https://chatgpt.com/codex/tasks/task_e_68c1bc157c0c832d853a80bb4e2f852e