### PR TITLE
Auto-remux MKV to MP4 on clean shutdown

### DIFF
--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -1264,6 +1264,12 @@ def main(argv=None) -> None:
         args = lp.parse_args(argv)
         width, height = [int(v) for v in args.resolution.lower().split("x")]
         streamer = cap = None
+        mkv_path = (
+            args.record_out
+            if args.record_out and args.record_out.endswith(".mkv")
+            else None
+        )
+        success = False
         try:
             run_live(
                 source=args.source,
@@ -1290,13 +1296,31 @@ def main(argv=None) -> None:
                 debug_overlay=args.debug_overlay,
                 cap_backend=args.cap_backend,
             )
+            success = True
         except KeyboardInterrupt:
             print("[pipeline] interrupted; shutting down…")
+            success = True
         finally:
             try:
                 streamer.close()
             except:
                 pass
+            if success and mkv_path:
+                subprocess.run(
+                    [
+                        "ffmpeg",
+                        "-hide_banner",
+                        "-y",
+                        "-i",
+                        mkv_path,
+                        "-c",
+                        "copy",
+                        "-movflags",
+                        "+faststart",
+                        mkv_path.replace(".mkv", "_final.mp4"),
+                    ],
+                    check=False,
+                )
             try:
                 cap.close()
             except:


### PR DESCRIPTION
## Summary
- Auto-convert `--record-out` MKV recordings to faststart MP4 after successful live run

## Testing
- `pytest tests/test_pipeline_smoke.py`

------
https://chatgpt.com/codex/tasks/task_e_68c1c4264560832d864373e31ab12b8b