### PR TITLE
Add MultiSink ffmpeg fallback for streaming

### DIFF
--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -305,7 +305,7 @@ def run_live(
     from .tracking.ball_tracker import TrackState
     from .vision.field_calibration import FieldCalibrator, img_to_field
     from .vision.yard_cropper import YardCropper
-    from .stream.streamer import FrameToFFmpeg
+    from .stream.streamer import FrameToFFmpeg, MultiSinkStreamer
 
     buf_size = int(fps * max(preroll + postroll, 1.0))
     cap = FrameCapture(
@@ -336,20 +336,34 @@ def run_live(
             if os.path.splitext(record_out)[1]:
                 base_dir = os.path.dirname(record_out) or "."
             record_out_path = os.path.join(base_dir, "%Y%m%d_%H%M%S_segment.mp4")
-        streamer = FrameToFFmpeg(
-            path=record_out_path,
-            width=out_w,
-            height=out_h,
-            fps=enc_fps,
-            encoder=encoder,
-            bitrate=bitrate,
-            keyint=keyint,
-            stream=stream,
-            rtmp_url=rtmp_url,
-            rtmp_key=rtmp_key,
-            fragmented_mp4=fragmented_mp4,
-            segment_seconds=segment_seconds,
-        )
+        rtmp_full = f"{(rtmp_url or '').rstrip('/')}/{rtmp_key}" if stream else None
+        try:
+            streamer = FrameToFFmpeg(
+                path=record_out_path,
+                width=out_w,
+                height=out_h,
+                fps=enc_fps,
+                encoder=encoder,
+                bitrate=bitrate,
+                keyint=keyint,
+                stream=stream,
+                rtmp_url=rtmp_url,
+                rtmp_key=rtmp_key,
+                fragmented_mp4=fragmented_mp4,
+                segment_seconds=segment_seconds,
+            )
+        except Exception as e:
+            print("[pipeline] tee unavailable or failed; using MultiSink", e)
+            streamer = MultiSinkStreamer(
+                path=record_out_path,
+                width=out_w,
+                height=out_h,
+                fps=enc_fps,
+                encoder=encoder,
+                bitrate=bitrate,
+                keyint=keyint,
+                rtmp_url_with_key=rtmp_full,
+            )
 
     if record_out:
         print(f"[pipeline] recording to: {record_out}")

--- a/analysis/stream/streamer.py
+++ b/analysis/stream/streamer.py
@@ -205,5 +205,88 @@ class FrameToFFmpeg:
             self._proc = None
 
 
+class MultiSinkStreamer:
+    def __init__(self, path, width, height, fps, encoder, bitrate, keyint, rtmp_url_with_key):
+        self.width, self.height, self.fps = width, height, fps
+        self.encoder, self.bitrate, self.keyint = encoder, bitrate, keyint
+        self.path = path
+        self.rtmp = rtmp_url_with_key
+        import os, subprocess
+
+        os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+
+        base = [
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-nostdin",
+            "-y",
+            "-f",
+            "rawvideo",
+            "-pix_fmt",
+            "bgr24",
+            "-s",
+            f"{width}x{height}",
+            "-r",
+            str(fps),
+            "-i",
+            "-",
+            "-an",
+            "-c:v",
+            encoder,
+            "-pix_fmt",
+            "yuv420p",
+            "-b:v",
+            bitrate,
+            "-maxrate",
+            bitrate,
+            "-bufsize",
+            str(int(1.5 * int(bitrate.rstrip("k")))) + "k",
+            "-g",
+            str(keyint),
+        ]
+        self.p_file = subprocess.Popen(
+            ["ffmpeg", *base, "-f", "matroska", path],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+        )
+        self.p_rtmp = subprocess.Popen(
+            ["ffmpeg", *base, "-f", "flv", rtmp_url_with_key],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+        )
+
+    def write(self, frame):
+        for p in (self.p_file, self.p_rtmp):
+            if p and p.poll() is None:
+                try:
+                    p.stdin.write(frame.tobytes())
+                except Exception:
+                    pass  # drop frame for this sink
+
+    def close(self):
+        for p in (self.p_file, self.p_rtmp):
+            if not p:
+                continue
+            try:
+                if p.stdin:
+                    try:
+                        p.stdin.flush()
+                    except Exception:
+                        pass
+                    try:
+                        p.stdin.close()
+                    except Exception:
+                        pass
+                p.wait(timeout=3)
+            except Exception:
+                try:
+                    p.kill()
+                except Exception:
+                    pass
+
+
 # Backwards compatibility
 Streamer = FrameToFFmpeg


### PR DESCRIPTION
## Summary
- support two ffmpeg processes when tee muxer is unavailable
- fall back to MultiSinkStreamer in live pipeline

## Testing
- `pytest` *(fails: SyntaxError and missing modules during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c2f571e820832da1c870c72f9b832c