### PR TITLE
Add MultiSinkStreamer for dual stream and record

### DIFF
--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -336,33 +336,34 @@ def run_live(
             if os.path.splitext(record_out)[1]:
                 base_dir = os.path.dirname(record_out) or "."
             record_out_path = os.path.join(base_dir, "%Y%m%d_%H%M%S_segment.mp4")
-        rtmp_full = f"{(rtmp_url or '').rstrip('/')}/{rtmp_key}" if stream else None
-        try:
-            streamer = FrameToFFmpeg(
-                path=record_out_path,
-                width=out_w,
-                height=out_h,
-                fps=enc_fps,
-                encoder=encoder,
-                bitrate=bitrate,
-                keyint=keyint,
-                stream=stream,
-                rtmp_url=rtmp_url,
-                rtmp_key=rtmp_key,
-                fragmented_mp4=fragmented_mp4,
-                segment_seconds=segment_seconds,
-            )
-        except Exception as e:
-            print("[pipeline] tee unavailable or failed; using MultiSink", e)
+
+        # Compose full RTMP(S) URL with key
+        rtmp_full = None
+        if stream:
+            url = (rtmp_url or "").strip()
+            key = (rtmp_key or "").strip()
+            if url and not url.startswith(("rtmp://", "rtmps://")):
+                url = "rtmps://" + url.lstrip("/")
+            # Prefer YouTube RTMPS
+            url = url.replace("rtmp://a.rtmp.youtube.com", "rtmps://a.rtmps.youtube.com")
+            if key and not url.rstrip("/").endswith("/" + key):
+                url = url.rstrip("/") + "/" + key
+            rtmp_full = url
+
+        # If both stream and record_out: use MultiSink (two ffmpegs)
+        if stream and record_out:
             streamer = MultiSinkStreamer(
-                path=record_out_path,
-                width=out_w,
-                height=out_h,
-                fps=enc_fps,
-                encoder=encoder,
-                bitrate=bitrate,
-                keyint=keyint,
-                rtmp_url_with_key=rtmp_full,
+                path=record_out_path, width=out_w, height=out_h, fps=enc_fps,
+                encoder=encoder, bitrate=bitrate, keyint=keyint,
+                rtmp_full=rtmp_full,
+            )
+        else:
+            # existing single-sink FrameToFFmpeg code path
+            streamer = FrameToFFmpeg(
+                path=record_out_path, width=out_w, height=out_h, fps=enc_fps,
+                encoder=encoder, bitrate=bitrate, keyint=keyint,
+                stream=stream, rtmp_url=rtmp_url, rtmp_key=rtmp_key,
+                fragmented_mp4=fragmented_mp4, segment_seconds=segment_seconds,
             )
 
     if record_out:

--- a/analysis/stream/streamer.py
+++ b/analysis/stream/streamer.py
@@ -206,86 +206,57 @@ class FrameToFFmpeg:
 
 
 class MultiSinkStreamer:
-    def __init__(self, path, width, height, fps, encoder, bitrate, keyint, rtmp_url_with_key):
+    def __init__(self, path, width, height, fps, encoder, bitrate, keyint, rtmp_full):
+        import os, subprocess
         self.width, self.height, self.fps = width, height, fps
         self.encoder, self.bitrate, self.keyint = encoder, bitrate, keyint
         self.path = path
-        self.rtmp = rtmp_url_with_key
-        import os, subprocess
-
+        self.rtmp = rtmp_full
         os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
 
         base = [
-            "-hide_banner",
-            "-loglevel",
-            "error",
-            "-nostdin",
-            "-y",
-            "-f",
-            "rawvideo",
-            "-pix_fmt",
-            "bgr24",
-            "-s",
-            f"{width}x{height}",
-            "-r",
-            str(fps),
-            "-i",
-            "-",
-            "-an",
-            "-c:v",
-            encoder,
-            "-pix_fmt",
-            "yuv420p",
-            "-b:v",
-            bitrate,
-            "-maxrate",
-            bitrate,
-            "-bufsize",
-            str(int(1.5 * int(bitrate.rstrip("k")))) + "k",
-            "-g",
-            str(keyint),
+            "ffmpeg", "-hide_banner", "-loglevel", "error", "-nostdin", "-y",
+            "-f", "rawvideo", "-pix_fmt", "bgr24",
+            "-s", f"{width}x{height}", "-r", str(fps), "-i", "-",
+            "-an", "-c:v", encoder, "-pix_fmt", "yuv420p",
+            "-b:v", bitrate, "-maxrate", bitrate,
+            "-bufsize", f"{int(1.5*int(bitrate.rstrip('k')))}k",
+            "-g", str(keyint),
         ]
+        # Local file sink (MKV for resilience)
         self.p_file = subprocess.Popen(
-            ["ffmpeg", *base, "-f", "matroska", path],
-            stdin=subprocess.PIPE,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.PIPE,
+            [*base, "-f", "matroska", path],
+            stdin=subprocess.PIPE, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE
         )
+        # RTMP(S) sink
         self.p_rtmp = subprocess.Popen(
-            ["ffmpeg", *base, "-f", "flv", rtmp_url_with_key],
-            stdin=subprocess.PIPE,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.PIPE,
+            [*base, "-f", "flv", rtmp_full],
+            stdin=subprocess.PIPE, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE
         )
 
     def write(self, frame):
+        # Try both sinks; if one dies, keep the other
+        data = frame.tobytes()
         for p in (self.p_file, self.p_rtmp):
             if p and p.poll() is None:
                 try:
-                    p.stdin.write(frame.tobytes())
+                    p.stdin.write(data)
                 except Exception:
-                    pass  # drop frame for this sink
+                    pass  # drop for this sink
 
     def close(self):
         for p in (self.p_file, self.p_rtmp):
-            if not p:
-                continue
+            if not p: continue
             try:
                 if p.stdin:
-                    try:
-                        p.stdin.flush()
-                    except Exception:
-                        pass
-                    try:
-                        p.stdin.close()
-                    except Exception:
-                        pass
+                    try: p.stdin.flush()
+                    except: pass
+                    try: p.stdin.close()
+                    except: pass
                 p.wait(timeout=3)
             except Exception:
-                try:
-                    p.kill()
-                except Exception:
-                    pass
+                try: p.kill()
+                except: pass
 
 
 # Backwards compatibility


### PR DESCRIPTION
## Summary
- Add MultiSinkStreamer to stream to RTMP and record locally using two ffmpeg processes
- Auto-select MultiSinkStreamer when both --stream and --record-out flags are used

## Testing
- `pytest` *(fails: SyntaxError invalid decimal literal; AttributeError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c30305c92c832d83cb611962ca7d16