### PR TITLE
Drop rpc_introspect_schema before redefinition

### DIFF
--- a/rpc_introspect_schema_all.sql
+++ b/rpc_introspect_schema_all.sql
@@ -1,0 +1,18 @@
+-- Drops and recreates rpc_introspect_schema with updated definition
+DROP FUNCTION IF EXISTS rpc_introspect_schema();
+
+CREATE FUNCTION rpc_introspect_schema()
+RETURNS TABLE (
+    schema_name text,
+    table_name text,
+    column_name text,
+    data_type text
+) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT c.table_schema, c.table_name, c.column_name, c.data_type
+    FROM information_schema.columns c
+    WHERE c.table_schema NOT IN ('pg_catalog', 'information_schema')
+    ORDER BY c.table_schema, c.table_name, c.ordinal_position;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Summary
- Drop existing `rpc_introspect_schema` before recreating it to accommodate new return types

## Testing
- `psql -f rpc_introspect_schema_all.sql` *(fails: psql not installed)*
- `sudo apt-get update` *(fails: 403 Forbidden fetching Ubuntu repositories)*

------
https://chatgpt.com/codex/tasks/task_e_68c30539d130832db56c91d96c938147