### PR TITLE
Add tendencies post-processor and integrate into pipeline

### DIFF
--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -12,6 +12,7 @@ from collections import Counter
 import html
 
 from .harmonizer import harmonize
+from .tendencies import main as write_tendencies
 
 try:
     # When executed as module (recommended)
@@ -1118,6 +1119,7 @@ def run_pipeline(
         }
         with open(os.path.join(run_dir, "report.json"), "w") as f:
             json.dump(report, f, indent=2)
+        write_tendencies(run_dir)
 
     # QA guardrails
     if rows:

--- a/analysis/tendencies.py
+++ b/analysis/tendencies.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+import json, csv, math, pathlib, collections
+from typing import Dict, Any, List, Tuple
+
+Play = Dict[str, Any]
+
+FAMILIES = {
+    "inside_run": ["dive","power","iso","counter","trap"],
+    "outside_run": ["sweep","jet","stretch","toss"],
+    "pa_boot": ["boot","naked","waggle","flare boot","play action","option"],
+    "quick_game": ["stick","quick screen","bubble","smoke","hitch","slant","flood","quick"]
+}
+
+def normalize(text:str)->str:
+    return (text or "").lower().strip()
+
+def infer_family(play: Play) -> str:
+    # Try explicit labels first, then keywords from clip title/notes
+    labels = [normalize(play.get("play_label")), normalize(play.get("family")), normalize(play.get("call"))]
+    blob = " ".join(labels + [normalize(play.get("title","")), normalize(play.get("notes",""))])
+    for fam, keys in FAMILIES.items():
+        if any(k in blob for k in keys):
+            return fam
+    # fallback: if run/pass bool exists
+    if play.get("is_run") is True: return "inside_run"
+    if play.get("is_pass") is True: return "quick_game"
+    return "unknown"
+
+def infer_direction(play: Play) -> str:
+    d = normalize(play.get("direction") or play.get("dir"))
+    if d in ("right","r","rt","rit","reo"): return "right"
+    if d in ("left","l","lt","lit","leo"): return "left"
+    # Heuristic: look for tokens in title/notes
+    blob = normalize(play.get("title","")+" "+play.get("notes",""))
+    if any(t in blob for t in [" right"," rt"," rit"," reo"]): return "right"
+    if any(t in blob for t in [" left"," lt"," lit"," leo"]): return "left"
+    return "unknown"
+
+def infer_formation(play: Play) -> str:
+    cand = normalize(play.get("formation") or play.get("set"))
+    if cand: return cand
+    # Heuristic from known MCA tokens
+    blob = normalize(play.get("title","")+" "+play.get("notes",""))
+    for key in ["rit","lit","reo","leo","rend","lend","trips","twins","bunch","i","wing","tight","empty"]:
+        if key in blob: return key
+    return "unknown"
+
+def load_plays(out_dir: pathlib.Path) -> List[Play]:
+    for fname in ["plays.jsonl","detections.jsonl","events.jsonl"]:
+        p = out_dir / fname
+        if p.exists():
+            with p.open() as f:
+                return [json.loads(line) for line in f if line.strip()]
+    return []
+
+def summarize(plays: List[Play]) -> Dict[str, Any]:
+    sums = {
+        "total": len(plays),
+        "by_family": collections.Counter(),
+        "by_formation": collections.Counter(),
+        "by_direction": collections.Counter(),
+        "run_pass": collections.Counter(),
+        "first_down_calls": collections.Counter(),
+        "third_and_medium_plus": collections.Counter(),
+        "explosives": 0
+    }
+    for p in plays:
+        fam = infer_family(p); sums["by_family"][fam]+=1
+        form = infer_formation(p); sums["by_formation"][form]+=1
+        dirn = infer_direction(p); sums["by_direction"][dirn]+=1
+
+        if p.get("is_run") is True: sums["run_pass"]["run"]+=1
+        elif p.get("is_pass") is True: sums["run_pass"]["pass"]+=1
+        else: sums["run_pass"]["unknown"]+=1
+
+        down = p.get("down")
+        togo = p.get("distance") or p.get("to_go")
+        if down == 1: sums["first_down_calls"][fam]+=1
+        try:
+            if down == 3 and float(togo or 0) >= 5:
+                sums["third_and_medium_plus"][fam]+=1
+        except Exception:
+            pass
+
+        # explosive heuristic: >=12 yards run or >=16 yards pass if gain present
+        gain = p.get("yards") or p.get("gain")
+        try:
+            g = float(gain)
+            if (p.get("is_run") and g >= 12) or (p.get("is_pass") and g >= 16):
+                sums["explosives"] += 1
+        except Exception:
+            pass
+    return sums
+
+def write_csv(out_dir: pathlib.Path, plays: List[Play], sums: Dict[str,Any]):
+    csv_path = out_dir / "tendencies.csv"
+    with csv_path.open("w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["metric","key","value"])
+        w.writerow(["total","plays",sums["total"]])
+        for k,v in sums["run_pass"].items(): w.writerow(["run_pass",k,v])
+        for k,v in sums["by_family"].items(): w.writerow(["family",k,v])
+        for k,v in sums["by_formation"].items(): w.writerow(["formation",k,v])
+        for k,v in sums["by_direction"].items(): w.writerow(["direction",k,v])
+    return csv_path
+
+def write_md(out_dir: pathlib.Path, sums: Dict[str,Any]):
+    md = out_dir / "tendencies.md"
+    total = max(1, sums["total"])
+    def pct(n): return f"{(100.0*n/total):.1f}%"
+    def block(counter: collections.Counter, title: str) -> str:
+        rows = sorted(counter.items(), key=lambda kv: kv[1], reverse=True)
+        lines = [f"### {title}"]
+        for k,v in rows[:8]:
+            lines.append(f"- **{k}**: {v} ({pct(v)})")
+        return "\n".join(lines)
+
+    content = f"""# Opponent Tendencies
+
+**Total plays:** {sums['total']}  
+**Explosives:** {sums['explosives']}
+
+{block(sums['run_pass'], "Run/Pass")}
+{block(sums['by_family'], "Play Families")}
+{block(sums['by_formation'], "Formations (top)")}
+{block(sums['by_direction'], "Direction")}
+### Situational
+- **1st down (by family):** {dict(sums['first_down_calls'])}
+- **3rd & 5+ (by family):** {dict(sums['third_and_medium_plus'])}
+"""
+    md.write_text(content)
+    return md
+
+def main(out_dir_str: str):
+    out_dir = pathlib.Path(out_dir_str)
+    plays = load_plays(out_dir)
+    sums = summarize(plays)
+    write_csv(out_dir, plays, sums)
+    write_md(out_dir, sums)
+
+if __name__ == "__main__":
+    import sys
+    main(sys.argv[1] if len(sys.argv)>1 else "output")


### PR DESCRIPTION
## Summary
- add `analysis.tendencies` to infer play family, formation, direction and build CSV/Markdown summaries
- hook tendencies summary generation into pipeline report step

## Testing
- `python -m analysis.tendencies output`
- `pytest` *(fails: ImportError: libGL.so.1 missing, AttributeError in gameday CLI, SyntaxError in play_classifier.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c32c694c40832dbd4061229691f909