### PR TITLE
Add directory-mode ingest to analysis pipeline

### DIFF
--- a/analysis/ingest_dir.py
+++ b/analysis/ingest_dir.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+import pathlib, json, subprocess, shlex, re, datetime
+
+
+def natural_key(s: str):
+    return [int(t) if t.isdigit() else t.lower() for t in re.split(r"(\d+)", s)]
+
+
+def discover_plays(input_dir: str):
+    p = pathlib.Path(input_dir)
+    files = sorted(
+        [x for x in p.glob("*.mp4") if x.is_file()],
+        key=lambda x: natural_key(x.name),
+    )
+    plays = []
+    for i, f in enumerate(files, 1):
+        # heuristics: attempt to infer direction or label from filename if present
+        name = f.stem
+        lower = name.lower()
+        direction = (
+            "right"
+            if any(t in lower for t in ["_r", "-r", " right", " rit", " reo"])
+            else "left"
+            if any(t in lower for t in ["_l", "-l", " left", " lit", " leo"])
+            else "unknown"
+        )
+        play = {
+            "index": i,
+            "src": str(f),
+            "title": name,
+            "notes": "",
+            "direction": direction,
+            "is_run": None,
+            "is_pass": None,
+            "down": None,
+            "distance": None,
+            "formation": None,
+            "opponent": "Lincoln Christian",
+            "opponent_primary_color": "black",
+            "team": "MCA 5th (White)",
+            "created_at": datetime.datetime.now().isoformat(timespec="seconds"),
+        }
+        plays.append(play)
+    return plays
+
+
+def write_plays_jsonl(out_dir: str, plays):
+    out = pathlib.Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    p = out / "plays.jsonl"
+    with p.open("w") as f:
+        for obj in plays:
+            f.write(json.dumps(obj, ensure_ascii=False) + "\n")
+    return str(p)
+
+
+def build_coaches_cut(out_dir: str, plays):
+    # concat list
+    out = pathlib.Path(out_dir)
+    concat = out / "concat.txt"
+    with concat.open("w", encoding="utf-8") as f:
+        for pl in plays:
+            # ffmpeg concat demuxer needs single quotes escaped
+            f.write(f"file '{pl['src'].replace("'","'\\''")}'\n")
+    coach_out = out / "coach_cut_opponent.mp4"
+    cmd = (
+        f"ffmpeg -y -f concat -safe 0 -i {shlex.quote(str(concat))} -c copy "
+        f"{shlex.quote(str(coach_out))}"
+    )
+    subprocess.run(cmd, shell=True, check=False)
+    return str(coach_out)

--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -1331,7 +1331,9 @@ def main(argv=None) -> None:
         return
 
     p = argparse.ArgumentParser()
-    p.add_argument("--video", required=True)
+    group = p.add_mutually_exclusive_group(required=True)
+    group.add_argument("--video", type=str)
+    group.add_argument("--input-dir", type=str)
     p.add_argument("--team", required=True)
     p.add_argument("--playbook", required=True)
     p.add_argument("--out", required=True)
@@ -1433,6 +1435,23 @@ def main(argv=None) -> None:
     p.set_defaults(require_classifier=True)
     args = p.parse_args(argv)
     print(f"[pipeline] config: {json.dumps(vars(args), sort_keys=True)}")
+
+    if args.input_dir:
+        from .ingest_dir import (
+            discover_plays,
+            write_plays_jsonl,
+            build_coaches_cut,
+        )
+
+        plays = discover_plays(args.input_dir)
+        write_plays_jsonl(args.out, plays)
+        build_coaches_cut(args.out, plays)
+        if args.generate_report:
+            try:
+                write_tendencies(args.out)
+            except Exception:
+                pass
+        return
 
     run_pipeline(
         video=args.video,


### PR DESCRIPTION
## Summary
- add `ingest_dir.py` to enumerate pre-cut plays, generate `plays.jsonl`, and build a coaches cut
- update pipeline CLI with `--input-dir` option and directory mode execution

## Testing
- `pytest` *(fails: ImportError: libGL.so.1; AttributeError: module 'gameday' has no attribute 'parse_args'; SyntaxError: invalid decimal literal)*

------
https://chatgpt.com/codex/tasks/task_e_68c32f5a3ac8832d81096b69a1d2b229