### PR TITLE
Use shlex.quote when building concat file

### DIFF
--- a/analysis/ingest_dir.py
+++ b/analysis/ingest_dir.py
@@ -60,8 +60,9 @@ def build_coaches_cut(out_dir: str, plays):
     concat = out / "concat.txt"
     with concat.open("w", encoding="utf-8") as f:
         for pl in plays:
-            # ffmpeg concat demuxer needs single quotes escaped
-            f.write(f"file '{pl['src'].replace("'","'\\''")}'\n")
+            # Use shlex.quote to safely escape file path
+            safe_path = shlex.quote(pl["src"])
+            f.write(f"file {safe_path}\n")
     coach_out = out / "coach_cut_opponent.mp4"
     cmd = (
         f"ffmpeg -y -f concat -safe 0 -i {shlex.quote(str(concat))} -c copy "


### PR DESCRIPTION
## Summary
- escape play paths using shlex.quote when building `concat.txt` for ffmpeg in coach's cut generation

## Testing
- `python -m analysis.pipeline --input-dir "input/opponent_lincoln_20250907" --team "Opponent: Lincoln Christian (black)" --playbook playbooks/mca_5th_playbook.json --out "$OUT" --generate-report --no-require-classifier` *(failed: `/bin/sh: 1: ffmpeg: not found`)*
- `pytest` *(errors: tests/test_ball_tracker.py, tests/test_gameday_cli.py, tests/test_play_classifier_device.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c3328c5560832db6a91165beebd8d2