### PR TITLE
Use absolute paths for coaches cut concat

### DIFF
--- a/analysis/ingest_dir.py
+++ b/analysis/ingest_dir.py
@@ -55,14 +55,15 @@ def write_plays_jsonl(out_dir: str, plays):
 
 
 def build_coaches_cut(out_dir: str, plays):
-    # concat list
     out = pathlib.Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+
     concat = out / "concat.txt"
     with concat.open("w", encoding="utf-8") as f:
         for pl in plays:
-            # Use shlex.quote to safely escape file path
-            safe_path = shlex.quote(pl["src"])
-            f.write(f"file {safe_path}\n")
+            abs_path = pathlib.Path(pl["src"]).resolve()
+            f.write(f"file {shlex.quote(str(abs_path))}\n")
+
     coach_out = out / "coach_cut_opponent.mp4"
     cmd = (
         f"ffmpeg -y -f concat -safe 0 -i {shlex.quote(str(concat))} -c copy "


### PR DESCRIPTION
## Summary
- ensure coaches-cut builder uses absolute paths in concat file
- allow ffmpeg to read these paths with -safe 0

## Testing
- `pytest` *(fails: ImportError: libGL.so.1 and AttributeError: module 'gameday' has no attribute 'parse_args')*

------
https://chatgpt.com/codex/tasks/task_e_68c334c070b8832dbff14b6345ac4add