### PR TITLE
Improve play discovery from filenames

### DIFF
--- a/analysis/ingest_dir.py
+++ b/analysis/ingest_dir.py
@@ -14,27 +14,72 @@ def discover_plays(input_dir: str):
     )
     plays = []
     for i, f in enumerate(files, 1):
-        # heuristics: attempt to infer direction or label from filename if present
         name = f.stem
         lower = name.lower()
-        direction = (
-            "right"
-            if any(t in lower for t in ["_r", "-r", " right", " rit", " reo"])
-            else "left"
-            if any(t in lower for t in ["_l", "-l", " left", " lit", " leo"])
-            else "unknown"
+
+        # direction
+        if re.search(r"(^|[ _-])(r|rt|right|rit|reo)([ _-]|$)", lower):
+            direction = "right"
+        elif re.search(r"(^|[ _-])(l|lt|left|lit|leo)([ _-]|$)", lower):
+            direction = "left"
+        else:
+            direction = "unknown"
+
+        # down & distance (1st&10, 2nd10, 3rd_and_7)
+        m = re.search(r"(1st|2nd|3rd|4th)[ _-]*(?:&|and)?[ _-]*(\d+)", lower)
+        down_map = {"1st": 1, "2nd": 2, "3rd": 3, "4th": 4}
+        down = down_map.get(m.group(1)) if m else None
+        distance = int(m.group(2)) if m else None
+
+        # family keywords
+        KEYS = {
+            "inside_run": ["dive", "power", "iso", "counter", "trap"],
+            "outside_run": ["sweep", "jet", "stretch", "toss"],
+            "pa_boot": ["boot", "waggle", "naked", "play action", "flare boot"],
+            "quick_game": ["screen", "stick", "hitch", "slant", "flood", "bubble", "smoke"],
+        }
+        family = next(
+            (fam for fam, words in KEYS.items() if any(w in lower for w in words)),
+            None,
         )
+        is_run = True if family in ("inside_run", "outside_run") else None
+        is_pass = True if family in ("pa_boot", "quick_game") else None
+
+        # formation tokens
+        form = None
+        for pat, label in [
+            (r"\brit\b", "rit"),
+            (r"\blit\b", "lit"),
+            (r"\breo\b", "reo"),
+            (r"\bleo\b", "leo"),
+            (r"\brend\b", "rend"),
+            (r"\blend\b", "lend"),
+            (r"\btrips?\b", "trips"),
+            (r"\btwins?\b", "twins"),
+            (r"\bbunch\b", "bunch"),
+            (r"\bwing\b", "wing"),
+            (r"\btight\b", "tight"),
+            (r"\bpistol\b", "pistol"),
+            (r"\bshotgun\b", "shotgun"),
+            (r"\bgun\b", "gun"),
+            (r"\bi[- ]?formation\b", "i-formation"),
+        ]:
+            if re.search(pat, lower):
+                form = label
+                break
+
         play = {
             "index": i,
             "src": str(f),
             "title": name,
             "notes": "",
             "direction": direction,
-            "is_run": None,
-            "is_pass": None,
-            "down": None,
-            "distance": None,
-            "formation": None,
+            "down": down,
+            "distance": distance,
+            "family": family,
+            "is_run": is_run,
+            "is_pass": is_pass,
+            "formation": form,
             "opponent": "Lincoln Christian",
             "opponent_primary_color": "black",
             "team": "MCA 5th (White)",


### PR DESCRIPTION
## Summary
- parse direction (R/L/rit/lit/reo/leo), down and distance, play families, and formation hints from video filenames in `discover_plays`
- set run/pass flags based on recognized play family

## Testing
- `pytest tests/test_pipeline_smoke.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c3372865e8832dac95f0da64a56f04