### PR TITLE
Add optical flow-based play autotagger and outcome tracking

### DIFF
--- a/analysis/autotag.py
+++ b/analysis/autotag.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+import cv2, json, pathlib, numpy as np, sys, math, statistics, os
+
+def read_clip(path, max_frames=180, step=2):
+    cap = cv2.VideoCapture(path)
+    frames = []
+    n = 0
+    while n < max_frames:
+        ok, f = cap.read()
+        if not ok: break
+        if n % step == 0:
+            frames.append(cv2.cvtColor(f, cv2.COLOR_BGR2GRAY))
+        n += 1
+    cap.release()
+    return frames
+
+def flow_features(frames):
+    # Farneback flow between consecutive frames
+    mags, angs, xs, ys = [], [], [], []
+    for i in range(1, len(frames)):
+        f0, f1 = frames[i-1], frames[i]
+        flow = cv2.calcOpticalFlowFarneback(f0, f1, None, 0.5, 3, 15, 3, 5, 1.2, 0)
+        vx, vy = flow[...,0], flow[...,1]
+        mag = np.sqrt(vx*vx + vy*vy)
+        ang = np.arctan2(vy, vx)  # radians, -pi..pi
+        mags.append(np.median(mag))
+        angs.append(np.median(ang))
+        xs.append(np.median(vx))
+        ys.append(np.median(vy))
+    if not mags:
+        return dict(mag_med=0, vx_med=0, vy_med=0, ang_med=0, mag_p95=0)
+    return dict(
+        mag_med = float(statistics.median(mags)),
+        mag_p95 = float(np.percentile(mags, 95)),
+        vx_med  = float(statistics.median(xs)),
+        vy_med  = float(statistics.median(ys)),
+        ang_med = float(statistics.median(angs)),
+    )
+
+def infer_direction(vx_med):
+    # Positive vx means motion to the right of the frame
+    if abs(vx_med) < 0.02: return "unknown"
+    return "right" if vx_med > 0 else "left"
+
+def infer_run_pass(mag_med, vy_med):
+    # Very rough: runs usually have steadier horizontal field motion near LOS;
+    # passes produce more erratic motion (dropback + disperse). Use thresholds.
+    if mag_med < 0.03: return "unknown"
+    # small vertical + steady magnitude -> "run"
+    return "run" if abs(vy_med) < 0.03 else "pass"
+
+def infer_outcome(mag_p95):
+    # Proxy for "did the play advance downfield": larger motion → positive
+    if mag_p95 >= 1.2: return "positive"
+    if mag_p95 <= 0.25: return "negative"
+    return "neutral"
+
+def process_jsonl(out_dir):
+    out = pathlib.Path(out_dir)
+    p = out / "plays.jsonl"
+    if not p.exists():
+        print(f"[autotag] missing {p}")
+        return
+    rows = [json.loads(x) for x in p.read_text().splitlines() if x.strip()]
+    updated = []
+    for i, pl in enumerate(rows, 1):
+        src = pl.get("src")
+        if not src or not pathlib.Path(src).exists():
+            updated.append(pl); continue
+        frames = read_clip(src, max_frames=180, step=2)
+        feats = flow_features(frames)
+        dir_guess = infer_direction(feats["vx_med"])
+        rp_guess  = infer_run_pass(feats["mag_med"], feats["vy_med"])
+        outc      = infer_outcome(feats["mag_p95"])
+        # Apply guesses only if not already set
+        if (pl.get("direction") in (None,"unknown")): pl["direction"] = dir_guess
+        if pl.get("is_run") is None and pl.get("is_pass") is None:
+            if rp_guess == "run": pl["is_run"]=True; pl["is_pass"]=False
+            elif rp_guess == "pass": pl["is_run"]=False; pl["is_pass"]=True
+            else: pl["is_run"]=None; pl["is_pass"]=None
+        pl["auto_outcome"] = outc
+        pl["auto_flow"] = feats
+        updated.append(pl)
+        print(f"[autotag] {i}/{len(rows)} {pathlib.Path(src).name}: dir={pl['direction']} rp={rp_guess} outcome={outc}")
+    # write back
+    with p.open("w") as f:
+        for pl in updated:
+            f.write(json.dumps(pl, ensure_ascii=False) + "\n")
+    print("[autotag] updated plays.jsonl")
+
+def main():
+    out_dir = sys.argv[1] if len(sys.argv)>1 else "output"
+    process_jsonl(out_dir)
+
+if __name__ == "__main__":
+    main()

--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -1445,6 +1445,11 @@ def main(argv=None) -> None:
 
         plays = discover_plays(args.input_dir)
         write_plays_jsonl(args.out, plays)
+        try:
+            from .autotag import process_jsonl as autotag_process
+            autotag_process(args.out)
+        except Exception as e:
+            print(f"[warn] autotag failed: {e}")
         build_coaches_cut(args.out, plays)
         if args.generate_report:
             try:

--- a/analysis/tendencies.py
+++ b/analysis/tendencies.py
@@ -76,10 +76,19 @@ def summarize(plays: List[Play]) -> Dict[str, Any]:
         fam = infer_family(p); sums["by_family"][fam]+=1
         form = infer_form(p); sums["by_formation"][form]+=1
         dirn = infer_direction(p); sums["by_direction"][dirn]+=1
-
-        if p.get("is_run") is True: sums["run_pass"]["run"]+=1
-        elif p.get("is_pass") is True: sums["run_pass"]["pass"]+=1
-        else: sums["run_pass"]["unknown"]+=1
+        if p.get("is_run") is True:
+            sums["run_pass"]["run"] += 1
+        elif p.get("is_pass") is True:
+            sums["run_pass"]["pass"] += 1
+        else:
+            af = p.get("auto_flow") or {}
+            mag_med = af.get("mag_med", 0)
+            vy_med = af.get("vy_med", 0)
+            if mag_med >= 0.03:
+                rp_guess = "run" if abs(vy_med) < 0.03 else "pass"
+                sums["run_pass"][rp_guess] += 1
+            else:
+                sums["run_pass"]["unknown"] += 1
 
         down = p.get("down")
         togo = p.get("distance") or p.get("to_go")
@@ -98,6 +107,10 @@ def summarize(plays: List[Play]) -> Dict[str, Any]:
                 sums["explosives"] += 1
         except Exception:
             pass
+        outcome = p.get("auto_outcome")
+        if outcome:
+            sums.setdefault("outcomes", collections.Counter())
+            sums["outcomes"][outcome] += 1
     return sums
 
 def write_csv(out_dir: pathlib.Path, plays: List[Play], sums: Dict[str,Any]):
@@ -110,6 +123,7 @@ def write_csv(out_dir: pathlib.Path, plays: List[Play], sums: Dict[str,Any]):
         for k,v in sums["by_family"].items(): w.writerow(["family",k,v])
         for k,v in sums["by_formation"].items(): w.writerow(["formation",k,v])
         for k,v in sums["by_direction"].items(): w.writerow(["direction",k,v])
+        for k,v in sums.get("outcomes", {}).items(): w.writerow(["outcome",k,v])
     return csv_path
 
 def write_md(out_dir: pathlib.Path, sums: Dict[str,Any]):
@@ -132,6 +146,7 @@ def write_md(out_dir: pathlib.Path, sums: Dict[str,Any]):
 {block(sums['by_family'], "Play Families")}
 {block(sums['by_formation'], "Formations (top)")}
 {block(sums['by_direction'], "Direction")}
+{block(sums.get('outcomes', collections.Counter()), "Outcomes")}
 ### Situational
 - **1st down (by family):** {dict(sums['first_down_calls'])}
 - **3rd & 5+ (by family):** {dict(sums['third_and_medium_plus'])}


### PR DESCRIPTION
## Summary
- Add `analysis/autotag.py` to tag plays via optical flow, estimating direction, run/pass, and outcome
- Invoke autotag step in input directory pipeline before generating tendencies
- Extend tendencies summary to leverage auto-flow run/pass guesses and track outcomes

## Testing
- `pytest tests/test_pipeline_smoke.py::test_pipeline_smoke -q`


------
https://chatgpt.com/codex/tasks/task_e_68c33b22318c832d9cdb6e7d1c6f02c0