### PR TITLE
Add automatic team identification and side-specific analytics

### DIFF
--- a/analysis/opponent_report.py
+++ b/analysis/opponent_report.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+import json, pathlib, csv, statistics, sys
+
+MCA_PLAYS = {
+    # Offense suggestions we can call vs THEIR defense
+    "edge_fast": ["Rit Jet Sweep", "Leo Jet Sweep", "Reo Quick Screen"],
+    "counter_cutback": ["Rit F Counter", "Lit F Counter", "Rit Power R"],
+    "flood_vs_zone": ["Reo Flood", "Leo Flood", "F Stick"],
+    "boot_vs_flow": ["Rit Flare Boot", "Lit Flare Boot"],
+}
+
+
+def load_jsonl(p):
+    return [json.loads(x) for x in p.read_text().splitlines() if x.strip()]
+
+
+def load_csv_counts(path):
+    counts = {}
+    if not path.exists():
+        return counts
+    with path.open() as f:
+        for row in csv.DictReader(f):
+            counts.setdefault(row["metric"], {})[row["key"]] = float(row["value"])
+    return counts
+
+
+def top_dirs(counts):
+    d = counts.get("direction", {})
+    items = sorted(d.items(), key=lambda kv: -kv[1])
+    return items[:2]
+
+
+def infer_def_weakness(def_counts):
+    # Heuristic: if direction bias exists, edge is weak to that side
+    dir_bias = top_dirs(def_counts)
+    recs = []
+    if dir_bias and dir_bias[0][0] in ("left", "right") and dir_bias[0][1] >= 6:
+        recs.append("edge_fast")
+    # If outside_run shows up as successful outcome (requires outcomes counter)
+    fam = def_counts.get("family", {})
+    if fam.get("outside_run", 0) >= fam.get("inside_run", 0) and fam.get("outside_run", 0) >= 6:
+        recs.append("counter_cutback")
+    # Default pass game ensures stress on flats/curl
+    recs.append("flood_vs_zone")
+    recs.append("boot_vs_flow")
+    return recs
+
+
+def positive_outcome_ratio(plays):
+    pos = sum(1 for p in plays if p.get("auto_outcome") == "positive")
+    return (pos, len(plays))
+
+
+def shortlist_star_clips(plays, k=6):
+    # Use flow p95 (saved under auto_flow.mag_p95) as proxy for impactful gain
+    scored = []
+    for p in plays:
+        m = (p.get("auto_flow") or {}).get("mag_p95", 0.0)
+        scored.append((m, pathlib.Path(p.get("src", "")).name))
+    scored.sort(reverse=True)
+    return [name for _, name in scored[:k]]
+
+
+def main(out_dir_str):
+    out = pathlib.Path(out_dir_str)
+    plays = load_jsonl(out / "plays.jsonl")
+    # Split sides
+    O = [p for p in plays if p.get("lincoln_side") == "offense"]
+    D = [p for p in plays if p.get("lincoln_side") == "defense"]
+
+    off_counts = load_csv_counts(out / "tendencies_offense.csv")
+    def_counts = load_csv_counts(out / "tendencies_defense.csv")
+
+    # Simple directional bias and family mix
+    star_off = shortlist_star_clips(O, k=6)
+
+    # Weakness recs: what WE should call on offense vs THEIR defense
+    rec_keys = infer_def_weakness(def_counts)
+    suggestions = [item for key in rec_keys for item in MCA_PLAYS.get(key, [])]
+
+    # Quick summary lines
+    o_pos, o_tot = positive_outcome_ratio(O)
+    d_pos, d_tot = positive_outcome_ratio(D)
+    lines = []
+    lines.append("# Lincoln Christian — Opponent Report\n")
+    lines.append(
+        f"**Clips analyzed:** {len(plays)}  |  **Lincoln Offense:** {len(O)}  |  **Lincoln Defense:** {len(D)}\n"
+    )
+    lines.append("## Lincoln Offense Tendencies (quick peek)")
+    rp = off_counts.get("run_pass", {})
+    fam = off_counts.get("family", {})
+    lines.append(f"- Run/Pass (auto): {int(rp.get('run', 0))} run / {int(rp.get('pass', 0))} pass")
+    if fam:
+        lines.append(
+            f"- Families top: {sorted(fam.items(), key=lambda kv: -kv[1])[:4]}"
+        )
+    lines.append(f"- Positive outcome rate (auto): {o_pos}/{o_tot}\n")
+    lines.append("**Star clips to review (highest impact motion):**")
+    for n in star_off:
+        lines.append(f"- {n}")
+    lines.append("\n## Lincoln Defense Tendencies (quick peek)")
+    rpD = def_counts.get("run_pass", {})
+    famD = def_counts.get("family", {})
+    lines.append(
+        f"- Offense faced (for context): {int(rpD.get('run', 0))} runs / {int(rpD.get('pass', 0))} passes"
+    )
+    if famD:
+        lines.append(
+            f"- Offense types vs them: {sorted(famD.items(), key=lambda kv:-kv[1])[:4]}"
+        )
+    lines.append(
+        f"- Positive outcome rate allowed (auto proxy): {d_pos}/{d_tot}\n"
+    )
+
+    lines.append("## Suggested MCA Calls vs Lincoln Defense")
+    for s in suggestions:
+        lines.append(f"- **{s}**")
+    lines.append(
+        "\n_Notes_: suggestions are heuristic. Confirm with the star clips and your assistants. If you tag 10–15 clips with `quick_tag`, rerun tendencies for sharper recs."
+    )
+    (out / "opponent_report.md").write_text("\n".join(lines), encoding="utf-8")
+    print("[opponent_report] wrote", out / "opponent_report.md")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1] if len(sys.argv) > 1 else "output")

--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -1446,6 +1446,11 @@ def main(argv=None) -> None:
         plays = discover_plays(args.input_dir)
         write_plays_jsonl(args.out, plays)
         try:
+            from .team_filter import apply as team_apply
+            team_apply(args.out)
+        except Exception as e:
+            print(f"[warn] team_filter failed: {e}")
+        try:
             from .autotag import process_jsonl as autotag_process
             autotag_process(args.out)
         except Exception as e:

--- a/analysis/team_filter.py
+++ b/analysis/team_filter.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+import cv2, json, pathlib, numpy as np, statistics, sys
+
+
+def sample_frames(path, max_samples=12):
+    cap = cv2.VideoCapture(str(path))
+    n, frames = 0, []
+    total = int(cap.get(cv2.CAP_PROP_FRAME_COUNT)) or 0
+    step = max(1, total // max_samples) if total else 5
+    while True:
+        ok, frame = cap.read()
+        if not ok:
+            break
+        if n % step == 0:
+            frames.append(frame)
+        n += 1
+        if len(frames) >= max_samples:
+            break
+    cap.release()
+    return frames
+
+
+def mask_black_bright(hsv):
+    # Black = low V & low S; White = high V & low S
+    # Hue is irrelevant for both extremes.
+    h, s, v = cv2.split(hsv)
+    black = cv2.inRange(hsv, (0, 0, 0), (180, 60, 60))
+    white = cv2.inRange(hsv, (0, 0, 180), (180, 40, 255))
+    return black, white
+
+
+def motion_score(prev_gray, gray, mask):
+    flow = cv2.calcOpticalFlowFarneback(
+        prev_gray, gray, None, 0.5, 3, 15, 3, 5, 1.2, 0
+    )
+    mag = np.sqrt(flow[..., 0] ** 2 + flow[..., 1] ** 2)
+    m = cv2.mean(mag, mask=mask)[0]
+    return float(m)
+
+
+def infer_lincoln_side(frames):
+    """Return side='offense'/'defense'/'unknown', conf (0..1)"""
+    # 1) Color dominance across frames
+    black_ratios, white_ratios = [], []
+    hsvs = [cv2.cvtColor(f, cv2.COLOR_BGR2HSV) for f in frames]
+    for hsv in hsvs:
+        black, white = mask_black_bright(hsv)
+        black_ratios.append(float(np.count_nonzero(black)) / (black.size))
+        white_ratios.append(float(np.count_nonzero(white)) / (white.size))
+    black_dom = statistics.median(black_ratios)
+    white_dom = statistics.median(white_ratios)
+
+    # 2) Early-motion attribution to black vs white (first 4 frame deltas)
+    motion_black, motion_white = [], []
+    grays = [cv2.cvtColor(f, cv2.COLOR_BGR2GRAY) for f in frames[:6]]
+    for i in range(1, len(grays)):
+        prev, cur = grays[i - 1], grays[i]
+        hsv = hsvs[i]
+        black, white = mask_black_bright(hsv)
+        motion_black.append(motion_score(prev, cur, black))
+        motion_white.append(motion_score(prev, cur, white))
+    mb = statistics.median(motion_black) if motion_black else 0.0
+    mw = statistics.median(motion_white) if motion_white else 0.0
+
+    # Heuristic: if black jerseys (Lincoln) have higher early motion near snap, they’re on offense
+    # Otherwise defense. Require some separation to be confident.
+    sep = mb - mw
+    if abs(sep) < 0.01:
+        side, conf = "unknown", 0.2
+    else:
+        side = "offense" if sep > 0 else "defense"
+        # confidence scales with separation and black presence
+        conf = max(0.2, min(0.95, 0.5 + 3.0 * abs(sep))) * max(
+            0.3, min(1.0, black_dom * 3)
+        )
+    return side, float(conf), dict(
+        black_dom=black_dom,
+        white_dom=white_dom,
+        motion_black=mb,
+        motion_white=mw,
+    )
+
+
+def tag_file(path):
+    frames = sample_frames(path, max_samples=10)
+    if not frames:
+        return "unknown", 0.0, dict(
+            black_dom=0, white_dom=0, motion_black=0, motion_white=0
+        )
+    return infer_lincoln_side(frames)
+
+
+def apply(out_dir: str):
+    out = pathlib.Path(out_dir)
+    p = out / "plays.jsonl"
+    if not p.exists():
+        print(f"[team_filter] missing {p}")
+        return
+    rows = [
+        json.loads(x) for x in p.read_text().splitlines() if x.strip()
+    ]
+    updated = []
+    for i, pl in enumerate(rows, 1):
+        src = pl.get("src")
+        if not src or not pathlib.Path(src).exists():
+            updated.append(pl)
+            continue
+        side, conf, diag = tag_file(src)
+        # Save only if not user-override present
+        if pl.get("lincoln_side") in (None, "unknown"):
+            pl["lincoln_side"] = side
+            pl["lincoln_side_conf"] = conf
+        pl["lincoln_diag"] = diag
+        updated.append(pl)
+        print(
+            f"[team_filter] {i}/{len(rows)} -> {pathlib.Path(src).name}: side={pl['lincoln_side']} conf={conf:.2f}"
+        )
+    with p.open("w") as f:
+        for pl in updated:
+            f.write(json.dumps(pl, ensure_ascii=False) + "\n")
+    print("[team_filter] updated plays.jsonl")
+
+
+def main():
+    out_dir = sys.argv[1] if len(sys.argv) > 1 else "output"
+    apply(out_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/tendencies.py
+++ b/analysis/tendencies.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-import json, csv, math, pathlib, collections, re
+import json, csv, math, pathlib, collections, re, argparse
 from typing import Dict, Any, List, Tuple
 
 Play = Dict[str, Any]
@@ -113,8 +113,8 @@ def summarize(plays: List[Play]) -> Dict[str, Any]:
             sums["outcomes"][outcome] += 1
     return sums
 
-def write_csv(out_dir: pathlib.Path, plays: List[Play], sums: Dict[str,Any]):
-    csv_path = out_dir / "tendencies.csv"
+def write_csv(out_dir: pathlib.Path, plays: List[Play], sums: Dict[str, Any], suffix: str = ""):
+    csv_path = out_dir / f"tendencies{suffix}.csv"
     with csv_path.open("w", newline="") as f:
         w = csv.writer(f)
         w.writerow(["metric","key","value"])
@@ -126,8 +126,9 @@ def write_csv(out_dir: pathlib.Path, plays: List[Play], sums: Dict[str,Any]):
         for k,v in sums.get("outcomes", {}).items(): w.writerow(["outcome",k,v])
     return csv_path
 
-def write_md(out_dir: pathlib.Path, sums: Dict[str,Any]):
-    md = out_dir / "tendencies.md"
+
+def write_md(out_dir: pathlib.Path, sums: Dict[str, Any], suffix: str = ""):
+    md = out_dir / f"tendencies{suffix}.md"
     total = max(1, sums["total"])
     def pct(n): return f"{(100.0*n/total):.1f}%"
     def block(counter: collections.Counter, title: str) -> str:
@@ -154,13 +155,30 @@ def write_md(out_dir: pathlib.Path, sums: Dict[str,Any]):
     md.write_text(content)
     return md
 
-def main(out_dir_str: str):
-    out_dir = pathlib.Path(out_dir_str)
-    plays = load_plays(out_dir)
+
+def parse_args():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("out_dir")
+    ap.add_argument("--only-lincoln-offense", action="store_true")
+    ap.add_argument("--only-lincoln-defense", action="store_true")
+    return ap.parse_args()
+
+
+def main():
+    args = parse_args()
+    out = pathlib.Path(args.out_dir)
+    plays = load_plays(out)
+    if args.only_lincoln_offense:
+        plays = [p for p in plays if p.get("lincoln_side") == "offense"]
+    if args.only_lincoln_defense:
+        plays = [p for p in plays if p.get("lincoln_side") == "defense"]
     sums = summarize(plays)
-    write_csv(out_dir, plays, sums)
-    write_md(out_dir, sums)
+    suffix = "_offense" if args.only_lincoln_offense else (
+        "_defense" if args.only_lincoln_defense else ""
+    )
+    write_csv(out, plays, sums, suffix)
+    write_md(out, sums, suffix)
+
 
 if __name__ == "__main__":
-    import sys
-    main(sys.argv[1] if len(sys.argv)>1 else "output")
+    main()


### PR DESCRIPTION
## Summary
- tag clips automatically with Lincoln's side (offense/defense/unknown) based on jersey color and motion
- allow tendencies report to filter by Lincoln offense or defense and emit suffixed files
- generate opponent_report.md with quick tendency summaries and call suggestions

## Testing
- `pytest tests/test_pipeline_cli_flags.py`


------
https://chatgpt.com/codex/tasks/task_e_68c33fa9596c832d82e977106eedad47