### PR TITLE
Improve side classification and analysis pipeline

### DIFF
--- a/analysis/autotag.py
+++ b/analysis/autotag.py
@@ -28,13 +28,15 @@ def flow_features(frames):
         xs.append(np.median(vx))
         ys.append(np.median(vy))
     if not mags:
-        return dict(mag_med=0, vx_med=0, vy_med=0, ang_med=0, mag_p95=0)
+        return dict(mag_med=0, vx_med=0, vy_med=0, ang_med=0, mag_p95=0, vy_std=0)
+    vy_std = float(np.std(ys)) if ys else 0.0
     return dict(
-        mag_med = float(statistics.median(mags)),
-        mag_p95 = float(np.percentile(mags, 95)),
-        vx_med  = float(statistics.median(xs)),
-        vy_med  = float(statistics.median(ys)),
-        ang_med = float(statistics.median(angs)),
+        mag_med=float(statistics.median(mags)),
+        mag_p95=float(np.percentile(mags, 95)),
+        vx_med=float(statistics.median(xs)),
+        vy_med=float(statistics.median(ys)),
+        ang_med=float(statistics.median(angs)),
+        vy_std=vy_std,
     )
 
 def infer_direction(vx_med):
@@ -42,11 +44,11 @@ def infer_direction(vx_med):
     if abs(vx_med) < 0.02: return "unknown"
     return "right" if vx_med > 0 else "left"
 
-def infer_run_pass(mag_med, vy_med):
-    # Very rough: runs usually have steadier horizontal field motion near LOS;
-    # passes produce more erratic motion (dropback + disperse). Use thresholds.
-    if mag_med < 0.03: return "unknown"
-    # small vertical + steady magnitude -> "run"
+def infer_run_pass(mag_med, vy_med, vy_std):
+    if mag_med < 0.02:
+        return "unknown"
+    if vy_std >= 0.08:
+        return "pass"
     return "run" if abs(vy_med) < 0.03 else "pass"
 
 def infer_outcome(mag_p95):
@@ -70,7 +72,7 @@ def process_jsonl(out_dir):
         frames = read_clip(src, max_frames=180, step=2)
         feats = flow_features(frames)
         dir_guess = infer_direction(feats["vx_med"])
-        rp_guess  = infer_run_pass(feats["mag_med"], feats["vy_med"])
+        rp_guess  = infer_run_pass(feats["mag_med"], feats["vy_med"], feats["vy_std"])
         outc      = infer_outcome(feats["mag_p95"])
         # Apply guesses only if not already set
         if (pl.get("direction") in (None,"unknown")): pl["direction"] = dir_guess

--- a/analysis/calibrate_team_colors.py
+++ b/analysis/calibrate_team_colors.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+"""Calibrate jersey color ranges for Lincoln from game film.
+
+This utility samples a handful of random clips from ``plays.jsonl`` and
+estimates HSV ranges for the team's dark (``black``) and light
+(``white``) jerseys using k-means clustering.  The resulting configuration
+is written to ``team_color_config.json`` inside the output directory.
+"""
+
+import json
+import pathlib
+import random
+import sys
+from typing import Iterable, List, Tuple
+
+import cv2  # type: ignore
+import numpy as np
+
+
+def _sample_paths(out_dir: pathlib.Path, k: int = 12) -> List[str]:
+    """Return up to ``k`` clip paths from ``plays.jsonl``."""
+
+    p = out_dir / "plays.jsonl"
+    rows = [json.loads(x) for x in p.read_text().splitlines() if x.strip()]
+    paths = [r["src"] for r in rows if "src" in r]
+    random.seed(42)
+    return random.sample(paths, min(k, len(paths)))
+
+
+def _kmeans_on_hsv(frames: Iterable[np.ndarray]) -> Tuple[Tuple[Tuple[int, int, int], Tuple[int, int, int]], Tuple[Tuple[int, int, int], Tuple[int, int, int]]]:
+    """Cluster HSV pixels and derive dark/light jersey ranges."""
+
+    samples: List[np.ndarray] = []
+    for fr in frames:
+        hsv = cv2.cvtColor(fr, cv2.COLOR_BGR2HSV)
+        h_, w_ = hsv.shape[:2]
+        # focus on midfield to avoid crowd/background
+        roi = hsv[h_ // 5 : 4 * h_ // 5, w_ // 6 : 5 * w_ // 6]
+        flat = roi.reshape(-1, 3)
+        if flat.size:
+            idx = np.random.choice(flat.shape[0], size=min(3000, flat.shape[0]), replace=False)
+            samples.append(flat[idx])
+
+    if not samples:
+        # Fallback to generic dark/light ranges
+        return ((0, 0, 0), (180, 60, 60)), ((0, 0, 180), (180, 40, 255))
+
+    allpix = np.vstack(samples).astype(np.float32)
+    K = 3
+    _, labels, centers = cv2.kmeans(
+        allpix,
+        K,
+        None,
+        (cv2.TERM_CRITERIA_EPS + cv2.TERM_CRITERIA_MAX_ITER, 20, 0.5),
+        4,
+        cv2.KMEANS_PP_CENTERS,
+    )
+
+    # Dark jersey → lowest V then lowest S
+    order = sorted(range(K), key=lambda i: (centers[i][2], centers[i][1]))
+    dark = centers[order[0]]
+    h, s, v = dark
+    lower = (max(0, int(h - 20)), 0, max(0, int(v - 40)))
+    upper = (min(180, int(h + 20)), int(min(80, s + 40)), int(v + 40))
+
+    # Light/white jersey → highest V cluster
+    light = centers[sorted(range(K), key=lambda i: -centers[i][2])[0]]
+    lh, ls, lv = light
+    lower_w = (0, 0, max(180, int(lv - 20)))
+    upper_w = (180, 40, 255)
+
+    return (lower, upper), (lower_w, upper_w)
+
+
+def _read_first_frame(path: str) -> np.ndarray | None:
+    cap = cv2.VideoCapture(path)
+    ok, fr = cap.read()
+    cap.release()
+    return fr if ok else None
+
+
+def run(out_dir_str: str) -> None:
+    out = pathlib.Path(out_dir_str)
+    paths = _sample_paths(out)
+    frames = [_read_first_frame(p) for p in paths]
+    frames = [f for f in frames if f is not None]
+    black_range, white_range = _kmeans_on_hsv(frames)
+    cfg = {
+        "black_hsv": {"lower": black_range[0], "upper": black_range[1]},
+        "white_hsv": {"lower": white_range[0], "upper": white_range[1]},
+    }
+    (out / "team_color_config.json").write_text(json.dumps(cfg, indent=2))
+    print("[calibrate] wrote", out / "team_color_config.json")
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry
+    run(sys.argv[1] if len(sys.argv) > 1 else "output")
+

--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -1451,6 +1451,16 @@ def main(argv=None) -> None:
         except Exception as e:
             print(f"[warn] team_filter failed: {e}")
         try:
+            from .calibrate_team_colors import run as calibrate_colors
+            calibrate_colors(args.out)
+        except Exception as e:
+            print(f"[warn] calibrate_team_colors failed: {e}")
+        try:
+            from .side_classifier import apply as side_apply
+            side_apply(args.out)
+        except Exception as e:
+            print(f"[warn] side_classifier failed: {e}")
+        try:
             from .autotag import process_jsonl as autotag_process
             autotag_process(args.out)
         except Exception as e:
@@ -1460,12 +1470,16 @@ def main(argv=None) -> None:
             phase_apply(args.out)
         except Exception as e:
             print(f"[warn] phase_classify failed: {e}")
-        # Clean up low-confidence & special teams
         try:
-            from .reclassify import main as reclassify_main
-            reclassify_main(args.out, min_side_conf=0.40, drop_special=True)
+            from .sequence_smooth import smooth as seq_smooth
+            seq_smooth(args.out)
         except Exception as e:
-            print(f"[warn] reclassify failed: {e}")
+            print(f"[warn] sequence_smooth failed: {e}")
+        try:
+            from .reclassify2 import main as reclass2
+            reclass2(args.out, min_side_conf=0.40)
+        except Exception as e:
+            print(f"[warn] reclassify2 failed: {e}")
         build_coaches_cut(args.out, plays)
         if args.generate_report:
             try:

--- a/analysis/reclassify2.py
+++ b/analysis/reclassify2.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+"""Reclassify plays with phase gating and smoothed side preference."""
+
+import json
+import pathlib
+import sys
+from typing import List, Dict
+
+
+def main(out_dir: str, min_side_conf: float = 0.40, drop_special: bool = True) -> None:
+    out = pathlib.Path(out_dir)
+    p = out / "plays.jsonl"
+    rows = [json.loads(x) for x in p.read_text().splitlines() if x.strip()]
+    cleaned: List[Dict[str, object]] = []
+    for r in rows:
+        side = r.get("lincoln_side_smoothed") or r.get("lincoln_side") or "unknown"
+        conf = float(r.get("lincoln_side_conf", 0.3))
+        phase = r.get("phase", "unknown")
+        if drop_special and phase == "special_teams":
+            side = "unknown"
+        if conf < min_side_conf and side != "unknown":
+            r["lincoln_low_conf"] = True
+        r["lincoln_side_final"] = side
+        cleaned.append(r)
+
+    with p.open("w") as f:
+        for r in cleaned:
+            f.write(json.dumps(r, ensure_ascii=False) + "\n")
+    print("[reclassify2] applied phase gating + smoothing preference")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    out = sys.argv[1] if len(sys.argv) > 1 else "output"
+    thr = float(sys.argv[2]) if len(sys.argv) > 2 else 0.40
+    main(out, thr, True)
+

--- a/analysis/sequence_smooth.py
+++ b/analysis/sequence_smooth.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+"""Hidden Markov Model smoothing of offense/defense classifications."""
+
+import json
+import pathlib
+import sys
+from typing import Dict, List
+
+
+STATES = ["offense", "defense"]
+# Drives rarely flip back and forth quickly; favour staying in the same state
+LOG_P_STAY = -0.1
+LOG_P_SWITCH = -2.0
+
+
+def _viterbi(obs: List[Dict[str, float]]) -> List[str]:
+    """Classic Viterbi decoding for a two-state HMM."""
+
+    V: List[Dict[str, tuple[float, str | None]]] = [
+        {s: (-1e9, None) for s in STATES} for _ in obs
+    ]
+
+    for s in STATES:
+        V[0][s] = (obs[0][s], None)
+
+    for t in range(1, len(obs)):
+        for s in STATES:
+            best = (-1e9, None)
+            for sp in STATES:
+                trans = LOG_P_STAY if s == sp else LOG_P_SWITCH
+                score = V[t - 1][sp][0] + trans + obs[t][s]
+                if score > best[0]:
+                    best = (score, sp)
+            V[t][s] = best
+
+    last_state = max(STATES, key=lambda s: V[-1][s][0])
+    path = [last_state]
+    for t in range(len(obs) - 1, 0, -1):
+        last_state = V[t][last_state][1]  # type: ignore[index]
+        path.append(last_state)  # type: ignore[arg-type]
+    return list(reversed(path))
+
+
+def smooth(out_dir: str) -> None:
+    out = pathlib.Path(out_dir)
+    p = out / "plays.jsonl"
+    rows = [json.loads(x) for x in p.read_text().splitlines() if x.strip()]
+
+    idx_map: List[int] = []
+    obs: List[Dict[str, float]] = []
+    for i, r in enumerate(rows):
+        if r.get("phase") == "special_teams":
+            continue
+        side = r.get("lincoln_side", "unknown")
+        c = float(r.get("lincoln_side_conf", 0.3))
+        ll = {"offense": -1.2, "defense": -1.2}
+        if side == "offense":
+            ll["offense"] = -0.1 + 1.5 * c
+        elif side == "defense":
+            ll["defense"] = -0.1 + 1.5 * c
+        obs.append(ll)
+        idx_map.append(i)
+
+    if not obs:
+        return
+
+    path = _viterbi(obs)
+    for state, idx in zip(path, idx_map):
+        rows[idx]["lincoln_side_smoothed"] = state
+
+    with p.open("w") as f:
+        for r in rows:
+            f.write(json.dumps(r, ensure_ascii=False) + "\n")
+    print("[sequence_smooth] wrote smoothed sides")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    smooth(sys.argv[1] if len(sys.argv) > 1 else "output")
+

--- a/analysis/side_classifier.py
+++ b/analysis/side_classifier.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+"""Multi-cue classifier determining Lincoln's side of the ball.
+
+The classifier combines colour-based motion cues, backfield activity, and
+spacing heuristics to label clips as offense, defense, special teams, or
+unknown.  It writes the results back into ``plays.jsonl``.
+"""
+
+import json
+import pathlib
+import statistics
+from typing import Dict, List, Tuple
+
+import cv2  # type: ignore
+import numpy as np
+
+
+def _load_colors(out_dir: pathlib.Path) -> Tuple[Tuple[int, int, int], Tuple[int, int, int], Tuple[int, int, int], Tuple[int, int, int]]:
+    p = out_dir / "team_color_config.json"
+    if not p.exists():
+        return (0, 0, 0), (180, 60, 60), (0, 0, 180), (180, 40, 255)
+    cfg = json.loads(p.read_text())
+    bl = tuple(cfg["black_hsv"]["lower"])
+    bu = tuple(cfg["black_hsv"]["upper"])
+    wl = tuple(cfg["white_hsv"]["lower"])
+    wu = tuple(cfg["white_hsv"]["upper"])
+    return bl, bu, wl, wu
+
+
+def _sample_frames(path: pathlib.Path, max_samples: int = 12) -> List[np.ndarray]:
+    cap = cv2.VideoCapture(str(path))
+    n, frames = 0, []
+    total = int(cap.get(cv2.CAP_PROP_FRAME_COUNT)) or 0
+    step = max(1, total // max_samples) if total else 5
+    while True:
+        ok, fr = cap.read()
+        if not ok:
+            break
+        if n % step == 0:
+            frames.append(fr)
+        n += 1
+        if len(frames) >= max_samples:
+            break
+    cap.release()
+    return frames
+
+
+def _flow(prev: np.ndarray, cur: np.ndarray) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    pr = cv2.cvtColor(prev, cv2.COLOR_BGR2GRAY)
+    cr = cv2.cvtColor(cur, cv2.COLOR_BGR2GRAY)
+    f = cv2.calcOpticalFlowFarneback(pr, cr, None, 0.5, 3, 15, 3, 5, 1.2, 0)
+    vx, vy = f[..., 0], f[..., 1]
+    mag = np.sqrt(vx * vx + vy * vy)
+    return vx, vy, mag
+
+
+def _cue_color_motion(frames: List[np.ndarray], bl_l, bl_u, wl_l, wl_u) -> float:
+    scores = []
+    for i in range(1, min(len(frames), 6)):
+        prev, cur = frames[i - 1], frames[i]
+        vx, vy, mag = _flow(prev, cur)
+        hsv = cv2.cvtColor(cur, cv2.COLOR_BGR2HSV)
+        black = cv2.inRange(hsv, bl_l, bl_u)
+        white = cv2.inRange(hsv, wl_l, wl_u)
+        mb = cv2.mean(mag, mask=black)[0]
+        mw = cv2.mean(mag, mask=white)[0]
+        scores.append(mb - mw)
+    if not scores:
+        return 0.0
+    return float(statistics.median(scores))
+
+
+def _cue_backfield_first(frames: List[np.ndarray]) -> float:
+    scores = []
+    for i in range(1, min(len(frames), 6)):
+        prev, cur = frames[i - 1], frames[i]
+        h, w = cur.shape[:2]
+        roi_prev = prev[int(0.55 * h) : int(0.85 * h), int(0.2 * w) : int(0.8 * w)]
+        roi_cur = cur[int(0.55 * h) : int(0.85 * h), int(0.2 * w) : int(0.8 * w)]
+        vx, vy, mag = _flow(roi_prev, roi_cur)
+        scores.append(float(np.median(mag)))
+    if not scores:
+        return 0.0
+    return float(statistics.median(scores))
+
+
+def _cue_spacing_special(frames: List[np.ndarray]) -> float:
+    def blob_count(fr: np.ndarray) -> Tuple[int, float]:
+        g = cv2.cvtColor(fr, cv2.COLOR_BGR2GRAY)
+        g = cv2.GaussianBlur(g, (5, 5), 0)
+        _, bw = cv2.threshold(g, 0, 255, cv2.THRESH_OTSU)
+        bw = cv2.bitwise_not(bw)
+        cnts, _ = cv2.findContours(bw, cv2.RETR_LIST, cv2.CHAIN_APPROX_SIMPLE)
+        areas = [cv2.contourArea(c) for c in cnts if cv2.contourArea(c) > 80]
+        return len(areas), (np.mean(areas) if areas else 0.0)
+
+    if not frames:
+        return 0.0
+    n1, a1 = blob_count(frames[0])
+    n4, a4 = blob_count(frames[min(3, len(frames) - 1)])
+    score = 0.0
+    if n1 <= 20 and (n4 - n1) >= 8:
+        score += 0.6
+    if a1 >= 400:
+        score += 0.2
+    return float(score)
+
+
+def _classify_side(path: pathlib.Path, colors) -> Tuple[str, float, Dict[str, float]]:
+    bl_l, bl_u, wl_l, wl_u = colors
+    frames = _sample_frames(path)
+    if not frames:
+        return "unknown", 0.2, {}
+    s_color = _cue_color_motion(frames, bl_l, bl_u, wl_l, wl_u)
+    s_back = _cue_backfield_first(frames)
+    s_st = _cue_spacing_special(frames)
+    if s_st >= 0.7:
+        return "special_teams", min(0.95, 0.6 + 0.4 * s_st), {"s_color": s_color, "s_back": s_back, "s_st": s_st}
+    raw = 0.6 * np.tanh(2.5 * s_color) + 0.4 * np.tanh(3.0 * (s_back - 0.02))
+    if raw > 0.15:
+        return "offense", float(min(0.95, 0.5 + raw)), {"s_color": s_color, "s_back": s_back, "s_st": s_st}
+    if raw < -0.05:
+        return "defense", float(min(0.95, 0.5 + abs(raw))), {"s_color": s_color, "s_back": s_back, "s_st": s_st}
+    return "unknown", 0.3, {"s_color": s_color, "s_back": s_back, "s_st": s_st}
+
+
+def apply(out_dir: str) -> None:
+    out = pathlib.Path(out_dir)
+    colors = _load_colors(out)
+    p = out / "plays.jsonl"
+    rows = [json.loads(x) for x in p.read_text().splitlines() if x.strip()]
+    upd: List[Dict[str, object]] = []
+    for i, r in enumerate(rows, 1):
+        src = r.get("src")
+        if not src or not pathlib.Path(src).exists():
+            upd.append(r)
+            continue
+        side, conf, diag = _classify_side(pathlib.Path(src), colors)
+        if r.get("lincoln_side") in (None, "unknown"):
+            r["lincoln_side"] = side
+        else:
+            r["lincoln_side"] = r["lincoln_side"]
+        r["lincoln_side_conf"] = float(conf)
+        r["lincoln_diag2"] = diag
+        upd.append(r)
+        print(f"[side_classifier] {i}/{len(rows)} {pathlib.Path(src).name}: side={r['lincoln_side']} conf={conf:.2f}")
+
+    with p.open("w") as f:
+        for r in upd:
+            f.write(json.dumps(r, ensure_ascii=False) + "\n")
+    print("[side_classifier] updated plays.jsonl")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    import sys
+
+    apply(sys.argv[1] if len(sys.argv) > 1 else "output")
+

--- a/analysis/tendencies.py
+++ b/analysis/tendencies.py
@@ -161,7 +161,14 @@ def parse_args():
     ap.add_argument("out_dir")
     ap.add_argument("--only-lincoln-offense", action="store_true")
     ap.add_argument("--only-lincoln-defense", action="store_true")
-    ap.add_argument("--exclude-phase", default="", help="comma list of phases to exclude")
+    ap.add_argument("--use-smoothed-side", dest="use_smoothed_side", action="store_true")
+    ap.add_argument("--no-use-smoothed-side", dest="use_smoothed_side", action="store_false")
+    ap.set_defaults(use_smoothed_side=True)
+    ap.add_argument(
+        "--exclude-phase",
+        default="special_teams,unknown",
+        help="comma list of phases to exclude",
+    )
     ap.add_argument("--min-side-conf", type=float, default=0.40)
     return ap.parse_args()
 
@@ -172,21 +179,23 @@ def main():
     plays = load_plays(out)
     excl = set()
     if args.exclude_phase:
-        excl = set([x.strip() for x in args.exclude_phase.split(",") if x.strip()])
+        excl = {x.strip() for x in args.exclude_phase.split(",") if x.strip()}
     plays = [p for p in plays if p.get("phase") not in excl]
+
+    side_key = "lincoln_side_final" if args.use_smoothed_side else "lincoln_side"
 
     if args.min_side_conf:
         plays = [
             p
             for p in plays
-            if float(p.get("lincoln_side_conf", 0)) >= args.min_side_conf
-            or p.get("lincoln_side") == "unknown"
+            if p.get(side_key) == "unknown"
+            or float(p.get("lincoln_side_conf", 0)) >= args.min_side_conf
         ]
 
     if args.only_lincoln_offense:
-        plays = [p for p in plays if p.get("lincoln_side") == "offense"]
+        plays = [p for p in plays if p.get(side_key) == "offense"]
     if args.only_lincoln_defense:
-        plays = [p for p in plays if p.get("lincoln_side") == "defense"]
+        plays = [p for p in plays if p.get(side_key) == "defense"]
 
     sums = summarize(plays)
     suffix = ""
@@ -198,6 +207,8 @@ def main():
         suffix += f"_conf{int(args.min_side_conf*100)}"
     if args.exclude_phase:
         suffix += "_nophase"
+    if args.use_smoothed_side:
+        suffix += "_smooth"
     write_csv(out, plays, sums, suffix)
     write_md(out, sums, suffix)
 


### PR DESCRIPTION
## Summary
- auto-calibrate Lincoln jersey colours and multi-cue side classifier
- smooth offense/defense sequence with HMM and reclassify with phase gating
- enhance autotag run/pass rules and update tendencies/pipeline to use clean splits

## Testing
- `pytest` *(fails: AttributeError: module 'gameday' has no attribute 'parse_args')*


------
https://chatgpt.com/codex/tasks/task_e_68c40a66ca9c832d9bf534a7528853a3