### PR TITLE
feat: improve side classification with seed model

### DIFF
--- a/analysis/apply_side_model.py
+++ b/analysis/apply_side_model.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+import json, pathlib, numpy as np, sys
+
+def load_model(out):
+    m=json.loads((out/"side_model.json").read_text())
+    return m
+
+def load_feats(out):
+    return json.loads((out/"features.json").read_text())
+
+def predict_one(f, M):
+    if not f or not f.get("ok"):
+        return "unknown", 0.25
+    x=np.array([float(f.get(k,0.0)) for k in M["feats"]], dtype=np.float32)
+    mu=np.array(M["mu"]); sigma=np.array(M["sigma"])
+    xn=(x-mu)/sigma
+    W=np.array(M["W"]); b=np.array(M["b"])
+    z = xn.dot(W)+b
+    z = z - z.max()
+    e=np.exp(z); p=e/np.sum(e)
+    idx=int(np.argmax(p)); return M["classes"][idx], float(p[idx])
+
+def apply(out_dir):
+    out=pathlib.Path(out_dir); model=load_model(out); feat=load_feats(out)
+    p=out/"plays.jsonl"; rows=[json.loads(x) for x in p.read_text().splitlines() if x.strip()]
+    upd=[]
+    for r in rows:
+        src=r.get("src"); f=feat.get(src)
+        lab, conf = predict_one(f, model)
+        # precedence: manual override (seed_labels.json) will be picked up later by reclassifier
+        r["lincoln_side_model"]=lab; r["lincoln_side_model_conf"]=conf
+        upd.append(r)
+    with p.open("w") as w:
+        for r in upd: w.write(json.dumps(r, ensure_ascii=False)+"\n")
+    print("[apply_model] wrote model predictions")
+
+if __name__=="__main__":
+    apply(sys.argv[1] if len(sys.argv)>1 else "output")

--- a/analysis/feat_extract.py
+++ b/analysis/feat_extract.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+import cv2, numpy as np, json, pathlib, statistics
+
+def _read_frames(path, max_samples=12):
+    cap = cv2.VideoCapture(str(path))
+    frames=[]; total=int(cap.get(cv2.CAP_PROP_FRAME_COUNT) or 0)
+    step=max(1,total//max_samples) if total else 5; i=0
+    while True:
+        ok, fr=cap.read()
+        if not ok: break
+        if i%step==0: frames.append(fr)
+        i+=1
+        if len(frames)>=max_samples: break
+    cap.release(); return frames
+
+def _flow(prev,cur):
+    pr=cv2.cvtColor(prev,cv2.COLOR_BGR2GRAY)
+    cr=cv2.cvtColor(cur, cv2.COLOR_BGR2GRAY)
+    f=cv2.calcOpticalFlowFarneback(pr,cr,None,0.5,3,15,3,5,1.2,0)
+    vx,vy=f[...,0],f[...,1]; mag=np.sqrt(vx*vx+vy*vy)
+    return vx,vy,mag
+
+def _mask_hsv(fr, low, up):
+    hsv=cv2.cvtColor(fr, cv2.COLOR_BGR2HSV)
+    return cv2.inRange(hsv, low, up)
+
+def _blob_stats(fr):
+    g=cv2.cvtColor(fr,cv2.COLOR_BGR2GRAY)
+    g=cv2.GaussianBlur(g,(5,5),0)
+    _,bw=cv2.threshold(g,0,255,cv2.THRESH_OTSU)
+    bw=cv2.bitwise_not(bw)
+    cnts,_=cv2.findContours(bw,cv2.RETR_LIST,cv2.CHAIN_APPROX_SIMPLE)
+    areas=[cv2.contourArea(c) for c in cnts if cv2.contourArea(c)>80]
+    return len(areas), (float(np.mean(areas)) if areas else 0.0)
+
+def _load_colors(out_dir: pathlib.Path):
+    p=out_dir/"team_color_config.json"
+    if not p.exists():
+        # fallback: broad black/white ranges
+        return (0,0,0),(180,60,60),(0,0,180),(180,40,255)
+    cfg=json.loads(p.read_text())
+    bl_l=tuple(cfg["black_hsv"]["lower"]); bl_u=tuple(cfg["black_hsv"]["upper"])
+    wh_l=tuple(cfg["white_hsv"]["lower"]); wh_u=tuple(cfg["white_hsv"]["upper"])
+    return bl_l,bl_u,wh_l,wh_u
+
+def extract_for_clip(path, out_dir: pathlib.Path):
+    bl_l,bl_u,wh_l,wh_u=_load_colors(out_dir)
+    frames=_read_frames(path, max_samples=10)
+    if not frames: 
+        return {"ok":False}
+
+    # color ratios on first frame
+    bmask=_mask_hsv(frames[0], bl_l, bl_u)
+    wmask=_mask_hsv(frames[0], wh_l, wh_u)
+    black_ratio=float(np.count_nonzero(bmask))/bmask.size
+    white_ratio=float(np.count_nonzero(wmask))/wmask.size
+
+    # early optical flow deltas
+    mags=[]; vxs=[]; vys=[]; mb_minus_mw=[]
+    for i in range(1, min(len(frames), 6)):
+        prev,cur=frames[i-1],frames[i]
+        vx,vy,mag=_flow(prev,cur)
+        mags.append(float(np.median(mag)))
+        vxs.append(float(np.median(vx)))
+        vys.append(float(np.median(vy)))
+        hsv=cv2.cvtColor(cur, cv2.COLOR_BGR2HSV)
+        b=cv2.inRange(hsv, bl_l, bl_u); w=cv2.inRange(hsv, wh_l, wh_u)
+        mb=cv2.mean(mag, mask=b)[0]; mw=cv2.mean(mag, mask=w)[0]
+        mb_minus_mw.append(mb - mw)
+
+    mag_med=float(statistics.median(mags)) if mags else 0.0
+    mag_p90=float(np.percentile(mags,90)) if mags else 0.0
+    vx_med=float(statistics.median(vxs)) if vxs else 0.0
+    vy_med=float(statistics.median(vys)) if vys else 0.0
+    vy_std=float(np.std(vys)) if vys else 0.0
+    color_lead=float(statistics.median(mb_minus_mw)) if mb_minus_mw else 0.0
+
+    # spacing (special teams cue)
+    n1,a1=_blob_stats(frames[0]); n4,a4=_blob_stats(frames[min(3,len(frames)-1)])
+
+    return {
+        "ok":True,
+        "black_ratio":black_ratio, "white_ratio":white_ratio,
+        "mag_med":mag_med, "mag_p90":mag_p90,
+        "vx_med":vx_med, "vy_med":vy_med, "vy_std":vy_std,
+        "color_lead":color_lead,
+        "n1":float(n1), "a1":float(a1), "n4":float(n4), "a4":float(a4)
+    }
+
+def cache_all(out_dir_str: str):
+    out=pathlib.Path(out_dir_str); p=out/"plays.jsonl"
+    rows=[json.loads(x) for x in p.read_text().splitlines() if x.strip()]
+    feat={}
+    for i,r in enumerate(rows,1):
+        src=r.get("src"); 
+        if not src or not pathlib.Path(src).exists(): continue
+        f=extract_for_clip(src,out)
+        feat[src]=f
+        print(f"[feat] {i}/{len(rows)} {pathlib.Path(src).name} ok={f['ok']}")
+    (out/"features.json").write_text(json.dumps(feat, indent=2))
+    print("[feat] wrote", out/"features.json")
+
+if __name__=="__main__":
+    import sys; cache_all(sys.argv[1] if len(sys.argv)>1 else "output")

--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -1455,6 +1455,20 @@ def main(argv=None) -> None:
             calibrate_colors(args.out)
         except Exception as e:
             print(f"[warn] calibrate_team_colors failed: {e}")
+
+        from .feat_extract import cache_all as feat_cache
+        feat_cache(args.out)
+
+        from pathlib import Path
+        outp=Path(args.out)
+        if (outp/"seed_labels.json").exists():
+            try:
+                from .train_side_model import main as train_model
+                train_model(args.out)
+                from .apply_side_model import apply as apply_model
+                apply_model(args.out)
+            except Exception as e:
+                print(f"[warn] side model failed: {e}")
         try:
             from .side_classifier import apply as side_apply
             side_apply(args.out)
@@ -1475,11 +1489,8 @@ def main(argv=None) -> None:
             seq_smooth(args.out)
         except Exception as e:
             print(f"[warn] sequence_smooth failed: {e}")
-        try:
-            from .reclassify2 import main as reclass2
-            reclass2(args.out, min_side_conf=0.40)
-        except Exception as e:
-            print(f"[warn] reclassify2 failed: {e}")
+        from .reclassify2 import main as reclass2
+        reclass2(args.out, min_side_conf=0.40)
         build_coaches_cut(args.out, plays)
         if args.generate_report:
             try:

--- a/analysis/reclassify2.py
+++ b/analysis/reclassify2.py
@@ -1,37 +1,42 @@
 from __future__ import annotations
+import json, pathlib, sys
 
-"""Reclassify plays with phase gating and smoothed side preference."""
+def main(out_dir: str, min_side_conf=0.40):
+    out=pathlib.Path(out_dir)
+    p=out/"plays.jsonl"
+    rows=[json.loads(x) for x in p.read_text().splitlines() if x.strip()]
+    seeds={}
+    sp=out/"seed_labels.json"
+    if sp.exists(): seeds=json.loads(sp.read_text())
 
-import json
-import pathlib
-import sys
-from typing import List, Dict
-
-
-def main(out_dir: str, min_side_conf: float = 0.40, drop_special: bool = True) -> None:
-    out = pathlib.Path(out_dir)
-    p = out / "plays.jsonl"
-    rows = [json.loads(x) for x in p.read_text().splitlines() if x.strip()]
-    cleaned: List[Dict[str, object]] = []
+    cleaned=[]
     for r in rows:
-        side = r.get("lincoln_side_smoothed") or r.get("lincoln_side") or "unknown"
-        conf = float(r.get("lincoln_side_conf", 0.3))
-        phase = r.get("phase", "unknown")
-        if drop_special and phase == "special_teams":
-            side = "unknown"
-        if conf < min_side_conf and side != "unknown":
-            r["lincoln_low_conf"] = True
-        r["lincoln_side_final"] = side
+        src=r.get("src"); phase=r.get("phase","unknown")
+        # precedence: manual override > model > heuristic > smoothed
+        side = None; conf=0.0
+        if src in seeds:
+            side=seeds[src]; conf=0.99
+        elif r.get("lincoln_side_model"):
+            side=r["lincoln_side_model"]; conf=float(r.get("lincoln_side_model_conf",0.5))
+        elif r.get("lincoln_side"):
+            side=r["lincoln_side"]; conf=float(r.get("lincoln_side_conf",0.3))
+        elif r.get("lincoln_side_smoothed"):
+            side=r["lincoln_side_smoothed"]; conf=0.35
+
+        # phase gating
+        if phase=="special_teams":
+            side="unknown"
+
+        r["lincoln_side_final"]=side or "unknown"
+        r["lincoln_side_final_conf"]=conf
+        r["lincoln_low_conf"] = bool(conf < min_side_conf and r["lincoln_side_final"]!="unknown")
         cleaned.append(r)
 
-    with p.open("w") as f:
-        for r in cleaned:
-            f.write(json.dumps(r, ensure_ascii=False) + "\n")
-    print("[reclassify2] applied phase gating + smoothing preference")
+    with p.open("w") as w:
+        for r in cleaned: w.write(json.dumps(r, ensure_ascii=False)+"\n")
+    print("[reclassify2] finalized side with precedence & overrides")
 
-
-if __name__ == "__main__":  # pragma: no cover
-    out = sys.argv[1] if len(sys.argv) > 1 else "output"
-    thr = float(sys.argv[2]) if len(sys.argv) > 2 else 0.40
-    main(out, thr, True)
-
+if __name__=="__main__":
+    out=sys.argv[1] if len(sys.argv)>1 else "output"
+    thr=float(sys.argv[2]) if len(sys.argv)>2 else 0.40
+    main(out, thr)

--- a/analysis/seed_labels.py
+++ b/analysis/seed_labels.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+import json, pathlib, sys
+
+HELP = """Usage:
+python -m analysis.seed_labels OUT --offense 7,9,15 --defense 3,4 --special 20,21
+Indexes refer to the order in plays.jsonl (1-based), or pass filenames with --files.
+"""
+
+def main():
+    out=pathlib.Path(sys.argv[1] if len(sys.argv)>1 else "output")
+    args=sys.argv[2:]
+    idx_off, idx_def, idx_sp = [], [], []
+    files_mode=False
+
+    def parse_list(s):
+        return [x.strip() for x in s.split(",") if x.strip()]
+
+    i=0
+    while i<len(args):
+        if args[i]=="--offense":
+            idx_off+=parse_list(args[i+1]); i+=2
+        elif args[i]=="--defense":
+            idx_def+=parse_list(args[i+1]); i+=2
+        elif args[i]=="--special":
+            idx_sp+=parse_list(args[i+1]); i+=2
+        elif args[i]=="--files":
+            files_mode=True; i+=1
+        else:
+            print(HELP); return
+
+    rows=[json.loads(x) for x in (out/"plays.jsonl").read_text().splitlines() if x.strip()]
+    srcs=[r["src"] for r in rows]
+    labels={}
+    if files_mode:
+        # items are filenames
+        def to_src(name):
+            for s in srcs:
+                if pathlib.Path(s).name==name: return s
+            return None
+        for n in idx_off:
+            s=to_src(n); 
+            if s: labels[s]="offense"
+        for n in idx_def:
+            s=to_src(n); 
+            if s: labels[s]="defense"
+        for n in idx_sp:
+            s=to_src(n); 
+            if s: labels[s]="special_teams"
+    else:
+        # items are indices 1-based
+        for n in idx_off:
+            j=int(n)-1
+            if 0<=j<len(srcs): labels[srcs[j]]="offense"
+        for n in idx_def:
+            j=int(n)-1
+            if 0<=j<len(srcs): labels[srcs[j]]="defense"
+        for n in idx_sp:
+            j=int(n)-1
+            if 0<=j<len(srcs): labels[srcs[j]]="special_teams"
+
+    (out/"seed_labels.json").write_text(json.dumps(labels, indent=2))
+    print("[seed] wrote", out/"seed_labels.json")
+
+if __name__=="__main__":
+    main()

--- a/analysis/tendencies.py
+++ b/analysis/tendencies.py
@@ -161,9 +161,7 @@ def parse_args():
     ap.add_argument("out_dir")
     ap.add_argument("--only-lincoln-offense", action="store_true")
     ap.add_argument("--only-lincoln-defense", action="store_true")
-    ap.add_argument("--use-smoothed-side", dest="use_smoothed_side", action="store_true")
-    ap.add_argument("--no-use-smoothed-side", dest="use_smoothed_side", action="store_false")
-    ap.set_defaults(use_smoothed_side=True)
+    ap.add_argument("--use-raw-side", action="store_true", help="use original side classifier output")
     ap.add_argument(
         "--exclude-phase",
         default="special_teams,unknown",
@@ -182,14 +180,15 @@ def main():
         excl = {x.strip() for x in args.exclude_phase.split(",") if x.strip()}
     plays = [p for p in plays if p.get("phase") not in excl]
 
-    side_key = "lincoln_side_final" if args.use_smoothed_side else "lincoln_side"
+    side_key = "lincoln_side" if args.use_raw_side else "lincoln_side_final"
 
     if args.min_side_conf:
+        conf_key = "lincoln_side_conf" if args.use_raw_side else "lincoln_side_final_conf"
         plays = [
             p
             for p in plays
             if p.get(side_key) == "unknown"
-            or float(p.get("lincoln_side_conf", 0)) >= args.min_side_conf
+            or float(p.get(conf_key, 0)) >= args.min_side_conf
         ]
 
     if args.only_lincoln_offense:
@@ -207,8 +206,8 @@ def main():
         suffix += f"_conf{int(args.min_side_conf*100)}"
     if args.exclude_phase:
         suffix += "_nophase"
-    if args.use_smoothed_side:
-        suffix += "_smooth"
+    if args.use_raw_side:
+        suffix += "_raw"
     write_csv(out, plays, sums, suffix)
     write_md(out, sums, suffix)
 

--- a/analysis/train_side_model.py
+++ b/analysis/train_side_model.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+import json, pathlib, numpy as np, sys
+
+CLASSES=["offense","defense","special_teams"]
+FEATS=["black_ratio","white_ratio","mag_med","mag_p90","vx_med","vy_med","vy_std","color_lead","n1","a1","n4","a4"]
+
+def load_feats(out):
+    feat=json.loads((out/"features.json").read_text())
+    return feat
+
+def load_seeds(out):
+    seeds=json.loads((out/"seed_labels.json").read_text())
+    return seeds
+
+def build_XY(feat, seeds):
+    X=[]; y=[]
+    for src,lab in seeds.items():
+        f=feat.get(src); 
+        if not f or not f.get("ok"): continue
+        X.append([float(f.get(k,0.0)) for k in FEATS])
+        y.append(CLASSES.index(lab))
+    X=np.array(X, dtype=np.float32); y=np.array(y, dtype=np.int64)
+    return X,y
+
+def normalize(X):
+    mu=X.mean(axis=0); sigma=X.std(axis=0)+1e-6
+    return (X-mu)/sigma, mu, sigma
+
+def softmax(z):
+    z=z - z.max(axis=1, keepdims=True)
+    e=np.exp(z); return e/np.sum(e,axis=1,keepdims=True)
+
+def train_softmax(X,y,lr=0.05,epochs=400,lam=1e-3):
+    N,D=X.shape; C=len(CLASSES)
+    W=np.zeros((D,C), dtype=np.float32); b=np.zeros((C,), dtype=np.float32)
+    Y=np.eye(C, dtype=np.float32)[y]
+    for _ in range(epochs):
+        S=X.dot(W)+b
+        P=softmax(S)
+        gradW = X.T.dot(P - Y)/N + lam*W
+        gradb = (P - Y).mean(axis=0)
+        W -= lr*gradW; b -= lr*gradb
+    return W,b
+
+def save_model(out, mu,sigma,W,b):
+    model={"mu":mu.tolist(),"sigma":sigma.tolist(),"W":W.tolist(),"b":b.tolist(),"classes":CLASSES,"feats":FEATS}
+    (out/"side_model.json").write_text(json.dumps(model, indent=2))
+    print("[train] wrote", out/"side_model.json")
+
+def main(out_dir):
+    out=pathlib.Path(out_dir)
+    feat=load_feats(out); seeds=load_seeds(out)
+    X,y=build_XY(feat,seeds)
+    if len(y)<4:
+        print("[train] need at least 4 seed examples across classes"); return
+    Xn,mu,sigma=normalize(X)
+    W,b=train_softmax(Xn,y,lr=0.05,epochs=800,lam=1e-3)
+    save_model(out,mu,sigma,W,b)
+
+if __name__=="__main__":
+    main(sys.argv[1] if len(sys.argv)>1 else "output")


### PR DESCRIPTION
## Summary
- add feature extractor, seed label helper, and softmax model for side detection
- wire model training/apply into pipeline with precedence for manual overrides
- use `lincoln_side_final` and confidence filtering in tendencies reports

## Testing
- `pytest` *(fails: AttributeError: module 'gameday' has no attribute 'parse_args')*

------
https://chatgpt.com/codex/tasks/task_e_68c410008198832d880aa7b471869bbf