### PR TITLE
Add plays.jsonl guard to analysis scripts

### DIFF
--- a/analysis/apply_side_model.py
+++ b/analysis/apply_side_model.py
@@ -20,8 +20,8 @@ def predict_one(f, M):
     e=np.exp(z); p=e/np.sum(e)
     idx=int(np.argmax(p)); return M["classes"][idx], float(p[idx])
 
-def apply(out_dir):
-    out=pathlib.Path(out_dir); model=load_model(out); feat=load_feats(out)
+def apply(out: pathlib.Path):
+    model=load_model(out); feat=load_feats(out)
     p=out/"plays.jsonl"; rows=[json.loads(x) for x in p.read_text().splitlines() if x.strip()]
     upd=[]
     for r in rows:
@@ -34,5 +34,19 @@ def apply(out_dir):
         for r in upd: w.write(json.dumps(r, ensure_ascii=False)+"\n")
     print("[apply_model] wrote model predictions")
 
+def main():
+    out_arg = sys.argv[1] if len(sys.argv) > 1 else ""
+    out = pathlib.Path(out_arg) if out_arg else pathlib.Path("output")
+
+    plays_path = out / "plays.jsonl"
+    if not plays_path.exists():
+        raise SystemExit(
+            f"[apply_model] plays.jsonl not found at '{plays_path}'. "
+            "Tip: verify OUT matches your pipeline run (e.g., OUT=output/opponent_lincoln_20250912) "
+            "and call: python -m analysis.apply_side_model \"$OUT\""
+        )
+
+    apply(out)
+
 if __name__=="__main__":
-    apply(sys.argv[1] if len(sys.argv)>1 else "output")
+    main()

--- a/analysis/feat_extract.py
+++ b/analysis/feat_extract.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-import cv2, numpy as np, json, pathlib, statistics
+import cv2, numpy as np, json, pathlib, statistics, sys
 
 def _read_frames(path, max_samples=12):
     cap = cv2.VideoCapture(str(path))
@@ -87,8 +87,8 @@ def extract_for_clip(path, out_dir: pathlib.Path):
         "n1":float(n1), "a1":float(a1), "n4":float(n4), "a4":float(a4)
     }
 
-def cache_all(out_dir_str: str):
-    out=pathlib.Path(out_dir_str); p=out/"plays.jsonl"
+def cache_all(out: pathlib.Path):
+    p=out/"plays.jsonl";
     rows=[json.loads(x) for x in p.read_text().splitlines() if x.strip()]
     feat={}
     for i,r in enumerate(rows,1):
@@ -100,5 +100,19 @@ def cache_all(out_dir_str: str):
     (out/"features.json").write_text(json.dumps(feat, indent=2))
     print("[feat] wrote", out/"features.json")
 
+def main():
+    out_arg = sys.argv[1] if len(sys.argv) > 1 else ""
+    out = pathlib.Path(out_arg) if out_arg else pathlib.Path("output")
+
+    plays_path = out / "plays.jsonl"
+    if not plays_path.exists():
+        raise SystemExit(
+            f"[feat] plays.jsonl not found at '{plays_path}'. "
+            "Tip: verify OUT matches your pipeline run (e.g., OUT=output/opponent_lincoln_20250912) "
+            "and call: python -m analysis.feat_extract \"$OUT\""
+        )
+
+    cache_all(out)
+
 if __name__=="__main__":
-    import sys; cache_all(sys.argv[1] if len(sys.argv)>1 else "output")
+    main()

--- a/analysis/opponent_report.py
+++ b/analysis/opponent_report.py
@@ -61,9 +61,19 @@ def shortlist_star_clips(plays, k=6):
     return [name for _, name in scored[:k]]
 
 
-def main(out_dir_str):
-    out = pathlib.Path(out_dir_str)
-    plays = load_jsonl(out / "plays.jsonl")
+def main():
+    out_arg = sys.argv[1] if len(sys.argv) > 1 else ""
+    out = pathlib.Path(out_arg) if out_arg else pathlib.Path("output")
+
+    plays_path = out / "plays.jsonl"
+    if not plays_path.exists():
+        raise SystemExit(
+            f"[opponent_report] plays.jsonl not found at '{plays_path}'. "
+            "Tip: verify OUT matches your pipeline run (e.g., OUT=output/opponent_lincoln_20250912) "
+            "and call: python -m analysis.opponent_report \"$OUT\""
+        )
+
+    plays = load_jsonl(plays_path)
     # Split sides
     O = [p for p in plays if p.get("lincoln_side") == "offense"]
     D = [p for p in plays if p.get("lincoln_side") == "defense"]
@@ -123,4 +133,4 @@ def main(out_dir_str):
 
 
 if __name__ == "__main__":
-    main(sys.argv[1] if len(sys.argv) > 1 else "output")
+    main()

--- a/analysis/reclassify2.py
+++ b/analysis/reclassify2.py
@@ -2,8 +2,18 @@ from __future__ import annotations
 import json, pathlib, sys
 
 def main(out_dir: str, min_side_conf=0.40):
-    out=pathlib.Path(out_dir)
-    p=out/"plays.jsonl"
+    out_arg = out_dir
+    out = pathlib.Path(out_arg) if out_arg else pathlib.Path("output")
+
+    plays_path = out / "plays.jsonl"
+    if not plays_path.exists():
+        raise SystemExit(
+            f"[reclassify2] plays.jsonl not found at '{plays_path}'. "
+            "Tip: verify OUT matches your pipeline run (e.g., OUT=output/opponent_lincoln_20250912) "
+            "and call: python -m analysis.reclassify2 \"$OUT\""
+        )
+
+    p=plays_path
     rows=[json.loads(x) for x in p.read_text().splitlines() if x.strip()]
     seeds={}
     sp=out/"seed_labels.json"
@@ -37,6 +47,6 @@ def main(out_dir: str, min_side_conf=0.40):
     print("[reclassify2] finalized side with precedence & overrides")
 
 if __name__=="__main__":
-    out=sys.argv[1] if len(sys.argv)>1 else "output"
+    out=sys.argv[1] if len(sys.argv)>1 else ""
     thr=float(sys.argv[2]) if len(sys.argv)>2 else 0.40
     main(out, thr)

--- a/analysis/seed_labels.py
+++ b/analysis/seed_labels.py
@@ -7,7 +7,17 @@ Indexes refer to the order in plays.jsonl (1-based), or pass filenames with --fi
 """
 
 def main():
-    out=pathlib.Path(sys.argv[1] if len(sys.argv)>1 else "output")
+    out_arg = sys.argv[1] if len(sys.argv) > 1 else ""
+    out = pathlib.Path(out_arg) if out_arg else pathlib.Path("output")
+
+    plays_path = out / "plays.jsonl"
+    if not plays_path.exists():
+        raise SystemExit(
+            f"[seed] plays.jsonl not found at '{plays_path}'. "
+            "Tip: verify OUT matches your pipeline run (e.g., OUT=output/opponent_lincoln_20250912) "
+            "and call: python -m analysis.seed_labels \"$OUT\" --offense 7  OR  --files --offense \"Wide - Clip 007.mp4\""
+        )
+
     args=sys.argv[2:]
     idx_off, idx_def, idx_sp = [], [], []
     files_mode=False
@@ -28,7 +38,7 @@ def main():
         else:
             print(HELP); return
 
-    rows=[json.loads(x) for x in (out/"plays.jsonl").read_text().splitlines() if x.strip()]
+    rows=[json.loads(x) for x in plays_path.read_text().splitlines() if x.strip()]
     srcs=[r["src"] for r in rows]
     labels={}
     if files_mode:

--- a/analysis/train_side_model.py
+++ b/analysis/train_side_model.py
@@ -47,8 +47,18 @@ def save_model(out, mu,sigma,W,b):
     (out/"side_model.json").write_text(json.dumps(model, indent=2))
     print("[train] wrote", out/"side_model.json")
 
-def main(out_dir):
-    out=pathlib.Path(out_dir)
+def main():
+    out_arg = sys.argv[1] if len(sys.argv) > 1 else ""
+    out = pathlib.Path(out_arg) if out_arg else pathlib.Path("output")
+
+    plays_path = out / "plays.jsonl"
+    if not plays_path.exists():
+        raise SystemExit(
+            f"[train] plays.jsonl not found at '{plays_path}'. "
+            "Tip: verify OUT matches your pipeline run (e.g., OUT=output/opponent_lincoln_20250912) "
+            "and call: python -m analysis.train_side_model \"$OUT\""
+        )
+
     feat=load_feats(out); seeds=load_seeds(out)
     X,y=build_XY(feat,seeds)
     if len(y)<4:
@@ -58,4 +68,4 @@ def main(out_dir):
     save_model(out,mu,sigma,W,b)
 
 if __name__=="__main__":
-    main(sys.argv[1] if len(sys.argv)>1 else "output")
+    main()


### PR DESCRIPTION
## Summary
- ensure analysis scripts fail fast with a helpful message when plays.jsonl is missing
- update feature extraction, model training, application, reclassification, and reporting scripts to share this guard

## Testing
- `pytest` *(fails: SyntaxError in tests/test_ball_tracker.py and missing libGL for cv2)*

------
https://chatgpt.com/codex/tasks/task_e_68c4149245fc832d86175a4c647a9881