### PR TITLE
Merge seed labels instead of overwriting

### DIFF
--- a/analysis/seed_labels.py
+++ b/analysis/seed_labels.py
@@ -68,8 +68,13 @@ def main():
             j=int(n)-1
             if 0<=j<len(srcs): labels[srcs[j]]="special_teams"
 
-    (out/"seed_labels.json").write_text(json.dumps(labels, indent=2))
-    print("[seed] wrote", out/"seed_labels.json")
+    seed_path = out/"seed_labels.json"
+    if seed_path.exists():
+        existing = json.loads(seed_path.read_text())
+        existing.update(labels)
+        labels = existing
+    seed_path.write_text(json.dumps(labels, indent=2))
+    print("[seed] merged and wrote", seed_path)
 
 if __name__=="__main__":
     main()


### PR DESCRIPTION
## Summary
- merge new seed labels with existing `seed_labels.json`
- log merge action when writing file

## Testing
- `pytest tests/test_label_harmonizer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c41e6cb3a0832d9e6101a549ecb393