### PR TITLE
Add JSONL validator for plays data

### DIFF
--- a/analysis/validate_jsonl.py
+++ b/analysis/validate_jsonl.py
@@ -1,0 +1,13 @@
+import json, sys, pathlib
+p = pathlib.Path(sys.argv[1]) if len(sys.argv)>1 else pathlib.Path("plays.jsonl")
+for i, line in enumerate(p.read_text().splitlines(), 1):
+    line = line.strip()
+    if not line:
+        print(f"[warn] blank line {i}")
+        continue
+    try:
+        obj = json.loads(line)
+        if not isinstance(obj, dict):
+            print(f"[warn] line {i} is {type(obj).__name__}, not object")
+    except Exception as e:
+        print(f"[error] line {i} invalid JSON: {e}")


### PR DESCRIPTION
## Summary
- add `analysis.validate_jsonl` to flag blank or malformed lines

## Testing
- `python -m analysis.validate_jsonl "$OUT/plays.jsonl"`
- `pytest` *(fails: module 'gameday' has no attribute 'parse_args'; invalid decimal literal in play_classifier.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c41e87ed48832dba5a1e0923453f29