### PR TITLE
Add scaffolding for generic opponent scouting

### DIFF
--- a/analysis/det_track.py
+++ b/analysis/det_track.py
@@ -1,0 +1,116 @@
+"""Detection and tracking entry points.
+
+This module wraps a very small YOLOv8 + ByteTrack pipeline.  The goal is to
+provide a consistent API for the rest of the analysis stack without pulling in
+heavy third‑party dependencies during unit testing.  When the required
+libraries are not available (for example in a CI environment) the detector
+gracefully falls back to returning an empty track set.
+
+The output format mirrors the contract described in the upgrade notes: a
+dictionary with ``fps`` and ``frame_count`` fields and a ``frames`` list
+containing per‑frame track dictionaries.  Each track dictionary exposes the
+fields ``track_id``, ``x1``, ``y1``, ``x2``, ``y2`` and ``cls``.
+
+Example
+-------
+
+>>> run_det_track("clip.mp4")
+{'fps': 30.0, 'frame_count': 120, 'frames': [...]}
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List
+
+try:  # pragma: no cover - optional heavy deps
+    import cv2  # type: ignore
+    from ultralytics import YOLO  # type: ignore
+    from .third_party.bytetrack import ByteTracker
+except Exception:  # pragma: no cover
+    cv2 = None  # type: ignore
+    YOLO = None  # type: ignore
+    ByteTracker = None  # type: ignore
+
+
+def run_det_track(video_path: str) -> Dict[str, object]:
+    """Run person detection and ByteTrack tracking on ``video_path``.
+
+    If the required dependencies are missing or the video cannot be read, an
+    empty result with ``frame_count`` set to ``0`` is returned.  This keeps
+    downstream modules operational in minimal test environments.
+    """
+
+    if cv2 is None or YOLO is None or ByteTracker is None:
+        return {"fps": 0.0, "frame_count": 0, "frames": []}
+
+    cap = cv2.VideoCapture(str(video_path))
+    if not cap.isOpened():
+        return {"fps": 0.0, "frame_count": 0, "frames": []}
+
+    fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
+    frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT) or 0)
+    model = YOLO("yolov8n.pt")
+    tracker = ByteTracker()
+
+    frames: List[List[Dict[str, float]]] = []
+    while True:
+        ret, frame = cap.read()
+        if not ret:
+            break
+        detections: List[tuple] = []
+        try:  # ultralytics API can differ slightly between versions
+            results = model(frame, verbose=False)[0]
+            boxes = getattr(results, "boxes", None)
+            if boxes is not None:
+                for xyxy, cls, conf in zip(boxes.xyxy.tolist(), boxes.cls.tolist(), boxes.conf.tolist()):
+                    if int(cls) == 0:  # person class
+                        detections.append((*xyxy, float(conf)))
+        except Exception:
+            detections = []
+
+        active = tracker.update(detections)
+        frame_tracks = [
+            {
+                "track_id": t["id"],
+                "x1": t["bbox"][0],
+                "y1": t["bbox"][1],
+                "x2": t["bbox"][2],
+                "y2": t["bbox"][3],
+                "cls": 0,
+            }
+            for t in active
+        ]
+        frames.append(frame_tracks)
+
+    cap.release()
+    return {"fps": float(fps), "frame_count": frame_count, "frames": frames}
+
+
+def write_tracks_json(out_dir: Path, clip_path: str, tracks: Dict[str, object]) -> None:
+    """Write ``tracks`` to ``OUT/tracks/<clip_basename>.json``."""
+
+    out_dir = Path(out_dir)
+    tracks_dir = out_dir / "tracks"
+    tracks_dir.mkdir(parents=True, exist_ok=True)
+    base = Path(clip_path).stem
+    with (tracks_dir / f"{base}.json").open("w", encoding="utf-8") as f:
+        json.dump(tracks, f)
+
+
+def _main() -> None:  # pragma: no cover - CLI helper
+    import argparse
+
+    ap = argparse.ArgumentParser(description="detect and track players")
+    ap.add_argument("out_dir")
+    ap.add_argument("--clip", required=True)
+    args = ap.parse_args()
+
+    tracks = run_det_track(args.clip)
+    write_tracks_json(Path(args.out_dir), args.clip, tracks)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    _main()
+

--- a/analysis/formation_infer.py
+++ b/analysis/formation_infer.py
@@ -1,0 +1,54 @@
+"""Offensive formation and personnel inference (stub).
+
+The real system analyses player pre‑snap alignment to determine personnel
+groupings and a plain‑language formation description.  Here we provide a very
+small heuristic version that simply counts the number of players assigned to
+team colour ``0`` and produces a placeholder formation string.  This keeps
+downstream code operational without requiring complex geometry logic.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Dict, Any
+
+
+def run(out_dir: Path, clip_path: str, tracks_path: str, out_path: str | None = None) -> Dict[str, Any]:
+    with open(tracks_path, "r", encoding="utf-8") as f:
+        tracks = json.load(f)
+
+    first = (tracks.get("frames") or [None])[0] or []
+    offense = [tr for tr in first if tr.get("track_id") is not None]
+    n_skill = max(0, len(offense) - 5)
+    personnel = f"{min(2, n_skill)}{max(0, n_skill-1)}" if offense else None
+    formation_text = f"{personnel} personnel" if personnel else None
+
+    roles = {str(tr.get("track_id")): "UNK" for tr in first}
+    data = {
+        "offense_personnel": personnel,
+        "formation_text": formation_text,
+        "roles": roles,
+    }
+
+    out_file = Path(out_path) if out_path else Path(out_dir) / "formations" / f"{Path(clip_path).stem}.json"
+    out_file.parent.mkdir(parents=True, exist_ok=True)
+    with out_file.open("w", encoding="utf-8") as f:
+        json.dump(data, f)
+    return data
+
+
+def _cli() -> None:  # pragma: no cover
+    ap = argparse.ArgumentParser(description="formation inference stub")
+    ap.add_argument("out_dir")
+    ap.add_argument("--clip", required=True)
+    ap.add_argument("--tracks", required=True)
+    ap.add_argument("--out", default=None)
+    args = ap.parse_args()
+    run(Path(args.out_dir), args.clip, args.tracks, args.out)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    _cli()
+

--- a/analysis/jersey_ocr.py
+++ b/analysis/jersey_ocr.py
@@ -1,0 +1,44 @@
+"""Jersey number OCR utilities (stub).
+
+The production system would crop player regions and run a dedicated OCR model
+to infer jersey numbers.  For the purposes of the tests we simply expose a
+function that returns ``None`` for every track.  This keeps the pipeline
+interfaces intact without requiring heavy OCR dependencies.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Dict, Any
+
+
+def run(out_dir: Path, clip_path: str, tracks_path: str, out_path: str | None = None) -> Dict[str, Any]:
+    """Produce a mapping of ``track_id`` -> ``jersey_number`` (always ``None``)."""
+
+    with open(tracks_path, "r", encoding="utf-8") as f:
+        tracks = json.load(f)
+
+    numbers = {str(tr.get("track_id")): None for tr in (tracks.get("frames") or [None])[0] or []}
+
+    out_file = Path(out_path) if out_path else Path(out_dir) / "numbers" / f"{Path(clip_path).stem}.json"
+    out_file.parent.mkdir(parents=True, exist_ok=True)
+    with out_file.open("w", encoding="utf-8") as f:
+        json.dump(numbers, f)
+    return numbers
+
+
+def _cli() -> None:  # pragma: no cover
+    ap = argparse.ArgumentParser(description="jersey number OCR stub")
+    ap.add_argument("out_dir")
+    ap.add_argument("--clip", required=True)
+    ap.add_argument("--tracks", required=True)
+    ap.add_argument("--out", default=None)
+    args = ap.parse_args()
+    run(Path(args.out_dir), args.clip, args.tracks, args.out)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    _cli()
+

--- a/analysis/opponent_report.py
+++ b/analysis/opponent_report.py
@@ -1,159 +1,85 @@
+"""Generate a simple Markdown opponent report from tendency CSVs."""
+
 from __future__ import annotations
-import json, pathlib, csv, sys, collections
 
-MCA_PLAYS = {
-    # Offense suggestions we can call vs THEIR defense
-    "edge_fast": ["Rit Jet Sweep", "Leo Jet Sweep", "Reo Quick Screen"],
-    "counter_cutback": ["Rit F Counter", "Lit F Counter", "Rit Power R"],
-    "flood_vs_zone": ["Reo Flood", "Leo Flood", "F Stick"],
-    "boot_vs_flow": ["Rit Flare Boot", "Lit Flare Boot"],
-}
+import csv
+import json
+from pathlib import Path
+from typing import Dict, List
 
 
-def load_jsonl(p):
-    return [json.loads(x) for x in p.read_text().splitlines() if x.strip()]
+def _load_csv(path: Path) -> Dict[str, List[Dict[str, str]]]:
+    if not path.exists():
+        return {}
+    out: Dict[str, List[Dict[str, str]]] = {}
+    with path.open() as f:
+        for row in csv.DictReader(f):
+            out.setdefault(row["metric"], []).append(row)
+    return out
 
 
-def try_load_csv(path: pathlib.Path):
-    """Return list of rows from CSV if path exists, else None."""
-    p = pathlib.Path(path)
-    if not p.exists():
-        return None
-    with p.open() as f:
-        return list(csv.DictReader(f))
+def _top(rows: List[Dict[str, str]], k: int = 3) -> List[Dict[str, str]]:
+    rows.sort(key=lambda r: int(r.get("count", "0")), reverse=True)
+    return rows[:k]
 
 
-def summarize(csv_rows):
-    """Summarize tendencies CSV into convenient counters."""
-    rp = collections.Counter()
-    fam = collections.Counter()
-    direction = collections.Counter()
-    pos = 0
-    total = 0
-    for r in csv_rows or []:
-        metric = r.get("metric")
-        val = r.get("value")
-        c = int(r.get("count") or r.get("value") or 0)
-        if metric == "rp":
-            rp[val] += c
-        elif metric == "family":
-            fam[val] += c
-        elif metric == "direction":
-            direction[val] += c
-        elif metric == "outcome" and val == "positive":
-            pos += c
-        elif metric == "total" and val in ("clips", "plays"):
-            total = c
-    return rp, fam, direction, pos, total
-
-
-def top_dirs(counts):
-    d = counts.get("direction", {})
-    items = sorted(d.items(), key=lambda kv: -kv[1])
-    return items[:2]
-
-
-def infer_def_weakness(def_counts):
-    # Heuristic: if direction bias exists, edge is weak to that side
-    dir_bias = top_dirs(def_counts)
-    recs = []
-    if dir_bias and dir_bias[0][0] in ("left", "right") and dir_bias[0][1] >= 6:
-        recs.append("edge_fast")
-    # If outside_run shows up as successful outcome (requires outcomes counter)
-    fam = def_counts.get("family", {})
-    if fam.get("outside_run", 0) >= fam.get("inside_run", 0) and fam.get("outside_run", 0) >= 6:
-        recs.append("counter_cutback")
-    # Default pass game ensures stress on flats/curl
-    recs.append("flood_vs_zone")
-    recs.append("boot_vs_flow")
-    return recs
-
-
-def positive_outcome_ratio(plays):
-    pos = sum(1 for p in plays if p.get("auto_outcome") == "positive")
-    return (pos, len(plays))
-
-
-def shortlist_star_clips(plays, k=6):
-    # Use flow p95 (saved under auto_flow.mag_p95) as proxy for impactful gain
-    scored = []
-    for p in plays:
-        m = (p.get("auto_flow") or {}).get("mag_p95", 0.0)
-        scored.append((m, pathlib.Path(p.get("src", "")).name))
-    scored.sort(reverse=True)
-    return [name for _, name in scored[:k]]
-
-
-def main():
-    out_arg = sys.argv[1] if len(sys.argv) > 1 else ""
-    out = pathlib.Path(out_arg) if out_arg else pathlib.Path("output")
-
-    plays_path = out / "plays.jsonl"
-    if not plays_path.exists():
-        raise SystemExit(
-            f"[opponent_report] plays.jsonl not found at '{plays_path}'. "
-            "Tip: verify OUT matches your pipeline run (e.g., OUT=output/opponent_lincoln_20250912) "
-            "and call: python -m analysis.opponent_report \"$OUT\""
-        )
-
-    plays = load_jsonl(plays_path)
-    # Split sides
-    O = [p for p in plays if p.get("lincoln_side") == "offense"]
-    D = [p for p in plays if p.get("lincoln_side") == "defense"]
-
-    off_csv = try_load_csv(out / "tendencies_offense.csv")
-    def_csv = try_load_csv(out / "tendencies_defense.csv")
-
-    off_rp, off_fam, off_dir, off_pos_csv, off_total_csv = summarize(off_csv)
-    def_rp, def_fam, def_dir, def_pos_csv, def_total_csv = summarize(def_csv)
-
-    o_pos, o_tot = (
-        (off_pos_csv, off_total_csv) if off_total_csv else positive_outcome_ratio(O)
-    )
-    d_pos, d_tot = (
-        (def_pos_csv, def_total_csv) if def_total_csv else positive_outcome_ratio(D)
-    )
-
-    star_off = shortlist_star_clips(O, k=6)
-
-    def_counts = {"direction": def_dir, "family": def_fam}
-    rec_keys = infer_def_weakness(def_counts)
-    suggestions = [item for key in rec_keys for item in MCA_PLAYS.get(key, [])]
-
+def _fmt_top(rows: List[Dict[str, str]]) -> List[str]:
     lines = []
-    lines.append("# Lincoln Christian — Opponent Report\n")
-    lines.append(
-        f"**Clips analyzed:** {len(plays)}  |  **Lincoln Offense:** {off_total_csv or len(O)}  |  **Lincoln Defense:** {def_total_csv or len(D)}\n"
-    )
-    lines.append("## Lincoln Offense Tendencies (quick peek)")
-    lines.append(
-        f"- Run/Pass (auto): {int(off_rp.get('run', 0))} run / {int(off_rp.get('pass', 0))} pass"
-    )
-    if off_fam:
-        lines.append(f"- Families top: {off_fam.most_common(5)}")
-    lines.append(f"- Positive outcome rate (auto): {o_pos}/{o_tot}\n")
-    lines.append("**Star clips to review (highest impact motion):**")
-    for n in star_off:
-        lines.append(f"- {n}")
-    lines.append("\n## Lincoln Defense Tendencies (quick peek)")
-    lines.append(
-        f"- Offense faced (for context): {int(def_rp.get('run', 0))} runs / {int(def_rp.get('pass', 0))} passes"
-    )
-    if def_fam:
-        lines.append(f"- Offense types vs them: {def_fam.most_common(5)}")
-    lines.append(
-        f"- Positive outcome rate allowed (auto proxy): {d_pos}/{d_tot}\n"
-    )
-
-    lines.append("## Suggested MCA Calls vs Lincoln Defense")
-    for s in suggestions:
-        lines.append(f"- **{s}**")
-    lines.append(
-        "\n_Notes_: suggestions are heuristic. Confirm with the star clips and your assistants. If you tag 10–15 clips with `quick_tag`, rerun tendencies for sharper recs."
-    )
-    (out / "opponent_report.md").write_text("\n".join(lines), encoding="utf-8")
-    print("[opponent_report] wrote", out / "opponent_report.md")
+    for r in rows:
+        avg = float(r.get("avg_yards" or 0))
+        lines.append(f"- {r['value']} ({r['count']} plays, avg {avg:.1f} yd)")
+    return lines or ["- none"]
 
 
-if __name__ == "__main__":
-    main()
+def build_section(title: str, csv_rows: Dict[str, List[Dict[str, str]]]) -> List[str]:
+    lines = [f"## {title}"]
+    rp = {r["value"]: r for r in csv_rows.get("run_pass", [])}
+    if rp:
+        run = rp.get("run", {"count": "0", "avg_yards": "0"})
+        pas = rp.get("pass", {"count": "0", "avg_yards": "0"})
+        lines.append(
+            f"Run: {run['count']} (avg {float(run['avg_yards']):.1f} yd) | Pass: {pas['count']} (avg {float(pas['avg_yards']):.1f} yd)"
+        )
+    forms = _top(csv_rows.get("formation_text", []))
+    if forms:
+        lines.append("Top formations:")
+        lines.extend(_fmt_top(forms))
+    dirs = _top(csv_rows.get("run_direction", []))
+    if dirs:
+        lines.append("Run direction:")
+        lines.extend(_fmt_top(dirs))
+    routes = _top(csv_rows.get("route_primary", []))
+    if routes:
+        lines.append("Routes:")
+        lines.extend(_fmt_top(routes))
+    return lines
+
+
+def main(out_dir: str) -> Path:
+    out = Path(out_dir)
+    plays = [json.loads(l) for l in (out / "plays.jsonl").read_text().splitlines() if l.strip()]
+    total = len(plays)
+    off_csv = _load_csv(out / "tendencies_offense.csv")
+    def_csv = _load_csv(out / "tendencies_defense.csv")
+
+    lines = [
+        "# Opponent Report",
+        f"**Total clips analysed:** {total}",
+        "",
+    ]
+    lines.extend(build_section("Offense", off_csv))
+    lines.append("")
+    lines.extend(build_section("Defense", def_csv))
+
+    report = out / "opponent_report.md"
+    report.write_text("\n".join(lines), encoding="utf-8")
+    return report
+
+
+if __name__ == "__main__":  # pragma: no cover
+    import sys
+
+    if len(sys.argv) < 2:
+        raise SystemExit("usage: python -m analysis.opponent_report <OUT>")
+    main(sys.argv[1])
+

--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -12,7 +12,7 @@ from collections import Counter
 import html
 
 from .harmonizer import harmonize
-from .tendencies import main as write_tendencies
+from .tendencies import run_from_pipeline as write_tendencies
 
 try:
     # When executed as module (recommended)
@@ -199,6 +199,97 @@ def _write_warnings(
             wf.write("warnings:\n")
             for line in warnings:
                 wf.write(f"  {line}\n")
+
+
+# ---------------------------------------------------------------------------
+# Generic opponent scouting helpers
+
+def _make_side_cuts(out_dir: str, plays: list[dict]) -> None:
+    """Create offense/defense cutups using ffmpeg concat."""
+
+    def _build(side: str, clips: list[str]) -> None:
+        if not clips:
+            return
+        outp = pathlib.Path(out_dir)
+        concat = outp / f"{side}_concat.txt"
+        with concat.open("w", encoding="utf-8") as f:
+            for clip in clips:
+                f.write(f"file '{pathlib.Path(clip).resolve()}'\n")
+        out_mp4 = outp / f"lincoln_{side}_cut.mp4"
+        subprocess.run(
+            [
+                "ffmpeg",
+                "-y",
+                "-f",
+                "concat",
+                "-safe",
+                "0",
+                "-i",
+                str(concat),
+                "-c",
+                "copy",
+                str(out_mp4),
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+    offense = [p["src"] for p in plays if p.get("lincoln_side_final") == "offense"]
+    defense = [p["src"] for p in plays if p.get("lincoln_side_final") == "defense"]
+    _build("offense", offense)
+    _build("defense", defense)
+
+
+def _generic_scout_pipeline(out_dir: str, plays: list[dict], *, csv_out: str | None, make_side_cuts: bool) -> None:
+    from pathlib import Path
+    from . import det_track, team_assign, jersey_ocr, formation_infer, run_pass_routes, yardage
+
+    outp = Path(out_dir)
+    updated: list[dict] = []
+    for play in plays:
+        clip = play.get("src")
+        try:
+            tracks = det_track.run_det_track(clip)
+            det_track.write_tracks_json(outp, clip, tracks)
+            tracks_json = outp / "tracks" / f"{Path(clip).stem}.json"
+            team = team_assign.assign_from_tracks(tracks)
+            formation = formation_infer.run(outp, clip, str(tracks_json))
+            events = run_pass_routes.run(outp, clip, str(tracks_json))
+            yards = yardage.run(outp, clip, str(tracks_json))
+            jersey_ocr.run(outp, clip, str(tracks_json))
+            play.update(team)
+            play.update(events)
+            play.update(yards)
+            play["offense_personnel"] = formation.get("offense_personnel")
+            play["formation_text"] = formation.get("formation_text")
+            play.setdefault("phase", "unknown")
+            play.setdefault("players", team.get("players", []))
+        except Exception:
+            play.setdefault("phase", "unknown")
+            play.setdefault("lincoln_side_final", "unknown")
+            play.setdefault("lincoln_side_final_conf", 0.0)
+            play.setdefault("players", [])
+            play.setdefault("offense_personnel", None)
+            play.setdefault("formation_text", None)
+            play.setdefault("run_pass", "unknown")
+            play.setdefault("run_direction", "unknown")
+            play.setdefault("route_primary", "unknown")
+            play.setdefault("yards_gained", None)
+            play.setdefault("explosive", False)
+        updated.append(play)
+
+    plays_path = outp / "plays.jsonl"
+    with plays_path.open("w", encoding="utf-8") as f:
+        for p in updated:
+            f.write(json.dumps(p) + "\n")
+
+    if csv_out:
+        try:
+            write_tendencies(out_dir, csv_out=csv_out)
+        except Exception as e:  # pragma: no cover - best effort
+            print(f"[warn] tendencies failed: {e}")
+    if make_side_cuts:
+        _make_side_cuts(out_dir, updated)
 
 
 def _load_model_labels(
@@ -1377,6 +1468,21 @@ def main(argv=None) -> None:
         action="store_true",
         help=argparse.SUPPRESS,
     )
+    p.add_argument(
+        "--scout-generic",
+        action="store_true",
+        help="enable generic opponent scouting pipeline",
+    )
+    p.add_argument(
+        "--make-side-cuts",
+        action="store_true",
+        help="emit offense/defense cutups when scouting",
+    )
+    p.add_argument(
+        "--csv-out",
+        default=None,
+        help="write per-side tendencies CSV to this path",
+    )
     p.add_argument("--debug-weak", action="store_true")
 
     p.add_argument("--enhance", action="store_true", help="enhance exported clips")
@@ -1491,10 +1597,20 @@ def main(argv=None) -> None:
             print(f"[warn] sequence_smooth failed: {e}")
         from .reclassify2 import main as reclass2
         reclass2(args.out, min_side_conf=0.40)
+        if args.scout_generic:
+            try:
+                _generic_scout_pipeline(
+                    args.out,
+                    plays,
+                    csv_out=args.csv_out,
+                    make_side_cuts=args.make_side_cuts,
+                )
+            except Exception as e:
+                print(f"[warn] scout_generic failed: {e}")
         build_coaches_cut(args.out, plays)
         if args.generate_report:
             try:
-                write_tendencies(args.out)
+                write_tendencies(args.out, csv_out=args.csv_out)
             except Exception:
                 pass
         return

--- a/analysis/run_pass_routes.py
+++ b/analysis/run_pass_routes.py
@@ -1,0 +1,40 @@
+"""Run/pass classification and rudimentary route detection (stub)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Dict, Any
+
+
+def run(out_dir: Path, clip_path: str, tracks_path: str, out_path: str | None = None) -> Dict[str, Any]:
+    # In the real system this function would analyse player motion and the ball
+    # trajectory.  For the simplified stub we return unknown values so that the
+    # rest of the pipeline can proceed without requiring heavy computation.
+    data = {
+        "run_pass": "unknown",
+        "run_direction": "unknown",
+        "route_primary": "unknown",
+    }
+
+    out_file = Path(out_path) if out_path else Path(out_dir) / "events" / f"{Path(clip_path).stem}.json"
+    out_file.parent.mkdir(parents=True, exist_ok=True)
+    with out_file.open("w", encoding="utf-8") as f:
+        json.dump(data, f)
+    return data
+
+
+def _cli() -> None:  # pragma: no cover
+    ap = argparse.ArgumentParser(description="run/pass & route stub")
+    ap.add_argument("out_dir")
+    ap.add_argument("--clip", required=True)
+    ap.add_argument("--tracks", required=True)
+    ap.add_argument("--out", default=None)
+    args = ap.parse_args()
+    run(Path(args.out_dir), args.clip, args.tracks, args.out)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    _cli()
+

--- a/analysis/team_assign.py
+++ b/analysis/team_assign.py
@@ -1,0 +1,89 @@
+"""Team colour clustering and side‑of‑ball assignment.
+
+The real project performs jersey colour clustering and ball‑possession
+analysis to determine which team is on offence or defence for a given clip.
+For the purposes of the unit tests we implement a very small, mostly
+placeholder version of that logic.  The module exposes a ``finalize_side_label``
+helper that resolves seed overrides and a ``run`` function used by the
+pipeline.  When invoked as a script it writes a small JSON file describing the
+assigned players.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Dict, Any, List
+
+
+def finalize_side_label(
+    row: Dict[str, Any],
+    model_decision: str,
+    seed_override: str | None,
+    conf: float,
+) -> Dict[str, Any]:
+    """Resolve the final side label using seed overrides."""
+
+    side = model_decision
+    if seed_override in {"offense", "defense", "special_teams"}:
+        side = seed_override
+    row["lincoln_side_final"] = side
+    row["lincoln_side_final_conf"] = float(conf)
+    return row
+
+
+def assign_from_tracks(tracks: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a trivial assignment for ``tracks``.
+
+    Each track in the first frame is alternately assigned to team ``0`` or ``1``.
+    This is obviously not sufficient for real analysis but provides stable
+    output for downstream modules and tests.
+    """
+
+    players: List[Dict[str, Any]] = []
+    first_frame = (tracks.get("frames") or [None])[0] or []
+    for i, tr in enumerate(first_frame):
+        players.append(
+            {
+                "track_id": int(tr.get("track_id", i)),
+                "team_color_id": i % 2,
+                "jersey_number": None,
+                "role": "UNK",
+                "pre_snap_xy": [0.0, 0.0],
+            }
+        )
+
+    return {
+        "lincoln_side_final": "unknown",
+        "lincoln_side_final_conf": 0.0,
+        "players": players,
+    }
+
+
+def run(out_dir: Path, clip_path: str, tracks_path: str) -> Dict[str, Any]:
+    with open(tracks_path, "r", encoding="utf-8") as f:
+        tracks = json.load(f)
+    data = assign_from_tracks(tracks)
+
+    team_dir = Path(out_dir) / "team_assign"
+    team_dir.mkdir(parents=True, exist_ok=True)
+    base = Path(clip_path).stem
+    with (team_dir / f"{base}.json").open("w", encoding="utf-8") as f:
+        json.dump(data, f)
+    return data
+
+
+def _cli() -> None:  # pragma: no cover - CLI helper
+    ap = argparse.ArgumentParser(description="assign teams to tracks")
+    ap.add_argument("out_dir")
+    ap.add_argument("--clip", required=True)
+    ap.add_argument("--tracks", required=True)
+    args = ap.parse_args()
+
+    run(Path(args.out_dir), args.clip, args.tracks)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    _cli()
+

--- a/analysis/tendencies.py
+++ b/analysis/tendencies.py
@@ -1,238 +1,191 @@
+"""Compute simple opponent tendencies from ``plays.jsonl``.
+
+This module focuses on the generic scouting data produced by the upgraded
+pipeline.  The implementation intentionally favours clarity over performance
+and keeps external dependencies to a minimum so it can run in the unit tests.
+
+The public entry point is :func:`run_from_pipeline` which is used by the
+pipeline module.  A command line interface is also provided for ad‑hoc runs.
+"""
+
 from __future__ import annotations
-import json, csv, math, pathlib, collections, re, argparse
-from typing import Dict, Any, List, Tuple
+
+import argparse
+import csv
+import json
+import statistics
+from collections import defaultdict, Counter
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Tuple
 
 Play = Dict[str, Any]
 
-FAMILIES = {
-    "inside_run": ["dive","power","iso","counter","trap"],
-    "outside_run": ["sweep","jet","stretch","toss"],
-    "pa_boot": ["boot","naked","waggle","flare boot","play action","option"],
-    "quick_game": ["stick","quick screen","bubble","smoke","hitch","slant","flood","quick"]
-}
 
-def normalize(text:str)->str:
-    return (text or "").lower().strip()
+# ---------------------------------------------------------------------------
+# Data loading and filtering
 
-norm = normalize
+def load_plays(out_dir: Path) -> List[Play]:
+    path = out_dir / "plays.jsonl"
+    if not path.exists():
+        return []
+    with path.open() as f:
+        return [json.loads(line) for line in f if line.strip()]
 
-def infer_family(play: Play) -> str:
-    # Try explicit labels first, then keywords from clip title/notes
-    labels = [normalize(play.get("play_label")), normalize(play.get("family")), normalize(play.get("call"))]
-    blob = " ".join(labels + [normalize(play.get("title","")), normalize(play.get("notes",""))])
-    for fam, keys in FAMILIES.items():
-        if any(k in blob for k in keys):
-            return fam
-    # fallback: if run/pass bool exists
-    if play.get("is_run") is True: return "inside_run"
-    if play.get("is_pass") is True: return "quick_game"
-    return "unknown"
 
-def infer_direction(play: Play) -> str:
-    d = normalize(play.get("direction") or play.get("dir"))
-    if d in ("right","r","rt","rit","reo"): return "right"
-    if d in ("left","l","lt","lit","leo"): return "left"
-    # Heuristic: look for tokens in title/notes
-    blob = normalize(play.get("title","")+" "+play.get("notes",""))
-    if any(t in blob for t in [" right"," rt"," rit"," reo"]): return "right"
-    if any(t in blob for t in [" left"," lt"," lit"," leo"]): return "left"
-    return "unknown"
+def filter_plays(plays: Iterable[Play], *, only_off=False, only_def=False,
+                 exclude_phase: Iterable[str] | None = None,
+                 min_conf: float | None = None) -> List[Play]:
+    exclude_phase = set(exclude_phase or [])
+    result = []
+    for p in plays:
+        if p.get("phase") in exclude_phase:
+            continue
+        side = p.get("lincoln_side_final") or p.get("lincoln_side")
+        conf = float(p.get("lincoln_side_final_conf") or p.get("lincoln_side_conf") or 0)
+        if min_conf is not None and side != "unknown" and conf < min_conf:
+            continue
+        if only_off and side != "offense":
+            continue
+        if only_def and side != "defense":
+            continue
+        result.append(p)
+    return result
 
-FORM_TOKENS = [
-  r"\brit\b", r"\blit\b", r"\breo\b", r"\bleo\b",
-  r"\brend\b", r"\blend\b",
-  r"\btrips?\b", r"\btwins?\b", r"\bbunch\b", r"\bwing\b", r"\btight\b",
-  r"\bpistol\b", r"\bgun\b", r"\bshotgun\b", r"\bi[- ]?formation\b"
-]
 
-def infer_form(p: Play) -> str:
-    cand = norm(p.get("formation") or p.get("set"))
-    if cand: return cand
-    blob = norm((p.get("title") or "")+" "+(p.get("notes") or ""))
-    for pat in FORM_TOKENS:
-        if re.search(pat, blob): return re.sub(r"\\b", "", pat).strip("\\")
-    return "unknown"
+# ---------------------------------------------------------------------------
+# Aggregation helpers
 
-def load_plays(out_dir: pathlib.Path) -> List[Play]:
-    for fname in ["plays.jsonl","detections.jsonl","events.jsonl"]:
-        p = out_dir / fname
-        if p.exists():
-            with p.open() as f:
-                return [json.loads(line) for line in f if line.strip()]
-    return []
+def _success(play: Play) -> bool:
+    yards = float(play.get("yards_gained") or 0.0)
+    rp = play.get("run_pass")
+    if rp == "run":
+        return yards >= 3.0
+    if rp == "pass":
+        return yards >= 5.0
+    return False
 
-def summarize(plays: List[Play]) -> Dict[str, Any]:
-    sums = {
-        "total": len(plays),
-        "by_family": collections.Counter(),
-        "by_formation": collections.Counter(),
-        "by_direction": collections.Counter(),
-        "run_pass": collections.Counter(),
-        "first_down_calls": collections.Counter(),
-        "third_and_medium_plus": collections.Counter(),
-        "explosives": 0
+
+def summarise(plays: Iterable[Play]) -> Dict[str, Dict[str, List[Play]]]:
+    agg: Dict[str, Dict[str, List[Play]]] = {
+        "run_pass": defaultdict(list),
+        "formation_text": defaultdict(list),
+        "offense_personnel": defaultdict(list),
+        "run_direction": defaultdict(list),
+        "route_primary": defaultdict(list),
     }
     for p in plays:
-        fam = infer_family(p); sums["by_family"][fam]+=1
-        form = infer_form(p); sums["by_formation"][form]+=1
-        dirn = infer_direction(p); sums["by_direction"][dirn]+=1
-        if p.get("is_run") is True:
-            sums["run_pass"]["run"] += 1
-        elif p.get("is_pass") is True:
-            sums["run_pass"]["pass"] += 1
-        else:
-            af = p.get("auto_flow") or {}
-            mag_med = af.get("mag_med", 0)
-            vy_med = af.get("vy_med", 0)
-            if mag_med >= 0.03:
-                rp_guess = "run" if abs(vy_med) < 0.03 else "pass"
-                sums["run_pass"][rp_guess] += 1
-            else:
-                sums["run_pass"]["unknown"] += 1
+        for key in agg:
+            val = p.get(key, "unknown") or "unknown"
+            agg[key][val].append(p)
+    return agg
 
-        down = p.get("down")
-        togo = p.get("distance") or p.get("to_go")
-        if down == 1: sums["first_down_calls"][fam]+=1
-        try:
-            if down == 3 and float(togo or 0) >= 5:
-                sums["third_and_medium_plus"][fam]+=1
-        except Exception:
-            pass
 
-        # explosive heuristic: >=12 yards run or >=16 yards pass if gain present
-        gain = p.get("yards") or p.get("gain")
-        try:
-            g = float(gain)
-            if (p.get("is_run") and g >= 12) or (p.get("is_pass") and g >= 16):
-                sums["explosives"] += 1
-        except Exception:
-            pass
-        outcome = p.get("auto_outcome")
-        if outcome:
-            sums.setdefault("outcomes", collections.Counter())
-            sums["outcomes"][outcome] += 1
-    return sums
+def _metric_rows(agg: Dict[str, Dict[str, List[Play]]]) -> List[Tuple[str, str, int, float, float, float, int]]:
+    rows: List[Tuple[str, str, int, float, float, float, int]] = []
+    for metric, groups in agg.items():
+        for val, plays in groups.items():
+            yards = [float(p.get("yards_gained") or 0.0) for p in plays]
+            count = len(plays)
+            avg = statistics.fmean(yards) if yards else 0.0
+            median = statistics.median(yards) if yards else 0.0
+            success = sum(1 for p in plays if _success(p))
+            success_rate = success / count if count else 0.0
+            explosives = sum(1 for p in plays if p.get("explosive"))
+            rows.append((metric, val, count, avg, median, success_rate, explosives))
+    return rows
 
-def write_csv(
-    out_dir: pathlib.Path,
-    sums: Dict[str, Any],
-    suffix: str = "",
-    csv_out: str | None = None,
-):
-    csv_path = pathlib.Path(csv_out) if csv_out else out_dir / f"tendencies{suffix}.csv"
+
+# ---------------------------------------------------------------------------
+# Output helpers
+
+def write_csv(out_dir: Path, rows: List[Tuple[str, str, int, float, float, float, int]],
+              csv_out: str | None = None) -> Path:
+    csv_path = Path(csv_out) if csv_out else out_dir / "tendencies.csv"
     with csv_path.open("w", newline="") as f:
         w = csv.writer(f)
-        w.writerow(["metric", "value", "count"])
-        w.writerow(["total", "plays", sums["total"]])
-        for k, v in sums["run_pass"].items():
-            w.writerow(["run_pass", k, v])
-        for k, v in sums["by_family"].items():
-            w.writerow(["family", k, v])
-        for k, v in sums["by_formation"].items():
-            w.writerow(["formation", k, v])
-        for k, v in sums["by_direction"].items():
-            w.writerow(["direction", k, v])
-        for k, v in sums.get("outcomes", {}).items():
-            w.writerow(["outcome", k, v])
+        w.writerow(["metric", "value", "count", "avg_yards", "median_yards", "success_rate", "explosives"])
+        for r in rows:
+            w.writerow(r)
     return csv_path
 
 
-def write_md(out_dir: pathlib.Path, sums: Dict[str, Any], suffix: str = ""):
-    md = out_dir / f"tendencies{suffix}.md"
-    total = max(1, sums["total"])
-    def pct(n): return f"{(100.0*n/total):.1f}%"
-    def block(counter: collections.Counter, title: str) -> str:
-        rows = sorted(counter.items(), key=lambda kv: kv[1], reverse=True)
-        lines = [f"### {title}"]
-        for k,v in rows[:8]:
-            lines.append(f"- **{k}**: {v} ({pct(v)})")
-        return "\n".join(lines)
+def write_md(out_dir: Path, rows: List[Tuple[str, str, int, float, float, float, int]]) -> Path:
+    total = 0
+    rp = Counter()
+    forms = Counter()
+    dirs = Counter()
+    routes = Counter()
+    for metric, val, count, *_ in rows:
+        if metric == "run_pass":
+            rp[val] += count; total += count
+        if metric == "formation_text":
+            forms[val] += count
+        if metric == "run_direction":
+            dirs[val] += count
+        if metric == "route_primary":
+            routes[val] += count
 
-    content = f"""# Opponent Tendencies
+    def fmt(counter: Counter) -> str:
+        parts = [f"- {k}: {v}" for k, v in counter.most_common(5)]
+        return "\n".join(parts) if parts else "- none"
 
-**Total plays:** {sums['total']}  
-**Explosives:** {sums['explosives']}
-
-{block(sums['run_pass'], "Run/Pass")}
-{block(sums['by_family'], "Play Families")}
-{block(sums['by_formation'], "Formations (top)")}
-{block(sums['by_direction'], "Direction")}
-{block(sums.get('outcomes', collections.Counter()), "Outcomes")}
-### Situational
-- **1st down (by family):** {dict(sums['first_down_calls'])}
-- **3rd & 5+ (by family):** {dict(sums['third_and_medium_plus'])}
-"""
-    md.write_text(content)
-    return md
+    lines = ["# Opponent Tendencies", f"**Total plays:** {total}", "", "## Run/Pass", fmt(rp), "", "## Formations", fmt(forms), "", "## Run Direction", fmt(dirs), "", "## Routes", fmt(routes)]
+    md_path = out_dir / "tendencies.md"
+    md_path.write_text("\n".join(lines), encoding="utf-8")
+    return md_path
 
 
-def parse_args():
-    ap = argparse.ArgumentParser()
+# ---------------------------------------------------------------------------
+# Entry points
+
+def _run(args: argparse.Namespace) -> Tuple[Path, Path]:
+    out_dir = Path(args.out_dir)
+    plays = load_plays(out_dir)
+    plays = filter_plays(
+        plays,
+        only_off=args.only_lincoln_offense,
+        only_def=args.only_lincoln_defense,
+        exclude_phase=args.exclude_phase.split(",") if args.exclude_phase else [],
+        min_conf=args.min_side_conf,
+    )
+    agg = summarise(plays)
+    rows = _metric_rows(agg)
+    csv_path = write_csv(out_dir, rows, args.csv_out)
+    md_path = write_md(out_dir, rows)
+    return csv_path, md_path
+
+
+def run_from_pipeline(out_dir: str, *, only_lincoln_offense: bool = False,
+                      only_lincoln_defense: bool = False,
+                      exclude_phase: str = "special_teams,unknown",
+                      min_side_conf: float = 0.40,
+                      csv_out: str | None = None) -> Tuple[Path, Path]:
+    args = argparse.Namespace(
+        out_dir=out_dir,
+        only_lincoln_offense=only_lincoln_offense,
+        only_lincoln_defense=only_lincoln_defense,
+        exclude_phase=exclude_phase,
+        min_side_conf=min_side_conf,
+        csv_out=csv_out,
+    )
+    return _run(args)
+
+
+def parse_args() -> argparse.Namespace:  # pragma: no cover - CLI helper
+    ap = argparse.ArgumentParser(description="compute opponent tendencies")
     ap.add_argument("out_dir")
     ap.add_argument("--only-lincoln-offense", action="store_true")
     ap.add_argument("--only-lincoln-defense", action="store_true")
-    ap.add_argument(
-        "--use-raw-side",
-        action="store_true",
-        help="Use lincoln_side instead of lincoln_side_final",
-    )
-    ap.add_argument(
-        "--exclude-phase",
-        default="special_teams,unknown",
-        help="comma list of phases to exclude",
-    )
+    ap.add_argument("--exclude-phase", default="special_teams,unknown")
     ap.add_argument("--min-side-conf", type=float, default=0.40)
-    ap.add_argument(
-        "--csv-out",
-        type=str,
-        default=None,
-        help="Write computed tendencies to this CSV file",
-    )
+    ap.add_argument("--csv-out", default=None)
     return ap.parse_args()
 
 
-def main():
-    args = parse_args()
-    out = pathlib.Path(args.out_dir)
-    plays = load_plays(out)
-    excl = set()
-    if args.exclude_phase:
-        excl = {x.strip() for x in args.exclude_phase.split(",") if x.strip()}
-    plays = [p for p in plays if p.get("phase") not in excl]
-
-    side_key = "lincoln_side" if args.use_raw_side else "lincoln_side_final"
-    conf_key = "lincoln_side_conf" if args.use_raw_side else "lincoln_side_final_conf"
-
-    if args.min_side_conf:
-        plays = [
-            p
-            for p in plays
-            if p.get(side_key) == "unknown"
-            or float(p.get(conf_key, 0)) >= args.min_side_conf
-        ]
-
-    if args.only_lincoln_offense:
-        plays = [p for p in plays if p.get(side_key) == "offense"]
-    if args.only_lincoln_defense:
-        plays = [p for p in plays if p.get(side_key) == "defense"]
-
-    sums = summarize(plays)
-    suffix = ""
-    if args.only_lincoln_offense:
-        suffix += "_offense"
-    if args.only_lincoln_defense:
-        suffix += "_defense"
-    if args.min_side_conf:
-        suffix += f"_conf{int(args.min_side_conf*100)}"
-    if args.exclude_phase:
-        suffix += "_nophase"
-    if args.use_raw_side:
-        suffix += "_raw"
-    csv_path = write_csv(out, sums, suffix, args.csv_out)
-    if args.csv_out:
-        print(f"[tendencies] wrote {csv_path}")
-    write_md(out, sums, suffix)
+def main() -> None:  # pragma: no cover - CLI entry
+    _run(parse_args())
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main()
+

--- a/analysis/third_party/bytetrack/__init__.py
+++ b/analysis/third_party/bytetrack/__init__.py
@@ -1,0 +1,16 @@
+"""Lightweight ByteTrack implementation used for tests.
+
+This module intentionally provides only a very small subset of the real
+ByteTrack algorithm.  It implements IOU based association with a simple
+velocity smoothing.  The goal of the vendor copy is to avoid pulling in a
+heavy dependency while keeping the public API similar to the real tracker.
+
+The tracker is good enough for unit tests and for running on the small
+example clips that accompany the repository.  It is **not** intended to be
+production quality.
+"""
+
+from .tracker import ByteTracker
+
+__all__ = ["ByteTracker"]
+

--- a/analysis/third_party/bytetrack/tracker.py
+++ b/analysis/third_party/bytetrack/tracker.py
@@ -1,0 +1,131 @@
+"""Very small ByteTrack style tracker.
+
+The implementation below is intentionally compact.  It performs greedy IOU
+matching between existing tracks and new detections and applies a simple
+velocity based smoothing.  Only the features that are required by the unit
+tests are implemented.  Tracks are represented as dictionaries with the keys
+`id` and `bbox` (in ``xyxy`` format).
+
+Example
+-------
+
+>>> tracker = ByteTracker()
+>>> detections = [(0, 0, 10, 10, 0.9)]  # x1, y1, x2, y2, score
+>>> tracker.update(detections)
+[{'id': 1, 'bbox': [0, 0, 10, 10]}]
+
+The real ByteTrack algorithm contains many more optimisations and heuristics.
+This version is sufficient for tests and for building higher level modules in
+the repository without pulling in a heavy dependency.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Tuple
+
+
+def _iou(box_a: Tuple[float, float, float, float],
+         box_b: Tuple[float, float, float, float]) -> float:
+    """Compute intersection over union of two ``xyxy`` boxes."""
+
+    ax1, ay1, ax2, ay2 = box_a
+    bx1, by1, bx2, by2 = box_b
+
+    inter_x1 = max(ax1, bx1)
+    inter_y1 = max(ay1, by1)
+    inter_x2 = min(ax2, bx2)
+    inter_y2 = min(ay2, by2)
+    if inter_x2 <= inter_x1 or inter_y2 <= inter_y1:
+        return 0.0
+    inter_area = (inter_x2 - inter_x1) * (inter_y2 - inter_y1)
+    area_a = (ax2 - ax1) * (ay2 - ay1)
+    area_b = (bx2 - bx1) * (by2 - by1)
+    union = area_a + area_b - inter_area
+    return inter_area / union if union > 0 else 0.0
+
+
+@dataclass
+class _Track:
+    bbox: Tuple[float, float, float, float]
+    id: int
+    vx: float = 0.0
+    vy: float = 0.0
+    age: int = 0
+
+
+class ByteTracker:
+    """Minimal ByteTrack style tracker.
+
+    Parameters
+    ----------
+    iou_threshold:
+        Minimum IOU required to associate a detection with an existing track.
+    max_age:
+        Number of consecutive frames a track may remain unmatched before it is
+        removed.
+    """
+
+    def __init__(self, iou_threshold: float = 0.3, max_age: int = 30) -> None:
+        self.iou_threshold = iou_threshold
+        self.max_age = max_age
+        self._next_id = 1
+        self.tracks: List[_Track] = []
+
+    def update(self, detections: List[Tuple[float, float, float, float, float]]):
+        """Update tracker with ``detections``.
+
+        Each detection is a tuple ``(x1, y1, x2, y2, score)``.  The score is not
+        used in this lightweight implementation but is accepted for API
+        compatibility.  Returns a list of active tracks represented as
+        dictionaries ``{"id": int, "bbox": [x1, y1, x2, y2]}``.
+        """
+
+        assigned = set()
+        # Greedy matching
+        for track in list(self.tracks):
+            best_iou = 0.0
+            best_det = None
+            for i, det in enumerate(detections):
+                if i in assigned:
+                    continue
+                iou = _iou(track.bbox, det[:4])
+                if iou > best_iou:
+                    best_iou = iou
+                    best_det = i
+            if best_iou >= self.iou_threshold and best_det is not None:
+                dx = detections[best_det][0] - track.bbox[0]
+                dy = detections[best_det][1] - track.bbox[1]
+                track.vx = 0.8 * track.vx + 0.2 * dx
+                track.vy = 0.8 * track.vy + 0.2 * dy
+                track.bbox = detections[best_det][:4]
+                track.age = 0
+                assigned.add(best_det)
+            else:
+                # decay age and predict simple motion
+                track.age += 1
+                if track.age > self.max_age:
+                    self.tracks.remove(track)
+                    continue
+                x1, y1, x2, y2 = track.bbox
+                track.bbox = (
+                    x1 + track.vx,
+                    y1 + track.vy,
+                    x2 + track.vx,
+                    y2 + track.vy,
+                )
+
+        # Create new tracks
+        for i, det in enumerate(detections):
+            if i in assigned:
+                continue
+            bbox = det[:4]
+            self.tracks.append(_Track(bbox=bbox, id=self._next_id))
+            self._next_id += 1
+
+        return [
+            {"id": t.id, "bbox": [float(x) for x in t.bbox]}
+            for t in self.tracks
+            if t.age <= self.max_age
+        ]
+

--- a/analysis/yardage.py
+++ b/analysis/yardage.py
@@ -1,0 +1,35 @@
+"""Yardage estimation utilities (stub)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Dict, Any
+
+
+def run(out_dir: Path, clip_path: str, tracks_path: str, out_path: str | None = None) -> Dict[str, Any]:
+    # Without a calibrated field model we cannot estimate yardage.  The stub
+    # simply returns ``yards_gained=None`` and ``explosive=False``.
+    data = {"yards_gained": None, "explosive": False}
+
+    out_file = Path(out_path) if out_path else Path(out_dir) / "yards" / f"{Path(clip_path).stem}.json"
+    out_file.parent.mkdir(parents=True, exist_ok=True)
+    with out_file.open("w", encoding="utf-8") as f:
+        json.dump(data, f)
+    return data
+
+
+def _cli() -> None:  # pragma: no cover
+    ap = argparse.ArgumentParser(description="yardage estimation stub")
+    ap.add_argument("out_dir")
+    ap.add_argument("--clip", required=True)
+    ap.add_argument("--tracks", required=True)
+    ap.add_argument("--out", default=None)
+    args = ap.parse_args()
+    run(Path(args.out_dir), args.clip, args.tracks, args.out)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    _cli()
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 python-dotenv>=1.0.0
-ultralytics
+ultralytics==8.*
 deep_sort_realtime
 easyocr
 opencv-python
@@ -11,3 +11,14 @@ google-auth
 google-auth-httplib2
 google-auth-oauthlib
 tqdm
+
+numpy
+scipy
+pandas
+# trackers
+onemetric
+lap
+filterpy
+
+# Optional helpers
+# mmpose==1.*


### PR DESCRIPTION
## Summary
- stub out YOLO/ByteTrack detection and tracking module
- add team assignment, jersey OCR, formation, event, and yardage placeholders
- extend pipeline and tendencies to support generic opponent scouting

## Testing
- `pytest` *(fails: AttributeError: module 'gameday' has no attribute 'parse_args')*

------
https://chatgpt.com/codex/tasks/task_e_68c46076d7ac832d97a13f3281c3fea6