### PR TITLE
Make feat_extract path-safe and harden pipeline

### DIFF
--- a/analysis/feat_extract.py
+++ b/analysis/feat_extract.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import cv2, numpy as np, json, pathlib, statistics, sys
+from pathlib import Path
 
 def _read_frames(path, max_samples=12):
     cap = cv2.VideoCapture(str(path))
@@ -87,12 +88,13 @@ def extract_for_clip(path, out_dir: pathlib.Path):
         "n1":float(n1), "a1":float(a1), "n4":float(n4), "a4":float(a4)
     }
 
-def cache_all(out: pathlib.Path):
-    p=out/"plays.jsonl";
+def cache_all(out_dir="output"):
+    out = Path(out_dir)            # ensure Path
+    p = out / "plays.jsonl"        # was using `out` before defining it
     rows=[json.loads(x) for x in p.read_text().splitlines() if x.strip()]
     feat={}
     for i,r in enumerate(rows,1):
-        src=r.get("src"); 
+        src=r.get("src");
         if not src or not pathlib.Path(src).exists(): continue
         f=extract_for_clip(src,out)
         feat[src]=f

--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -1563,7 +1563,10 @@ def main(argv=None) -> None:
             print(f"[warn] calibrate_team_colors failed: {e}")
 
         from .feat_extract import cache_all as feat_cache
-        feat_cache(args.out)
+        try:
+            feat_cache(pathlib.Path(args.out))  # be tolerant if feat_cache expects Path
+        except TypeError:
+            feat_cache(args.out)                # and if it expects str in older versions
 
         from pathlib import Path
         outp=Path(args.out)


### PR DESCRIPTION
## Summary
- Ensure feat_extract.cache_all works with string paths by converting to `Path`
- Wrap pipeline's feature cache call in a backward-compatible try/except

## Testing
- `PYTHONDONTWRITEBYTECODE=1 pytest` *(fails: module 'gameday' has no attribute 'parse_args'; SyntaxError in play_classifier.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c46eac4404832db2fb4264a92b2986