### PR TITLE
Simplify side model training and application

### DIFF
--- a/analysis/apply_side_model.py
+++ b/analysis/apply_side_model.py
@@ -1,61 +1,58 @@
 from __future__ import annotations
-import json, pathlib, numpy as np, sys
+import json, math, pathlib
+from pathlib import Path
 
+FEATURE_KEYS = None
 
-def load_model(out: pathlib.Path):
-    p = out/"side_model.json"
-    if not p.exists():
-        raise FileNotFoundError("side_model.json not found")
-    return json.loads(p.read_text())
+def load_model(out: Path):
+    m = json.loads((out/"side_model.json").read_text())
+    global FEATURE_KEYS
+    FEATURE_KEYS = m["features"]
+    return m
 
-
-def load_feats(out: pathlib.Path):
+def load_feats(out: Path):
     return json.loads((out/"features.json").read_text())
 
+def _vec(d):
+    return [float(d.get(k, 0.0)) for k in FEATURE_KEYS]
 
-def apply(out_dir: str | pathlib.Path = "output"):
-    out = pathlib.Path(out_dir)
+def _cosine(a,b):
+    dot = sum(x*y for x,y in zip(a,b))
+    na = math.sqrt(sum(x*x for x in a)) or 1e-6
+    nb = math.sqrt(sum(x*x for x in b)) or 1e-6
+    return max(0.0, min(1.0, dot/(na*nb)))
+
+def _predict_centroid(feat_vec, centroids):
+    # scores are cosine similarity to centroids
+    scores = {c: _cosine(feat_vec, v) for c,v in centroids.items()}
+    side = max(scores, key=scores.get)
+    conf = float(scores[side])
+    return side, conf
+
+def apply(out_dir: str):
+    out = Path(out_dir)
     model = load_model(out)
-    feat = load_feats(out)
+    feats = load_feats(out)
+    centroids = model["centroids"]
 
-    rows = feat["rows"]
-    X = np.array(feat["X"], dtype=float)
-
-    # only centroid model right now
-    cents = {k: np.array(v, dtype=float) for k, v in model["centroids"].items()}
-    classes = list(cents.keys())
-
-    preds = []
-    for i in range(len(rows)):
-        dists = {c: float(np.linalg.norm(X[i] - cents[c])) for c in classes}
-        # smaller distance = higher confidence
-        best = min(dists, key=dists.get)
-        # normalize to a [0,1] proxy confidence
-        inv = {c: 1.0 / (d + 1e-6) for c, d in dists.items()}
-        total = sum(inv.values())
-        conf = inv[best] / total if total else 0.5
-        preds.append((best, conf))
-
-    # write back into plays.jsonl (lincoln_side_pred / _conf)
+    # update plays.jsonl with side_model_pred fields
     p = out/"plays.jsonl"
-    lines = [json.loads(x) if x.strip().startswith("{") else x
-             for x in p.read_text().splitlines()]
-    j = 0
-    new_lines = []
-    for line in lines:
-        if isinstance(line, dict):
-            if j < len(preds):
-                side, conf = preds[j]
-                line["lincoln_side_pred"] = side
-                line["lincoln_side_pred_conf"] = round(conf, 4)
-                j += 1
-            new_lines.append(json.dumps(line))
-        else:
-            new_lines.append(line if isinstance(line, str) else json.dumps(line))
-    p.write_text("\n".join(new_lines))
+    rows = [json.loads(x) for x in p.read_text().splitlines() if x.strip()]
+    new_rows = []
+    for r in rows:
+        if not isinstance(r, dict): new_rows.append(r); continue
+        src = r.get("src")
+        f = feats.get(src)
+        if not f:
+            new_rows.append(r); continue
+        side, conf = _predict_centroid(_vec(f), centroids)
+        r["lincoln_side_model"] = side
+        r["lincoln_side_model_conf"] = conf
+        new_rows.append(r)
+
+    p.write_text("\n".join(json.dumps(r) for r in new_rows))
     print("[apply_model] wrote model predictions")
 
-
 if __name__ == "__main__":
-    apply(sys.argv[1] if len(sys.argv) > 1 else "output")
-
+    import sys
+    apply(sys.argv[1] if len(sys.argv)>1 else "output")

--- a/analysis/train_side_model.py
+++ b/analysis/train_side_model.py
@@ -1,64 +1,62 @@
 from __future__ import annotations
-import json, pathlib, numpy as np, sys
+import json, pathlib, statistics
+from pathlib import Path
 
+# very small centroid classifier to avoid sklearn dependency
+SIDE_INDEX = {"offense":0, "defense":1, "special_teams":2}
 
-def load_feats(out: pathlib.Path):
-    return json.loads((out/"features.json").read_text())
+FEATURE_KEYS = [
+    "black_ratio","white_ratio",
+    "flow_mean","flow_std","vx_mean","vy_mean",
+    "mb_minus_mw_mean"
+]
 
+def _load_feats(out: Path):
+    p = out/"features.json"
+    feat = json.loads(p.read_text())
+    return {k: v for k, v in feat.items()}
 
-def load_seeds(out: pathlib.Path):
+def _load_seeds(out: Path):
     p = out/"seed_labels.json"
-    return {} if not p.exists() else json.loads(p.read_text())
+    if not p.exists(): return {}
+    return json.loads(p.read_text())
 
+def _vec(d):
+    return [float(d.get(k, 0.0)) for k in FEATURE_KEYS]
 
-def save_model(out: pathlib.Path, model):
-    (out/"side_model.json").write_text(json.dumps(model))
-
-
-def train(out_dir: str | pathlib.Path = "output"):
-    out = pathlib.Path(out_dir)
-    feat = load_feats(out)
-    seeds = load_seeds(out)
-
-    # need seeds across >=2 classes
-    labels = set(seeds.values())
-    if len(seeds) < 3 or len(labels) < 2:
-        print("[train] need >=3 total seed examples across >=2 classes")
-        return None
-
-    # very small/shallow model: per-class centroids in feature space
-    X = []
-    y = []
-    src_to_idx = {row["src"]: i for i, row in enumerate(feat["rows"])}
-    for src, lab in seeds.items():
-        idx = src_to_idx.get(src)
-        if idx is None:
-            continue
-        X.append(feat["X"][idx])
-        y.append(lab)
-    if len(set(y)) < 2:
-        print("[train] insufficient class variety after mapping seeds")
-        return None
-
-    X = np.array(X, dtype=float)
-    y = np.array(y)
-    classes = sorted(set(y))
+def _centroid_train(feats: dict, seeds: dict):
+    # collect per-class vectors from seeds
+    byc = {k: [] for k in SIDE_INDEX}
+    for src, side in seeds.items():
+        f = feats.get(src)
+        if not f: continue
+        byc[side].append(_vec(f))
+    # need at least two classes to be useful
+    classes = [c for c, arr in byc.items() if len(arr) >= 2]
+    if len(classes) < 2:
+        raise RuntimeError("need >=2 classes with >=2 seeds each")
     centroids = {}
-    for c in classes:
-        centroids[c] = np.mean(X[y == c], axis=0).tolist()
+    for c, arr in byc.items():
+        if arr:
+            cols = list(zip(*arr))
+            centroids[c] = [statistics.fmean(col) for col in cols]
+    return {
+        "type":"centroid",
+        "features": FEATURE_KEYS,
+        "centroids": centroids
+    }
 
-    model = {"type": "centroid", "classes": classes, "centroids": centroids}
-    save_model(out, model)
-    print(f"[train] wrote {out/'side_model.json'}")
-    return model
+def main(out_dir: str):
+    out = Path(out_dir)
+    feats = _load_feats(out)
+    seeds = _load_seeds(out)
+    if not seeds:
+        raise RuntimeError("no seed_labels.json; seed a few obvious clips first")
 
-
-# Keep old zero-arg entrypoint but make it call the new API
-def main(out_dir: str = "output"):
-    return train(out_dir)
-
+    model = _centroid_train(feats, seeds)
+    (out/"side_model.json").write_text(json.dumps(model))
+    print("[train] wrote", out/"side_model.json")
 
 if __name__ == "__main__":
-    out = sys.argv[1] if len(sys.argv) > 1 else "output"
-    main(out)
-
+    import sys
+    main(sys.argv[1] if len(sys.argv) > 1 else "output")


### PR DESCRIPTION
## Summary
- Replace side model training script with a tiny centroid classifier using fixed features
- Simplify model application to cosine similarity against stored centroids and write predictions

## Testing
- `pytest` *(fails: Module 'cv2' missing libGL.so.1; AttributeError gameday.parse_args)*

------
https://chatgpt.com/codex/tasks/task_e_68c56291ce8c832da32981c415056843