### PR TITLE
docs: cross-link aerial replay pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,8 @@ artefacts. Run it with:
 python -m analysis.pipeline --video path/to/game.mp4 --team WHITE --playbook playbooks/mca_5th_playbook.json --out output/ --generate-report
 ```
 
+For a side-by-side 2-D aerial replay and optional clarity enhancements, see [Aerial replay pipeline](#aerial-replay-pipeline) and run with `--aerial true --enhance fast`.
+
 The command creates JSON lines files and, when `--generate-report` is used, a
 coach report under `output/reports/`.
 
@@ -659,6 +661,8 @@ artefacts. Run it with:
 ```bash
 python -m analysis.pipeline --video path/to/game.mp4 --team WHITE --playbook playbooks/mca_5th_playbook.json --out output/ --generate-report
 ```
+
+For a side-by-side 2-D aerial replay and optional clarity enhancements, see [Aerial replay pipeline](#aerial-replay-pipeline) and run with `--aerial true --enhance fast`.
 
 The command creates JSON lines files and, when `--generate-report` is used, a
 coach report under `output/reports/`.


### PR DESCRIPTION
## Summary
- link automated film analysis instructions to aerial replay pipeline

## Testing
- `PYTHONDONTWRITEBYTECODE=1 pytest -q` *(fails: module 'gameday' missing parse_args; SyntaxError in play_classifier.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c6dd4eff28832d9da3f95f67d32cf7