### PR TITLE
Make aerial requirements platform-aware for ONNX and optional deps

### DIFF
--- a/requirements-aerial.txt
+++ b/requirements-aerial.txt
@@ -7,8 +7,11 @@ matplotlib
 shapely
 filterpy
 lapx ; sys_platform != "win32"
+# alt: lapx @ git+https://github.com/erickw515/lapx.git
 norfair
-onnxruntime-gpu ; platform_system != "Darwin"
-onnxruntime ; platform_system == "Darwin"
+onnxruntime-gpu ; platform_system == "Linux" and platform_machine == "x86_64"
+onnxruntime     ; platform_system == "Linux" and platform_machine == "aarch64"
+onnxruntime     ; platform_system == "Darwin"
+# optional (jersey OCR; pipeline skips if not present)
 pytesseract
 tqdm


### PR DESCRIPTION
## Summary
- Add platform-specific markers for ONNX Runtime GPU/CPU wheels
- Document optional pytesseract and lapx alternate source in aerial requirements

## Testing
- `pytest -q` *(fails: module 'gameday' has no attribute 'parse_args')*

------
https://chatgpt.com/codex/tasks/task_e_68c6df0e0720832da416f6e66e9a69f1