### PR TITLE
Add enhance flag to analysis pipeline configuration

### DIFF
--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -1552,10 +1552,9 @@ def main(argv=None) -> None:
     )
     p.add_argument(
         "--enhance",
-        dest="enhance_level",
         choices=["none", "fast", "max"],
         default="none",
-        help="apply enhancement pipeline preset",
+        help="Video clarity pipeline: none (default), fast (stabilize+color), max (stabilize+superres+deblur+color).",
     )
     p.add_argument(
         "--role-labeling",
@@ -1603,7 +1602,9 @@ def main(argv=None) -> None:
     )
     p.set_defaults(require_classifier=True)
     args = p.parse_args(argv)
-    print(f"[pipeline] config: {json.dumps(vars(args), sort_keys=True)}")
+    cfg = dict(vars(args))
+    cfg["enhance_level"] = args.enhance
+    print(f"[pipeline] config: {json.dumps(cfg, sort_keys=True)}")
 
     if args.input_dir:
         from .ingest_dir import (
@@ -1701,7 +1702,7 @@ def main(argv=None) -> None:
         generate_clips=args.generate_clips,
         debug_weak=args.debug_weak,
         require_classifier=args.require_classifier,
-        enhance=args.enhance,
+        enhance=args.enhance != "none",
         enhance_zoom=args.enhance_zoom,
         enhance_stabilize=args.enhance_stabilize,
         enhance_bitrate=args.enhance_bitrate,
@@ -1716,7 +1717,7 @@ def main(argv=None) -> None:
         aerial_mode=args.aerial_mode,
         aerial_theme=args.aerial_theme,
         side_by_side=args.side_by_side if args.side_by_side is not None else args.aerial,
-        enhance_level=args.enhance_level,
+        enhance_level=cfg["enhance_level"],
         role_labeling=args.role_labeling,
     )
 


### PR DESCRIPTION
## Summary
- add `--enhance` flag for video clarity pipeline
- include enhancement level in runtime config and pass through pipeline

## Testing
- `pytest -q` *(fails: AttributeError: module 'gameday' has no attribute 'parse_args'; SyntaxError in play_classifier.py)*


------
https://chatgpt.com/codex/tasks/task_e_68c6e0d88154832d970595641ac45183