### PR TITLE
Add enhancement preset helper

### DIFF
--- a/analysis/enhance.py
+++ b/analysis/enhance.py
@@ -71,6 +71,11 @@ STEP_FUNCS = {
 }
 
 
+def preset_from_level(level: str) -> list[str]:
+    """Return enhancement steps for the given ``level``."""
+    return PRESETS.get(level, [])
+
+
 def enhance_pipeline(inp: str, out: str, steps: Iterable[str]) -> str:
     """Run enhancement ``steps`` sequentially writing result to ``out``.
 

--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -1156,9 +1156,9 @@ def run_pipeline(
             # New aerial replay and enhancement pipeline
             src_mp4 = mp4
             if enhance_level != "none":
-                from .enhance import enhance_pipeline, PRESETS
+                from .enhance import enhance_pipeline, preset_from_level
 
-                steps = PRESETS.get(enhance_level, [])
+                steps = preset_from_level(enhance_level)
                 enh_mp4 = os.path.join(pdir, f"{pid}_enh.mp4")
                 enhance_pipeline(src_mp4, enh_mp4, steps)
                 r["enhanced_path"] = enh_mp4


### PR DESCRIPTION
## Summary
- centralize enhancement preset lookup
- pipe enhancement level through pipeline

## Testing
- `pytest` *(fails: AttributeError: module 'gameday' has no attribute 'parse_args')*

------
https://chatgpt.com/codex/tasks/task_e_68c6effb44f0832d95db8b17ff56b3a4