### PR TITLE
compatibility shims and output path aliasing

### DIFF
--- a/analysis/core/io_utils.py
+++ b/analysis/core/io_utils.py
@@ -10,8 +10,22 @@ import json
 import os
 import shutil
 import tempfile
+import warnings
 from pathlib import Path
 from typing import Any, Iterable
+
+_OUTPUT_WARNED = False
+
+
+def _warn_outputs() -> None:
+    global _OUTPUT_WARNED
+    if not _OUTPUT_WARNED:
+        warnings.warn(
+            "'outputs/' is deprecated; use 'output/'",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        _OUTPUT_WARNED = True
 
 
 def ensure_dir(path: Path | str) -> Path:
@@ -63,13 +77,22 @@ def append_jsonl(path: Path | str, obj: Any) -> None:
         fh.write(json.dumps(obj) + "\n")
 
 
-def job_dir(job_name: str, create: bool = True) -> Path:
+def job_dir(job_name: str | os.PathLike[str], create: bool = True) -> Path:
     """Return the canonical output directory for ``job_name``.
 
-    Output directories live under ``output/<job_name>``.  A legacy
-    ``outputs`` directory is supported via symlink for backward
-    compatibility.
+    ``job_name`` may be a bare job identifier or a path under ``output`` or
+    ``outputs``.  Using ``outputs`` triggers a deprecation warning and is
+    redirected to ``output``.  A legacy ``outputs`` symlink is ensured for
+    external consumers.
     """
+    p = Path(job_name)
+    parts = p.parts
+    if parts and parts[0] == "outputs":
+        _warn_outputs()
+        p = Path(*parts[1:])
+    elif parts and parts[0] == "output":
+        p = Path(*parts[1:])
+
     root = Path("output")
     legacy = Path("outputs")
     if legacy.exists() and not root.exists():
@@ -81,12 +104,12 @@ def job_dir(job_name: str, create: bool = True) -> Path:
                 shutil.rmtree(legacy)
             legacy.symlink_to(root, target_is_directory=True)
     elif root.exists() and not legacy.exists():
-        # create legacy alias if required by external scripts
         try:
             legacy.symlink_to(root, target_is_directory=True)
         except FileExistsError:
             pass
-    jdir = root / job_name
+
+    jdir = root / p
     if create:
         ensure_dir(jdir)
         for sub in ("clips", "frames", "reports", "artifacts", "logs"):

--- a/analysis/io_utils.py
+++ b/analysis/io_utils.py
@@ -12,24 +12,37 @@ import shutil
 import warnings
 from pathlib import Path
 from typing import Any, Dict
-from datetime import datetime
 from tools.json_io import load_json_safe
 
 from .core import io_utils as _core
 
+_WARNED = False
+
+
+def _warn() -> None:
+    """Emit a deprecation warning once per process."""
+    global _WARNED
+    if not _WARNED:
+        warnings.warn(
+            "analysis.io_utils is deprecated; use analysis.core.io_utils",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        _WARNED = True
+
 
 def ensure_dir(path: Path) -> None:
-    warnings.warn("Deprecated, use analysis.core.io_utils.ensure_dir", DeprecationWarning)
+    _warn()
     _core.ensure_dir(path)
 
 
 def write_json(path: Path, obj: Dict[str, Any]) -> None:
-    warnings.warn("Deprecated, use analysis.core.io_utils.write_json", DeprecationWarning)
+    _warn()
     _core.write_json(path, obj)
 
 
 def append_jsonl(path: Path, obj: Dict[str, Any]) -> None:
-    warnings.warn("Deprecated, use analysis.core.io_utils.append_jsonl", DeprecationWarning)
+    _warn()
     _core.append_jsonl(path, obj)
 
 

--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -7,7 +7,7 @@ values. Flag and value styles are mutually exclusive to avoid ambiguity.
 
 from __future__ import annotations
 
-import os, sys, json, pathlib, argparse, csv, subprocess, logging, re, types, io
+import os, sys, json, pathlib, argparse, csv, subprocess, logging, re, types, io, warnings
 from collections import Counter
 import html
 
@@ -61,6 +61,27 @@ def _probe_vidstab() -> bool:
         data = proc.stdout + proc.stderr
         _HAS_VIDSTAB = "vidstabdetect" in data and "vidstabtransform" in data
     return _HAS_VIDSTAB
+
+
+class _DeprecatedFlag(argparse.Action):
+    """argparse action that warns once when a deprecated flag is used."""
+
+    _warned: dict[str, bool] = {}
+
+    def __init__(self, option_strings, dest, *, new_flag: str, **kwargs):
+        super().__init__(option_strings, dest, nargs=0, **kwargs)
+        self.new_flag = new_flag
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        key = option_string or self.option_strings[0]
+        if not self._warned.get(key):
+            warnings.warn(
+                f"{key} is deprecated; use {self.new_flag}",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            self._warned[key] = True
+        setattr(namespace, self.dest, True)
 
 
 def _ffmpeg(*args: str) -> subprocess.CompletedProcess:
@@ -1505,7 +1526,8 @@ def main(argv=None) -> None:
     p.add_argument(
         "--report",
         dest="generate_report",
-        action="store_true",
+        action=_DeprecatedFlag,
+        new_flag="--generate-report",
         help=argparse.SUPPRESS,
     )
     p.add_argument(
@@ -1517,7 +1539,8 @@ def main(argv=None) -> None:
     p.add_argument(
         "--clips",
         dest="generate_clips",
-        action="store_true",
+        action=_DeprecatedFlag,
+        new_flag="--generate-clips",
         help=argparse.SUPPRESS,
     )
     p.add_argument(

--- a/config.py
+++ b/config.py
@@ -10,22 +10,27 @@ from typing import Any, Dict
 
 from analysis.core.config import load_config as _load_config, get_cfg as _get_cfg
 
+_WARNED = False
+
+
+def _warn() -> None:
+    global _WARNED
+    if not _WARNED:
+        warnings.warn(
+            "config module is deprecated; use analysis.core.config",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        _WARNED = True
+
 
 def load_config(path: str | None, args: argparse.Namespace) -> Dict[str, Any]:
     """Compatibility wrapper for the new configuration loader."""
-    warnings.warn(
-        "Deprecated, use analysis.core.config.load_config",
-        DeprecationWarning,
-        stacklevel=2,
-    )
+    _warn()
     cli = vars(args) if args else {}
     return _load_config(cli)
 
 
 def get_config() -> Dict[str, Any]:
-    warnings.warn(
-        "Deprecated, use analysis.core.config.get_cfg",
-        DeprecationWarning,
-        stacklevel=2,
-    )
+    _warn()
     return _get_cfg()

--- a/env_loader.py
+++ b/env_loader.py
@@ -6,14 +6,23 @@ from pathlib import Path
 
 from analysis.core import config as _core_config
 
+_WARNED = False
+
+
+def _warn() -> None:
+    global _WARNED
+    if not _WARNED:
+        warnings.warn(
+            "env_loader.load_env is deprecated; use analysis.core.config.load_config",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        _WARNED = True
+
 
 def load_env(dotenv_path: str = ".env") -> None:
     """Deprecated; configuration is now handled by ``analysis.core.config``."""
-    warnings.warn(
-        "Deprecated, use analysis.core.config.load_config",
-        DeprecationWarning,
-        stacklevel=2,
-    )
+    _warn()
     _core_config.load_config()
 
 

--- a/ffmpeg_utils.py
+++ b/ffmpeg_utils.py
@@ -1,11 +1,10 @@
 import logging
-import subprocess
-import threading
 import os
 import shlex
+import subprocess
+import threading
 import time
 import warnings
-from datetime import datetime
 from typing import List, Optional, Tuple
 
 from analysis.core.media_utils import (
@@ -13,24 +12,29 @@ from analysis.core.media_utils import (
     ffmpeg_cut as _core_ffmpeg_cut,
 )
 
+_WARNED = False
+
+
+def _warn() -> None:
+    global _WARNED
+    if not _WARNED:
+        warnings.warn(
+            "ffmpeg_utils is deprecated; use analysis.core.media_utils",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        _WARNED = True
+
 
 def ffprobe_json(path: str | os.PathLike[str]):
     """Deprecated shim for :func:`analysis.core.media_utils.ffprobe_json`."""
-    warnings.warn(
-        "Deprecated, use analysis.core.media_utils.ffprobe_json",
-        DeprecationWarning,
-        stacklevel=2,
-    )
+    _warn()
     return _core_ffprobe_json(path)
 
 
 def ffmpeg_cut(src, start, end, dst, prefer_copy: bool = True):
     """Deprecated shim for :func:`analysis.core.media_utils.ffmpeg_cut`."""
-    warnings.warn(
-        "Deprecated, use analysis.core.media_utils.ffmpeg_cut",
-        DeprecationWarning,
-        stacklevel=2,
-    )
+    _warn()
     return _core_ffmpeg_cut(src, start, end, dst, prefer_copy=prefer_copy)
 
 


### PR DESCRIPTION
## Summary
- add DeprecationWarning shims for legacy modules
- warn once for legacy CLI flags
- enforce output/ with outputs/ compatibility symlink

## Testing
- `pytest tests/test_pipeline_cli_flags.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c6f1fc0490832dbf1ed1e46a51b525