### PR TITLE
refactor: replace enhance_zoom usage

### DIFF
--- a/analysis/pipeline.py
+++ b/analysis/pipeline.py
@@ -717,8 +717,8 @@ def run_pipeline(
     generate_clips: bool = False,
     debug_weak: bool = False,
     require_classifier: bool = True,
-    enhance: bool = False,
-    enhance_zoom: float = 0.95,
+    do_enhance: bool = False,
+    enhance: float = 0.95,
     enhance_stabilize: bool = False,
     enhance_bitrate: str = "10M",
     enhance_meta_zoom: bool = False,
@@ -1135,8 +1135,8 @@ def run_pipeline(
                 )
             r["clip_path"] = mp4
 
-            if enhance:
-                zoom_val = enhance_zoom
+            if do_enhance:
+                zoom_val = enhance
                 if enhance_meta_zoom:
                     pf = (r.get("play_family") or "").lower()
                     if pf == "run":
@@ -1756,8 +1756,8 @@ def main(argv=None) -> None:
         generate_clips=args.generate_clips,
         debug_weak=args.debug_weak,
         require_classifier=args.require_classifier,
-        enhance=args.enhance != "none",
-        enhance_zoom=args.enhance_zoom,
+        do_enhance=args.enhance != "none",
+        enhance=args.enhance,
         enhance_stabilize=args.enhance_stabilize,
         enhance_bitrate=args.enhance_bitrate,
         enhance_meta_zoom=args.enhance_meta_zoom,


### PR DESCRIPTION
## Summary
- remove old `enhance_zoom` argument in analysis pipeline
- use existing `--enhance` flag and add `do_enhance` gate

## Testing
- `pytest -q` *(fails: module 'gameday' has no attribute 'parse_args'; SyntaxError in play_classifier.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c6fb945ef8832d91901d63788b9878