### PR TITLE
Replace audit view builder with unified RP logic

### DIFF
--- a/scripts/build_audit_views.py
+++ b/scripts/build_audit_views.py
@@ -1,116 +1,134 @@
 from pathlib import Path
-import sys, os, json, csv, collections
+import sys, json, csv, collections
 
 ST_EXCLUDE = {"xp","kickoff","kick","punt","return","kneel","spike"}
 
 def keep_for_analytics(p):
-    # Match your analytics rules, but be permissive on 'phase'
-    if p.get("exclude_from_analytics"):
-        return False, ["exclude_flag"]
-    st = (p.get("st_fix") or p.get("st") or "").lower().strip()
-    if st in ST_EXCLUDE:
-        return False, [f"st:{st}"]
-    if p.get("special_teams"):
-        return False, ["special_teams"]
-    # DON'T hard filter on phase; many valid plays have blank/misc phases
-    side = p.get("side")
-    if side not in {"offense","defense"}:
-        return False, [f"side:{side}"]
+    if p.get("exclude_from_analytics"): return False, ["exclude_flag"]
+    st = (p.get("st_fix") or p.get("st") or "").lower()
+    if st in ST_EXCLUDE: return False, [f"st:{st}"]
+    if p.get("special_teams"): return False, ["special_teams"]
+    ph = (p.get("phase") or "").lower()
+    if ph and ph not in {"live","play"}: return False, [f"phase:{ph}"]
+    if p.get("side") not in {"offense","defense"}: return False, [f"side:{p.get('side')}"]
     return True, []
 
 def rp_and_dir(p):
-    # Final label with fallbacks
-    rp = (p.get("rp_fix") or p.get("rp") or
-          ("run" if p.get("is_run") else ("pass" if p.get("is_pass") else "unknown"))).lower()
-    if rp == "run":
-        d = (p.get("run_dir_fix") or p.get("run_dir") or "unknown").lower()
-    elif rp == "pass":
-        d = (p.get("dir_fix") or p.get("direction") or "unknown").lower()
-    else:
-        d = (p.get("dir_fix") or p.get("direction") or p.get("run_dir") or "unknown").lower()
-    # normalize
-    if d not in {"left","right","middle","unknown"}:
-        d = ("left" if "left" in d else
-             "right" if "right" in d else
-             "middle" if "mid" in d else
-             "unknown")
-    return rp, d
+    # 1) unified rp_dir if available (e.g., "pass:left", "run:right")
+    rpd = p.get("rp_dir") or p.get("rpdir")
+    if isinstance(rpd, str) and ":" in rpd:
+        rp, d = rpd.split(":", 1)
+        rp, d = (rp or "unknown").strip(), (d or "unknown").strip()
+        if rp in {"run","pass"}:
+            return rp, d
+
+    # 2) fall back to rp_fix / rp + run_dir/direction
+    rp_fix = p.get("rp_fix")
+    if rp_fix in {"run","pass"}:
+        d = (p.get("run_dir") if rp_fix == "run" else p.get("direction")) or "unknown"
+        return rp_fix, d
+
+    rp = p.get("rp")
+    if rp in {"run","pass"}:
+        d = (p.get("run_dir") if rp == "run" else p.get("direction")) or "unknown"
+        return rp, d
+
+    # 3) booleans
+    if p.get("is_run"):
+        return "run", (p.get("run_dir") or "unknown")
+    if p.get("is_pass"):
+        return "pass", (p.get("direction") or "unknown")
+
+    return "unknown", "unknown"
+
+def rp_flags_raw(p):
+    if p.get("is_run"): return "run"
+    if p.get("is_pass"): return "pass"
+    return "unknown"
 
 def main():
-    arg = sys.argv[1].strip() if len(sys.argv) > 1 else ""
-    out = Path(arg or os.environ.get("OUT", "output/opponent_jenks_silver_20250913"))
+    out = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("output/opponent_jenks_silver_20250913")
     plays_path = out / "plays.jsonl"
     audit_dir = out / "audit"
     audit_dir.mkdir(parents=True, exist_ok=True)
 
     if not plays_path.exists():
-        raise SystemExit(f"[error] {plays_path} not found")
+        sys.exit(f"[error] {plays_path} not found")
 
-    plays = [json.loads(l) for l in plays_path.read_text().splitlines() if l.strip()]
+    plays = [json.loads(x) for x in plays_path.read_text().splitlines() if x.strip()]
 
-    kept_rows = {"offense": [], "defense": []}
-    debug_rows = []
-
-    for p in plays:
-        kept, reasons = keep_for_analytics(p)
+    kept_by_side = {"offense": [], "defense": []}
+    kept_debug_rows = []
+    for idx, p in enumerate(plays, start=1):
+        keep, reasons = keep_for_analytics(p)
         rp_used, dir_used = rp_and_dir(p)
-        rp_flags = "run" if p.get("is_run") else ("pass" if p.get("is_pass") else "unknown")
-        debug_rows.append([
-            p.get("index"), p.get("side"),
-            p.get("phase"), p.get("st"), p.get("st_fix"),
-            bool(p.get("exclude_from_analytics")), bool(p.get("special_teams")),
-            bool(p.get("is_run")), bool(p.get("is_pass")),
-            p.get("rp_fix"), p.get("rp"), rp_flags,
-            p.get("dir_fix"), p.get("run_dir"), p.get("direction"),
-            rp_used, dir_used, kept, "|".join(reasons),
-            p.get("src") or p.get("clip") or "", p.get("title") or ""
-        ])
-        if kept and p.get("side") in kept_rows:
-            kept_rows[p["side"]].append((rp_used, dir_used))
+        rp_flags = rp_flags_raw(p)
 
-    # Debug
-    with (audit_dir/"audit_kept_debug.csv").open("w", newline="") as f:
-        w = csv.writer(f)
-        w.writerow([
-            "index","side","phase","st","st_fix","exclude_flag","special_teams",
-            "is_run","is_pass","rp_fix","rp_auto","rp_flags",
-            "dir_fix","run_dir","direction",
-            "rp_used","dir_used","kept","exclude_reasons","src","title"
-        ])
-        w.writerows(debug_rows)
+        kept_debug_rows.append({
+            "index": idx,
+            "kept": str(bool(keep)).lower(),
+            "exclude_reasons": ";".join(reasons),
+            "side": p.get("side") or "unknown",
+            "rp_used": rp_used,
+            "rp_flags": rp_flags,
+            "dir_used": dir_used,
+            "run_dir": p.get("run_dir") or "",
+            "direction": p.get("direction") or "",
+            "phase": p.get("phase") or "",
+            "st_fix": (p.get("st_fix") or p.get("st") or ""),
+            "exclude_flag": str(bool(p.get("exclude_from_analytics"))).lower(),
+            "src": p.get("src") or "",
+            "title": p.get("title") or "",
+        })
 
-    # Summary
-    with (audit_dir/"audit_summary.csv").open("w", newline="") as f:
-        w = csv.writer(f); w.writerow(["side","bucket","value","count"])
-        for side, vals in kept_rows.items():
-            cnt = collections.Counter()
-            for rp, d in vals:
-                cnt[("rp", rp)] += 1
-                cnt[("rp_dir", f"{rp}:{d}")] += 1
-            for (bucket, value), n in sorted(cnt.items()):
-                w.writerow([side, bucket, value, n])
+        if keep:
+            s = p.get("side")
+            if s in kept_by_side:
+                kept_by_side[s].append({"rp": rp_used, "dir": dir_used})
 
-    # Disagreements (rp_used vs raw flags)
-    with (audit_dir/"audit_disagreements.csv").open("w", newline="") as f:
-        w = csv.writer(f)
-        w.writerow(["index","side","rp_used","rp_flags","dir_used","run_dir","direction","phase","st_fix","exclude_flag","src","title"])
-        for row, p in zip(debug_rows, plays):
-            if not row[17]:  # kept == False? skip; we care about included analytics plays
-                continue
-            rp_used, dir_used, rp_flags = row[15], row[16], row[11]
-            if rp_used != rp_flags:
-                w.writerow([
-                    row[0], row[1], rp_used, rp_flags, dir_used,
-                    p.get("run_dir"), p.get("direction"), p.get("phase"), p.get("st_fix"),
-                    row[5], p.get("src") or "", p.get("title") or ""
-                ])
+    # Write debug rows
+    debug_path = audit_dir / "audit_kept_debug.csv"
+    with debug_path.open("w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=list(kept_debug_rows[0].keys()) if kept_debug_rows else [])
+        if kept_debug_rows: w.writeheader(); w.writerows(kept_debug_rows)
+
+    # Summary counts (mirror quick_* layout)
+    summary_rows = []
+    for side, arr in kept_by_side.items():
+        cnt = collections.Counter()
+        for x in arr:
+            rp = x["rp"]
+            d  = x["dir"] or "unknown"
+            cnt[("rp", rp)] += 1
+            cnt[("rp_dir", f"{rp}:{d}")] += 1
+        for (bucket, value), c in sorted(cnt.items()):
+            summary_rows.append({"side": side, "bucket": bucket, "value": value, "count": c})
+
+    summary_path = audit_dir / "audit_summary.csv"
+    with summary_path.open("w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=["side","bucket","value","count"])
+        w.writeheader(); w.writerows(summary_rows)
+
+    # Disagreements: rp_used vs rp_flags
+    dis_rows = []
+    for r in kept_debug_rows:
+        if r["kept"] == "true" and r["rp_used"] != r["rp_flags"]:
+            dis_rows.append({k: r[k] for k in [
+                "index","side","rp_used","rp_flags","dir_used","run_dir","direction",
+                "phase","st_fix","exclude_flag","src","title"
+            ]})
+    disagree_path = audit_dir / "audit_disagreements.csv"
+    with disagree_path.open("w", newline="") as f:
+        hdr = ["index","side","rp_used","rp_flags","dir_used","run_dir","direction","phase","st_fix","exclude_flag","src","title"]
+        w = csv.DictWriter(f, fieldnames=hdr)
+        w.writeheader(); w.writerows(dis_rows)
 
     print("[kept counts]")
-    for side, vals in kept_rows.items():
-        print(f"  {side}: {len(vals)}")
-    print("[wrote]", audit_dir/"audit_kept_debug.csv")
-    print("[wrote]", audit_dir/"audit_summary.csv")
-    print("[wrote]", audit_dir/"audit_disagreements.csv")
+    for side in ("offense","defense"):
+        print(f"  {side}: {len(kept_by_side[side])}")
+    print(f"[wrote] {debug_path}")
+    print(f"[wrote] {summary_path}")
+    print(f"[wrote] {disagree_path}")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- mirror analytics special-teams exclusions and phase filtering when deciding to keep plays
- add unified run/pass + direction derivation with rp_dir and fallbacks for audit outputs
- emit audit debug, summary, and disagreement CSVs using the updated structures

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb0c9d50e8832dbc4c8bf28869b616