### PR TITLE
Replace audit view builder filtering logic

### DIFF
--- a/scripts/build_audit_views.py
+++ b/scripts/build_audit_views.py
@@ -1,58 +1,47 @@
-#!/usr/bin/env python3
 from pathlib import Path
 import sys, json, csv, collections
 
-ST_EXCLUDE = {"xp","kickoff","punt","return","kneel","spike"}  # match analytics
+ST_EXCLUDE   = {"xp","kickoff","punt","return","kneel","spike","kick"}
+NON_LIVE     = {"dead","deadball","pre","presnap","post","postplay","timeout","halftime","setup"}
 
-def norm(v, allowed, default="unknown"):
-    v = (v or "").strip().lower()
-    return v if v in allowed else default
-
-def rp_from_flags(p):
-    r = bool(p.get("is_run")); s = bool(p.get("is_pass"))
-    if r and not s: return "run"
-    if s and not r: return "pass"
-    return "unknown"
-
-def rp_used(p):
-    # allow an audit or fixer override if present
-    v = (p.get("rp_fix") or p.get("rp") or "").strip().lower()
-    if v in {"run","pass","unknown"}:
-        return v
-    return rp_from_flags(p)
-
-def dir_used(p, rp):
-    if rp == "run":
-        return norm(p.get("run_dir") or p.get("direction"), {"left","right","unknown"})
-    if rp == "pass":
-        return norm(p.get("direction"), {"left","right","unknown"})
-    return "unknown"
-
-def keep_for_analytics(p, reasons_out):
-    # explicit exclude flag
+def keep_for_analytics(p):
+    # Explicit exclude
     if p.get("exclude_from_analytics"):
-        reasons_out.append("exclude_flag")
-        return False
-    # special teams labels
+        return False, ["exclude_flag"]
+    # Special teams (via st/st_fix) or explicit flag
     st = (p.get("st_fix") or p.get("st") or "").strip().lower()
     if st in ST_EXCLUDE:
-        reasons_out.append(f"st:{st}")
-        return False
-    # special_teams boolean
+        return False, [f"st:{st}"]
     if p.get("special_teams"):
-        reasons_out.append("special_teams")
-        return False
-    # safe phase filter
+        return False, ["special_teams"]
+    # Phase: only exclude clearly non-live phases; keep "", "unknown", etc.
     ph = (p.get("phase") or "").strip().lower()
-    if ph and ph not in {"live","play"}:
-        reasons_out.append(f"phase:{ph}")
-        return False
-    # side must be o/d
-    side = (p.get("side") or "").strip().lower()
+    if ph in NON_LIVE:
+        return False, [f"phase:{ph}"]
+    # Side must be offense/defense
+    side = p.get("side")
     if side not in {"offense","defense"}:
-        reasons_out.append(f"side:{side or 'none'}")
-        return False
-    return True
+        return False, [f"side:{side}"]
+    return True, []
+
+def rp_used_of(p):
+    if p.get("is_run"):  return "run"
+    if p.get("is_pass"): return "pass"
+    return "unknown"
+
+def rp_flags_of(p):
+    # If an original auto tag exists (e.g., "rp"), prefer it; otherwise fall back to current flags
+    rp = (p.get("rp") or "").strip().lower()
+    if rp in {"run","pass"}: return rp
+    return rp_used_of(p)
+
+def dir_used_of(p):
+    ru = rp_used_of(p)
+    if ru == "run":
+        return (p.get("run_dir") or "unknown").lower()
+    if ru == "pass":
+        return (p.get("direction") or "unknown").lower()
+    return "unknown"
 
 def main():
     out = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("output/opponent_jenks_silver_20250913")
@@ -61,86 +50,88 @@ def main():
     audit_dir.mkdir(parents=True, exist_ok=True)
 
     if not plays_path.exists():
-        sys.exit(f"[error] {plays_path} not found")
+        print(f"[error] {plays_path} not found")
+        sys.exit(1)
 
-    plays = [json.loads(x) for x in plays_path.read_text().splitlines() if x.strip()]
+    plays = [json.loads(l) for l in plays_path.read_text().splitlines() if l.strip()]
 
-    kept = {"offense": [], "defense": []}
+    kept = []
     debug_rows = []
     for i, p in enumerate(plays):
-        idx = p.get("index") or p.get("idx") or (i+1)
-        side = (p.get("side") or "").lower()
-        reasons = []
-        keep = keep_for_analytics(p, reasons)
-        rp = rp_used(p)
-        diru = dir_used(p, rp)
-        row = {
-            "index": idx,
-            "kept": str(bool(keep)).lower(),
-            "exclude_reasons": "|".join(reasons),
-            "side": side or "unknown",
-            "rp_used": rp,
-            "rp_flags": rp_from_flags(p),
-            "dir_used": diru,
-            "run_dir": (p.get("run_dir") or "unknown"),
-            "direction": (p.get("direction") or "unknown"),
-            "phase": (p.get("phase") or "unknown"),
+        k, reasons = keep_for_analytics(p)
+        if k: kept.append((i, p))
+        debug_rows.append({
+            "index": i,
+            "kept": str(k).lower(),
+            "exclude_reasons": ";".join(reasons),
+            "side": p.get("side",""),
+            "rp_used": rp_used_of(p),
+            "rp_flags": rp_flags_of(p),
+            "dir_used": dir_used_of(p),
+            "run_dir": (p.get("run_dir") or ""),
+            "direction": (p.get("direction") or ""),
+            "phase": (p.get("phase") or ""),
             "st_fix": (p.get("st_fix") or p.get("st") or ""),
             "exclude_flag": str(bool(p.get("exclude_from_analytics"))).lower(),
-            "src": (p.get("src") or ""),
-            "title": (p.get("title") or ""),
-        }
-        debug_rows.append(row)
-        if keep and side in kept:
-            kept[side].append({"index": idx, "rp": rp, "dir": diru})
+            "src": p.get("src",""),
+            "title": p.get("title",""),
+        })
 
-    # print kept counts
-    print("[kept counts]")
-    for s in ("offense","defense"):
-        print(f"  {s}: {len(kept[s])}")
-
-    # write debug
+    # Write debug
     dbg_p = audit_dir / "audit_kept_debug.csv"
     with dbg_p.open("w", newline="") as f:
-        w = csv.DictWriter(f, fieldnames=list(debug_rows[0].keys()) if debug_rows else [
-            "index","kept","exclude_reasons","side","rp_used","rp_flags","dir_used",
-            "run_dir","direction","phase","st_fix","exclude_flag","src","title"
-        ])
+        w = csv.DictWriter(f, fieldnames=list(debug_rows[0].keys()))
         w.writeheader(); w.writerows(debug_rows)
 
-    # build summary (side,bucket,value,count) to mirror quick_* CSVs
-    summary_rows = []
-    for side, items in kept.items():
-        cnt = collections.Counter()
-        for it in items:
-            rp = it["rp"]
-            cnt[("rp", rp)] += 1
-            cnt[("rp_dir", f"{rp}:{it['dir']}")] += 1
-        for (bucket, value), c in sorted(cnt.items()):
-            summary_rows.append({"side": side, "bucket": bucket, "value": value, "count": c})
+    # Summary (mirror quick_* CSVs): counts by side x (rp, rp_dir)
+    cnt = collections.Counter()
+    for _, p in kept:
+        side = p["side"]
+        ru = rp_used_of(p)
+        cnt[(side,"rp",ru)] += 1
+        d = dir_used_of(p)
+        cnt[(side,"rp_dir",f"{ru}:{d}")] += 1
 
     sum_p = audit_dir / "audit_summary.csv"
     with sum_p.open("w", newline="") as f:
-        w = csv.DictWriter(f, fieldnames=["side","bucket","value","count"])
-        w.writeheader(); w.writerows(summary_rows)
+        w = csv.writer(f)
+        w.writerow(["side","bucket","value","count"])
+        for (side,bucket,value), c in sorted(cnt.items()):
+            w.writerow([side,bucket,value,c])
 
-    # disagreements = where rp_used != rp_flags OR (rp_used=='run' and dir_used != run_dir)
-    # OR (rp_used=='pass' and dir_used != direction)
-    dis_rows = []
-    for r in debug_rows:
-        rp = r["rp_used"]; flags = r["rp_flags"]
-        diru = r["dir_used"]; run_dir = (r["run_dir"] or "unknown").lower()
-        direc = (r["direction"] or "unknown").lower()
-        dir_mismatch = (rp=="run" and diru!=norm(run_dir, {"left","right","unknown"})) or \
-                       (rp=="pass" and diru!=norm(direc, {"left","right","unknown"}))
-        if rp != flags or dir_mismatch:
-            dis_rows.append(r)
+    # Disagreements between rp_used and rp_flags (good retraining examples)
     dis_p = audit_dir / "audit_disagreements.csv"
     with dis_p.open("w", newline="") as f:
-        w = csv.DictWriter(f, fieldnames=list(debug_rows[0].keys()) if debug_rows else [])
-        if debug_rows: w.writeheader()
-        w.writerows(dis_rows)
+        w = csv.writer(f)
+        w.writerow(["index","kept","exclude_reasons","side","rp_used","rp_flags","dir_used",
+                    "run_dir","direction","phase","st_fix","exclude_flag","src","title"])
+        for i, p in kept:
+            ru = rp_used_of(p)
+            rf = rp_flags_of(p)
+            if ru != rf:
+                # find its debug row to grab reasons/flags consistently
+                dr = next((r for r in debug_rows if int(r["index"])==i), None)
+                w.writerow([
+                    i,
+                    dr["kept"] if dr else "true",
+                    dr["exclude_reasons"] if dr else "",
+                    p.get("side",""),
+                    ru,
+                    rf,
+                    dir_used_of(p),
+                    p.get("run_dir",""),
+                    p.get("direction",""),
+                    p.get("phase",""),
+                    (p.get("st_fix") or p.get("st") or ""),
+                    str(bool(p.get("exclude_from_analytics"))).lower(),
+                    p.get("src",""),
+                    p.get("title",""),
+                ])
 
+    print("[kept counts]")
+    by_side = collections.Counter(p.get("side") for _, p in kept)
+    print(f"  offense: {by_side.get('offense',0)}")
+    print(f"  defense: {by_side.get('defense',0)}")
     print(f"[wrote] {dbg_p}")
     print(f"[wrote] {sum_p}")
     print(f"[wrote] {dis_p}")


### PR DESCRIPTION
## Summary
- replace scripts/build_audit_views.py with updated logic that only excludes non-live phases
- adjust analytics filtering to drop special teams and explicit exclusions while keeping unknown phases
- generate audit CSV outputs with debug, summary, and disagreements mirroring quick_* CSV structure

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb1bce3aa0832d83500a120c7bcbac