### PR TITLE
Replace audit view builder with updated version

### DIFF
--- a/scripts/build_audit_views.py
+++ b/scripts/build_audit_views.py
@@ -1,140 +1,156 @@
 from pathlib import Path
 import sys, json, csv, collections
 
-ST_EXCLUDE   = {"xp","kickoff","punt","return","kneel","spike","kick"}
-NON_LIVE     = {"dead","deadball","pre","presnap","post","postplay","timeout","halftime","setup"}
+# --- helpers ---------------------------------------------------------------
+
+ST_EXCLUDE = {"xp","kickoff","kick","punt","return","kneel","spike"}
 
 def keep_for_analytics(p):
-    # Explicit exclude
+    # explicit excludes
     if p.get("exclude_from_analytics"):
         return False, ["exclude_flag"]
-    # Special teams (via st/st_fix) or explicit flag
+
+    # special teams by tag or st/st_fix
     st = (p.get("st_fix") or p.get("st") or "").strip().lower()
     if st in ST_EXCLUDE:
         return False, [f"st:{st}"]
     if p.get("special_teams"):
         return False, ["special_teams"]
-    # Phase: only exclude clearly non-live phases; keep "", "unknown", etc.
+
+    # phase: allow "", "unknown"; only drop explicit non-live phases
     ph = (p.get("phase") or "").strip().lower()
-    if ph in NON_LIVE:
+    if ph in {"dead","deadball","pre","presnap","post","postplay","timeout","halftime","setup"}:
         return False, [f"phase:{ph}"]
-    # Side must be offense/defense
-    side = p.get("side")
-    if side not in {"offense","defense"}:
-        return False, [f"side:{side}"]
+
+    # only analyze offense/defense
+    if p.get("side") not in {"offense","defense"}:
+        return False, [f"side:{p.get('side')}"]
+
     return True, []
 
-def rp_used_of(p):
-    if p.get("is_run"):  return "run"
-    if p.get("is_pass"): return "pass"
+def rp_from_flags(p):
+    # derive from is_run/is_pass flags (used only as fallback)
+    if p.get("is_run"):
+        return "run"
+    if p.get("is_pass"):
+        return "pass"
     return "unknown"
 
-def rp_flags_of(p):
-    # If an original auto tag exists (e.g., "rp"), prefer it; otherwise fall back to current flags
+def rp_final(p):
+    # prefer the FINAL label used by analytics/quick CSVs
     rp = (p.get("rp") or "").strip().lower()
-    if rp in {"run","pass"}: return rp
-    return rp_used_of(p)
+    if rp in {"run","pass"}:
+        return rp
+    return rp_from_flags(p)
 
-def dir_used_of(p):
-    ru = rp_used_of(p)
-    if ru == "run":
-        return (p.get("run_dir") or "unknown").lower()
-    if ru == "pass":
-        return (p.get("direction") or "unknown").lower()
-    return "unknown"
+def dir_final(p, rp):
+    if rp == "run":
+        d = (p.get("run_dir") or p.get("direction") or "unknown").strip().lower()
+    elif rp == "pass":
+        d = (p.get("direction") or "unknown").strip().lower()
+    else:
+        d = "unknown"
+    # normalize to left/right/unknown for stable buckets
+    if d not in {"left","right"}:
+        d = "unknown"
+    return d
+
+# --- main ------------------------------------------------------------------
 
 def main():
     out = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("output/opponent_jenks_silver_20250913")
     plays_path = out / "plays.jsonl"
-    audit_dir  = out / "audit"
+    audit_dir = out / "audit"
     audit_dir.mkdir(parents=True, exist_ok=True)
 
     if not plays_path.exists():
-        print(f"[error] {plays_path} not found")
-        sys.exit(1)
+        raise SystemExit(f"[error] plays.jsonl not found at {plays_path}")
 
-    plays = [json.loads(l) for l in plays_path.read_text().splitlines() if l.strip()]
+    plays = [json.loads(x) for x in plays_path.read_text().splitlines() if x.strip()]
 
     kept = []
     debug_rows = []
-    for i, p in enumerate(plays):
-        k, reasons = keep_for_analytics(p)
-        if k: kept.append((i, p))
+    disagree_rows = []
+    by_side_counts = {"offense":0, "defense":0}
+
+    for idx, p in enumerate(plays, start=1):
+        keep, reasons = keep_for_analytics(p)
+        if keep:
+            kept.append((idx, p))
+            by_side_counts[p["side"]] += 1
         debug_rows.append({
-            "index": i,
-            "kept": str(k).lower(),
-            "exclude_reasons": ";".join(reasons),
+            "index": idx,
+            "kept": str(bool(keep)).lower(),
+            "exclude_reasons": ";".join(reasons) if reasons else "",
             "side": p.get("side",""),
-            "rp_used": rp_used_of(p),
-            "rp_flags": rp_flags_of(p),
-            "dir_used": dir_used_of(p),
-            "run_dir": (p.get("run_dir") or ""),
-            "direction": (p.get("direction") or ""),
-            "phase": (p.get("phase") or ""),
-            "st_fix": (p.get("st_fix") or p.get("st") or ""),
-            "exclude_flag": str(bool(p.get("exclude_from_analytics"))).lower(),
+            "rp": p.get("rp",""),
+            "is_run": str(bool(p.get("is_run"))).lower(),
+            "is_pass": str(bool(p.get("is_pass"))).lower(),
+            "run_dir": p.get("run_dir",""),
+            "direction": p.get("direction",""),
+            "phase": p.get("phase",""),
+            "st_fix": p.get("st_fix",""),
             "src": p.get("src",""),
             "title": p.get("title",""),
         })
 
-    # Write debug
-    dbg_p = audit_dir / "audit_kept_debug.csv"
-    with dbg_p.open("w", newline="") as f:
-        w = csv.DictWriter(f, fieldnames=list(debug_rows[0].keys()))
-        w.writeheader(); w.writerows(debug_rows)
+        # disagreement = final rp vs flags (only for kept clips)
+        rp_f = rp_final(p)
+        rp_fl = rp_from_flags(p)
+        if keep and (rp_f != "unknown") and (rp_fl != "unknown") and rp_f != rp_fl:
+            disagree_rows.append([
+                idx, "true", "",
+                p.get("side",""),
+                rp_f, rp_fl,
+                dir_final(p, rp_f), p.get("run_dir",""), p.get("direction",""),
+                p.get("phase",""), p.get("st_fix",""), str(bool(p.get("exclude_from_analytics"))).lower(),
+                p.get("src",""), p.get("title","")
+            ])
+        elif not keep:
+            # show why it was dropped
+            disagree_rows.append([
+                idx, "false", ";".join(reasons),
+                p.get("side",""),
+                rp_final(p), rp_from_flags(p),
+                dir_final(p, rp_final(p)), p.get("run_dir",""), p.get("direction",""),
+                p.get("phase",""), p.get("st_fix",""), str(bool(p.get("exclude_from_analytics"))).lower(),
+                p.get("src",""), p.get("title","")
+            ])
 
-    # Summary (mirror quick_* CSVs): counts by side x (rp, rp_dir)
+    # Summary (mirror quick_* CSVs)
     cnt = collections.Counter()
     for _, p in kept:
         side = p["side"]
-        ru = rp_used_of(p)
-        cnt[(side,"rp",ru)] += 1
-        d = dir_used_of(p)
-        cnt[(side,"rp_dir",f"{ru}:{d}")] += 1
+        rp = rp_final(p)
+        cnt[(side, "rp", rp)] += 1
+        cnt[(side, "rp_dir", f"{rp}:{dir_final(p, rp)}")] += 1
 
-    sum_p = audit_dir / "audit_summary.csv"
-    with sum_p.open("w", newline="") as f:
+    # Write files
+    # kept debug
+    with (audit_dir/"audit_kept_debug.csv").open("w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=list(debug_rows[0].keys()))
+        w.writeheader(); w.writerows(debug_rows)
+
+    # summary
+    with (audit_dir/"audit_summary.csv").open("w", newline="") as f:
         w = csv.writer(f)
         w.writerow(["side","bucket","value","count"])
         for (side,bucket,value), c in sorted(cnt.items()):
             w.writerow([side,bucket,value,c])
 
-    # Disagreements between rp_used and rp_flags (good retraining examples)
-    dis_p = audit_dir / "audit_disagreements.csv"
-    with dis_p.open("w", newline="") as f:
+    # disagreements
+    with (audit_dir/"audit_disagreements.csv").open("w", newline="") as f:
         w = csv.writer(f)
         w.writerow(["index","kept","exclude_reasons","side","rp_used","rp_flags","dir_used",
                     "run_dir","direction","phase","st_fix","exclude_flag","src","title"])
-        for i, p in kept:
-            ru = rp_used_of(p)
-            rf = rp_flags_of(p)
-            if ru != rf:
-                # find its debug row to grab reasons/flags consistently
-                dr = next((r for r in debug_rows if int(r["index"])==i), None)
-                w.writerow([
-                    i,
-                    dr["kept"] if dr else "true",
-                    dr["exclude_reasons"] if dr else "",
-                    p.get("side",""),
-                    ru,
-                    rf,
-                    dir_used_of(p),
-                    p.get("run_dir",""),
-                    p.get("direction",""),
-                    p.get("phase",""),
-                    (p.get("st_fix") or p.get("st") or ""),
-                    str(bool(p.get("exclude_from_analytics"))).lower(),
-                    p.get("src",""),
-                    p.get("title",""),
-                ])
+        w.writerows(disagree_rows)
 
     print("[kept counts]")
-    by_side = collections.Counter(p.get("side") for _, p in kept)
-    print(f"  offense: {by_side.get('offense',0)}")
-    print(f"  defense: {by_side.get('defense',0)}")
-    print(f"[wrote] {dbg_p}")
-    print(f"[wrote] {sum_p}")
-    print(f"[wrote] {dis_p}")
+    for s in ("offense","defense"):
+        print(f"  {s}: {by_side_counts[s]}")
+    print(f"[wrote] {audit_dir/'audit_kept_debug.csv'}")
+    print(f"[wrote] {audit_dir/'audit_summary.csv'}")
+    print(f"[wrote] {audit_dir/'audit_disagreements.csv'}")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- replace the audit view builder with the provided drop-in script that matches analytics filtering logic and final run/pass labeling
- update audit outputs to rely on `run_dir`/`direction` buckets and emit summary, disagreements, and kept debug CSVs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb1eff8ce0832d87f1766a31a13ec9