### PR TITLE
Add audit-driven Jenks side tagging and side-aware analytics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ audit-sync: ensure-out
 	@echo "OUT=$(OUT)"
 	python3 scripts/audit_apply_csv.py "$(OUT)"
 	python3 scripts/audit_enrich_yards_dd.py "$(OUT)"
+	python3 scripts/fix_jenks_side.py "$(OUT)"
 	python3 scripts/sync_audit_to_analytics.py "$(OUT)"
 	python3 scripts/build_audit_views.py "$(OUT)"
 

--- a/scripts/Build-Reel.ps1
+++ b/scripts/Build-Reel.ps1
@@ -1,0 +1,129 @@
+[CmdletBinding()]
+param(
+    [string]$OutDir = $env:OUT,
+    [string]$SpansPath,
+    [string]$ScoreboardPath,
+    [string]$OutputPath
+)
+
+function TryParse-Double([string]$s, [ref]$outVal) {
+  $ci  = [System.Globalization.CultureInfo]::InvariantCulture
+  $ns  = [System.Globalization.NumberStyles]::Float
+  [double]$tmp = 0
+  $text = if ($null -eq $s) { "" } else { $s.ToString() }
+  $ok = [double]::TryParse($text, $ns, $ci, [ref]$tmp)
+  if ($ok) { $outVal.Value = $tmp }
+  return $ok
+}
+
+$ci = [System.Globalization.CultureInfo]::InvariantCulture
+
+if (-not $OutDir) {
+  throw "OUT directory not provided. Pass -OutDir or set the OUT environment variable."
+}
+$resolvedOut = Resolve-Path -Path $OutDir -ErrorAction Stop
+
+if (-not $SpansPath) {
+  $SpansPath = Join-Path $resolvedOut "highlight_spans.json"
+}
+if (-not (Test-Path $SpansPath)) {
+  throw "Spans file not found: $SpansPath"
+}
+
+if (-not $ScoreboardPath) {
+  $ScoreboardPath = Join-Path $resolvedOut "scoreboard_spans.json"
+}
+if (-not (Test-Path $ScoreboardPath)) {
+  throw "Scoreboard file not found: $ScoreboardPath"
+}
+
+if (-not $OutputPath) {
+  $OutputPath = Join-Path $resolvedOut "highlight_reel_plan.json"
+}
+
+$spanJson = Get-Content -Path $SpansPath -Raw -Encoding UTF8
+$spanItems = @()
+try {
+  $spanData = $spanJson | ConvertFrom-Json
+} catch {
+  throw "Unable to parse spans JSON from $SpansPath"
+}
+foreach ($s in $spanData) {
+  [double]$t0 = 0
+  [double]$t1 = 0
+  if (TryParse-Double $s.t0 ([ref]$t0) -and TryParse-Double $s.t1 ([ref]$t1)) {
+    $duration = [math]::Max(0.0, $t1 - $t0)
+    $segment = [pscustomobject]@{
+      Start    = $t0
+      End      = $t1
+      Duration = $duration
+      Label    = $s.label
+    }
+    $spanItems += $segment
+  }
+}
+
+if ($ScoreboardPath.ToLower().EndsWith('.json')) {
+  $scoreRaw = Get-Content -Path $ScoreboardPath -Raw -Encoding UTF8
+  try {
+    $scoreData = $scoreRaw | ConvertFrom-Json
+  } catch {
+    throw "Unable to parse scoreboard JSON from $ScoreboardPath"
+  }
+} else {
+  $scoreData = Import-Csv -Path $ScoreboardPath
+}
+
+$scoreItems = @()
+foreach ($r in $scoreData) {
+  [double]$start = 0
+  [double]$end = 0
+  [double]$scoreValue = 0
+  $startParsed = TryParse-Double $r.start ([ref]$start)
+  $endParsed = TryParse-Double $r.end ([ref]$end)
+  $scoreParsed = TryParse-Double $r.score ([ref]$scoreValue)
+  $scoreText = if ($scoreParsed) { $scoreValue.ToString($ci) } else { $r.score }
+  $item = [pscustomobject]@{
+    Start = if ($startParsed) { $start } else { $null }
+    End   = if ($endParsed) { $end } else { $null }
+    Score = $scoreText
+    Note  = $r.note
+  }
+  $scoreItems += $item
+}
+
+$plan = @{
+  segments  = @()
+  scoreboard = @()
+}
+foreach ($seg in $spanItems) {
+  $plan.segments += @{
+    start    = $seg.Start.ToString($ci)
+    end      = $seg.End.ToString($ci)
+    duration = $seg.Duration.ToString($ci)
+    label    = $seg.Label
+  }
+}
+foreach ($row in $scoreItems) {
+  $plan.scoreboard += @{
+    start = if ($null -ne $row.Start) { $row.Start.ToString($ci) } else { $null }
+    end   = if ($null -ne $row.End) { $row.End.ToString($ci) } else { $null }
+    score = $row.Score
+    note  = $row.Note
+  }
+}
+
+$filterParts = @()
+for ($i = 0; $i -lt $spanItems.Count; $i++) {
+  $seg = $spanItems[$i]
+  $startStr = $seg.Start.ToString($ci)
+  $endStr = $seg.End.ToString($ci)
+  $filterParts += "[0:v]trim=start=$startStr:end=$endStr,setpts=PTS-STARTPTS[v$i];"
+}
+$plan.filter_complex = ($filterParts -join '')
+
+$plan | ConvertTo-Json -Depth 5 | Set-Content -Path $OutputPath -Encoding UTF8
+
+Write-Host ("Segments parsed: {0}" -f $spanItems.Count)
+Write-Host ("Scoreboard entries: {0}" -f $scoreItems.Count)
+Write-Host ("Plan saved to {0}" -f $OutputPath)

--- a/scripts/audit_apply_csv.py
+++ b/scripts/audit_apply_csv.py
@@ -3,6 +3,8 @@ import csv, json, sys, re
 from pathlib import Path
 from collections import Counter, defaultdict
 
+from side_utils import side_for
+
 # Accept lots of human phrasing and map to a canonical tag
 ST_ALIASES = {
     "xp": {"xp", "pat", "extra point", "point after", "p.a.t."},
@@ -50,9 +52,9 @@ def write_jsonl(p, rows):
     p.write_text("\n".join(json.dumps(r, ensure_ascii=False) for r in rows)+"\n")
 
 def side_of(p):
-    for k in ("side","lincoln_side_final","lincoln_side","lincoln_side_smoothed"):
-        v=str(p.get(k,"")).lower()
-        if v in ("offense","defense"): return v
+    s = side_for("jenks", p)
+    if s in ("offense", "defense"):
+        return s
     return "unknown"
 
 def rp_of(p):
@@ -213,8 +215,8 @@ def main():
         if is_special(p): return False
         return True
 
-    off=[p for p in plays_sorted if str(p.get("side","")).lower()=="offense" and keep_for_analytics(p)]
-    deff=[p for p in plays_sorted if str(p.get("side","")).lower()=="defense" and keep_for_analytics(p)]
+    off=[p for p in plays_sorted if side_for("jenks", p)=="offense" and keep_for_analytics(p)]
+    deff=[p for p in plays_sorted if side_for("jenks", p)=="defense" and keep_for_analytics(p)]
 
     # ensure rp/dir defaults
     for p in off+deff:

--- a/scripts/build_audit_views.py
+++ b/scripts/build_audit_views.py
@@ -2,6 +2,8 @@
 from pathlib import Path
 import sys, json, csv, collections, re
 
+from side_utils import side_for
+
 ST_EXCLUDE = {"xp","kickoff","kick","punt","return","kneel","spike"}
 
 def keep(p):
@@ -16,7 +18,7 @@ def keep(p):
     ph = (p.get("phase") or "").strip().lower()
     if ph in {"dead","deadball","pre","presnap","post","postplay","timeout","halftime","setup"}:
         return False, [f"phase:{ph}"]
-    side = p.get("side")
+    side = side_for("jenks", p)
     if side not in {"offense","defense"}:
         return False, [f"side:{side}"]
     return True, []
@@ -59,7 +61,7 @@ def main():
     off_cnt = def_cnt = 0
     for i, p in enumerate(plays):
         ok, reasons = keep(p)
-        side = p.get("side") or ""
+        side = side_for("jenks", p) or ""
         rp_used  = rp_used_of(p)
         rp_flags = rp_flags_of(p)
         if rp_used == "run":
@@ -116,7 +118,7 @@ def main():
                 "index": idx,
                 "kept": "true",
                 "exclude_reasons": "",
-                "side": p.get("side") or "",
+                "side": side_for("jenks", p) or "",
                 "rp_used": rp_u,
                 "rp_flags": rp_f,
                 "dir_used": (p.get("run_dir") if rp_u=="run" else (p.get("direction") or "unknown")) if rp_u in {"run","pass"} else "unknown",

--- a/scripts/fix_jenks_side.py
+++ b/scripts/fix_jenks_side.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""Normalize Jenks/Metro side of ball based on the audited CSV template."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import re
+import shutil
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+Row = Dict[str, Any]
+Play = Dict[str, Any]
+
+ROW_KEY_PREFERENCES: Sequence[str] = (
+    "play_id",
+    "idx",
+    "index",
+    "play_index",
+    "row_id",
+    "play_number",
+)
+
+OFFENSE_RE = re.compile(r"\boff(?:en[cs]e)?\b|\boff_?team\b", re.IGNORECASE)
+DEFENSE_RE = re.compile(r"\bdef(?:en[cs]e)?\b|\bdef_?team\b", re.IGNORECASE)
+SIDE_HINT_RE = re.compile(r"(side|offen|defen)", re.IGNORECASE)
+TEAM_RE = re.compile(r"(team|opponent|opp|school|home|away|vs|versus|against)", re.IGNORECASE)
+JENKS_RE = re.compile(r"jenks", re.IGNORECASE)
+
+SIDE_VALUE_MAP = {
+    "o": "offense",
+    "off": "offense",
+    "offense": "offense",
+    "offence": "offense",
+    "offensive": "offense",
+    "d": "defense",
+    "def": "defense",
+    "defense": "defense",
+    "defence": "defense",
+    "defensive": "defense",
+}
+
+CLIP_FIELDS = ("clip", "src", "name", "title", "file")
+
+
+def _norm_name(name: str) -> str:
+    return re.sub(r"[^a-z0-9]", "", name.lower())
+
+
+def _preferred_column(fieldnames: Iterable[str], candidates: Sequence[str]) -> Optional[str]:
+    normalized = { _norm_name(field): field for field in fieldnames if field }
+    for cand in candidates:
+        key = _norm_name(cand)
+        if key in normalized:
+            return normalized[key]
+    return None
+
+
+def _collect_columns(fieldnames: Iterable[str], pattern: re.Pattern[str]) -> List[str]:
+    cols: List[str] = []
+    for name in fieldnames:
+        if name and pattern.search(name):
+            cols.append(name)
+    return cols
+
+
+def _clip_number(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+    text = str(value)
+    match = re.search(r"clip\s*[-_ ]?\s*(\d{1,4})", text, re.IGNORECASE)
+    if match:
+        try:
+            return int(match.group(1))
+        except ValueError:
+            return None
+    digits = re.findall(r"\d{1,4}", text)
+    if digits:
+        try:
+            return int(digits[-1])
+        except ValueError:
+            return None
+    return None
+
+
+def _row_mentions_jenks(row: Row, candidate_cols: Sequence[str]) -> bool:
+    if candidate_cols:
+        values = [row.get(col, "") for col in candidate_cols]
+    else:
+        values = list(row.values())
+    for val in values:
+        if JENKS_RE.search(str(val or "")):
+            return True
+    return False
+
+
+def _side_from_tokens(tokens: Iterable[str]) -> Optional[str]:
+    for tok in tokens:
+        key = SIDE_VALUE_MAP.get(tok)
+        if key:
+            return key
+    return None
+
+
+def _tokenize(value: Any) -> List[str]:
+    if value is None:
+        return []
+    text = str(value).strip().lower()
+    if not text:
+        return []
+    tokens = [t for t in re.split(r"[^a-z]+", text) if t]
+    # include exact string for single-letter cases like "O" or "D"
+    if len(text) == 1 and text in {"o", "d"}:
+        tokens.append(text)
+    if text in {"off", "def"}:
+        tokens.append(text)
+    return tokens
+
+
+def determine_row_side(row: Row, offense_cols: Sequence[str], defense_cols: Sequence[str],
+                        hint_cols: Sequence[str], jenks_cols: Sequence[str]) -> str:
+    offense_hit = any(JENKS_RE.search(str(row.get(col, ""))) for col in offense_cols)
+    defense_hit = any(JENKS_RE.search(str(row.get(col, ""))) for col in defense_cols)
+    if offense_hit and defense_hit:
+        return "conflict"
+    if offense_hit:
+        return "offense"
+    if defense_hit:
+        return "defense"
+
+    if not _row_mentions_jenks(row, jenks_cols):
+        return "unknown"
+
+    for col in hint_cols:
+        tokens = _tokenize(row.get(col))
+        side = _side_from_tokens(tokens)
+        if side:
+            return side
+    return "unknown"
+
+
+def load_audit_rows(audit_path: Path) -> Tuple[List[Row], List[str]]:
+    if not audit_path.exists():
+        raise SystemExit(f"[error] audit file not found: {audit_path}")
+    with audit_path.open(newline="", encoding="utf-8-sig") as f:
+        reader = csv.DictReader(f)
+        fieldnames = reader.fieldnames or []
+        rows: List[Row] = list(reader)
+    return rows, fieldnames
+
+
+def load_plays(plays_path: Path) -> List[Tuple[str, Optional[Play]]]:
+    entries: List[Tuple[str, Optional[Play]]] = []
+    if not plays_path.exists():
+        raise SystemExit(f"[error] plays file not found: {plays_path}")
+    with plays_path.open(encoding="utf-8") as f:
+        for line in f:
+            raw = line.rstrip("\n")
+            stripped = line.strip()
+            if not stripped:
+                entries.append((raw, None))
+                continue
+            try:
+                obj = json.loads(stripped)
+            except json.JSONDecodeError:
+                entries.append((raw, None))
+                continue
+            entries.append((raw, obj))
+    return entries
+
+
+def build_row_index(rows: List[Row], fieldnames: List[str]) -> Tuple[List[Dict[str, Any]], Dict[str, str], Dict[str, str], Dict[int, str]]:
+    key_col = _preferred_column(fieldnames, ROW_KEY_PREFERENCES)
+    if key_col is None:
+        key_col = "row_index"
+        for idx, row in enumerate(rows):
+            row[key_col] = str(idx)
+    offense_cols = _collect_columns(fieldnames, OFFENSE_RE)
+    defense_cols = _collect_columns(fieldnames, DEFENSE_RE)
+    hint_cols = _collect_columns(fieldnames, SIDE_HINT_RE)
+
+    jenks_cols = list(dict.fromkeys(_collect_columns(fieldnames, TEAM_RE) + offense_cols + defense_cols))
+    if not jenks_cols:
+        for fallback in ("clip", "src", "title"):
+            col = _preferred_column(fieldnames, (fallback,))
+            if col:
+                jenks_cols.append(col)
+
+    side_by_key: Dict[str, str] = {}
+    side_by_row: Dict[str, str] = {}
+    side_by_clip: Dict[int, str] = {}
+    ordered: List[Dict[str, Any]] = []
+
+    for idx, row in enumerate(rows):
+        side = determine_row_side(row, offense_cols, defense_cols, hint_cols, jenks_cols)
+        key_val = str(row.get(key_col, "")).strip()
+        if not key_val:
+            key_val = str(idx)
+        clip_num = None
+        for field in CLIP_FIELDS:
+            clip_num = _clip_number(row.get(field))
+            if clip_num is not None:
+                break
+        info = {
+            "key": key_val,
+            "row_index": str(idx),
+            "side": side,
+            "clip": clip_num,
+        }
+        ordered.append(info)
+        if side in {"offense", "defense"}:
+            side_by_key.setdefault(key_val, side)
+            side_by_row.setdefault(str(idx), side)
+            if clip_num is not None:
+                side_by_clip.setdefault(clip_num, side)
+    return ordered, side_by_key, side_by_row, side_by_clip
+
+
+def match_side(play: Play, idx: int, key_map: Dict[str, str], row_map: Dict[str, str], clip_map: Dict[int, str],
+               candidate_fields: Sequence[str]) -> Optional[str]:
+    for field in candidate_fields:
+        if field not in play:
+            continue
+        val = play.get(field)
+        if val is None:
+            continue
+        key = str(val).strip()
+        if key and key in key_map:
+            return key_map[key]
+    clip_num = None
+    for field in CLIP_FIELDS:
+        clip_num = _clip_number(play.get(field))
+        if clip_num is not None:
+            break
+    if clip_num is not None and clip_num in clip_map:
+        return clip_map[clip_num]
+    row_key = str(idx)
+    if row_key in row_map:
+        return row_map[row_key]
+    return None
+
+
+def write_plays(plays_path: Path, entries: List[Tuple[str, Optional[Play]]]) -> None:
+    text = "\n".join(
+        json.dumps(obj, ensure_ascii=False) if obj is not None else raw
+        for raw, obj in entries
+    )
+    plays_path.write_text(text + "\n", encoding="utf-8")
+
+
+def main(argv: Optional[Sequence[str]] = None) -> None:
+    parser = argparse.ArgumentParser(description="Set jenks_side/metro_side based on audit CSV")
+    default_out = os.environ.get("OUT")
+    parser.add_argument("out", nargs="?", default=default_out, help="Output directory containing plays.jsonl")
+    parser.add_argument("--audit", help="Path to audit_template.csv", default=None)
+    args = parser.parse_args(argv)
+
+    if not args.out:
+        parser.error("OUT directory not provided")
+    out_dir = Path(args.out)
+    plays_path = out_dir / "plays.jsonl"
+    audit_path = Path(args.audit) if args.audit else out_dir / "audit" / "audit_template.csv"
+
+    rows, fieldnames = load_audit_rows(audit_path)
+    if not rows:
+        print("[warn] audit CSV empty; no side updates applied")
+        return
+    _, side_by_key, side_by_row, side_by_clip = build_row_index(rows, fieldnames)
+
+    entries = load_plays(plays_path)
+    candidate_fields: List[str] = []
+    seen_fields = set()
+    for pref in ROW_KEY_PREFERENCES:
+        norm_pref = _norm_name(pref)
+        for _, obj in entries:
+            if obj is None:
+                continue
+            for field in obj.keys():
+                if _norm_name(str(field)) == norm_pref:
+                    if field not in seen_fields:
+                        candidate_fields.append(field)
+                        seen_fields.add(field)
+        if seen_fields:
+            break
+    if not candidate_fields:
+        candidate_fields = ["play_id", "index", "idx", "segment_id"]
+
+    backup = plays_path.parent / f"{plays_path.name}.bak"
+    shutil.copyfile(plays_path, backup)
+
+    summary = Counter()
+    updated = 0
+    for idx, (raw, obj) in enumerate(entries):
+        if obj is None:
+            continue
+        side = match_side(obj, idx, side_by_key, side_by_row, side_by_clip, candidate_fields)
+        if side in {"offense", "defense"}:
+            obj["jenks_side"] = side
+            obj["metro_side"] = "defense" if side == "offense" else "offense"
+            updated += 1
+            summary[side] += 1
+        else:
+            obj.pop("jenks_side", None)
+            obj.pop("metro_side", None)
+            if side:
+                summary[side] += 1
+            else:
+                summary["unmatched"] += 1
+        entries[idx] = (raw, obj)
+
+    write_plays(plays_path, entries)
+    counts = {k: summary[k] for k in sorted(summary)}
+    print(f"Jenks side counts: {counts}")
+    print(f"Updated plays: {updated}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/scripts/side_utils.py
+++ b/scripts/side_utils.py
@@ -1,0 +1,41 @@
+"""Shared helpers for determining which side of the ball a team is on."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+
+def _normalize(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip().lower()
+    return text or None
+
+
+def side_for(team_name: str, play: Dict[str, Any]) -> Optional[str]:
+    """Return the side ("offense"/"defense") for ``team_name`` in ``play``.
+
+    The legacy ``play["side"]`` field represents the opponent (Jenks) side for
+    most historical data sets.  When explicit ``jenks_side``/``metro_side`` keys
+    are available we prefer them, falling back to the legacy field so that older
+    exports keep working.
+    """
+
+    team = (_normalize(team_name) or "")
+    js = _normalize(play.get("jenks_side")) if isinstance(play, dict) else None
+    ms = _normalize(play.get("metro_side")) if isinstance(play, dict) else None
+    legacy = _normalize(play.get("side")) if isinstance(play, dict) else None
+
+    if "jenks" in team:
+        return js or legacy
+
+    if any(alias in team for alias in ("metro", "mca", "eagles")):
+        if ms:
+            return ms
+        if js == "offense":
+            return "defense"
+        if js == "defense":
+            return "offense"
+        return legacy
+
+    return legacy

--- a/scripts/sync_audit_to_analytics.py
+++ b/scripts/sync_audit_to_analytics.py
@@ -5,6 +5,8 @@ import re
 import statistics as stats
 from pathlib import Path
 
+from side_utils import side_for
+
 # ----- helpers ---------------------------------------------------------------
 
 
@@ -69,6 +71,10 @@ def idx_from_src(src: str):
 
 
 def get_side(p):
+    preferred = side_for("jenks", p)
+    pref_norm = safe_lower(preferred, "")
+    if pref_norm in ("offense", "defense"):
+        return pref_norm
     for key in ("side", "lincoln_side_final", "lincoln_side", "lincoln_side_smoothed"):
         v = safe_lower(p.get(key))
         if v in ("offense", "defense"):
@@ -223,6 +229,8 @@ def main(out_dir: str):
         s = get_side(p)
         if s in ("offense", "defense"):
             p["side"] = s
+            p["jenks_side"] = s
+            p["metro_side"] = "defense" if s == "offense" else "offense"
 
     # read audits if present
     audits = []
@@ -279,6 +287,8 @@ def main(out_dir: str):
         side_val = safe_lower(a.get("side"), "")
         if side_val in ("offense", "defense"):
             target["side"] = side_val
+            target["jenks_side"] = side_val
+            target["metro_side"] = "defense" if side_val == "offense" else "offense"
 
         # rp -> is_run/is_pass
         rp = safe_lower(a.get("rp"), "")
@@ -332,6 +342,8 @@ def main(out_dir: str):
         s = get_side(p)
         if s in ("offense", "defense"):
             p["side"] = s
+            p["jenks_side"] = s
+            p["metro_side"] = "defense" if s == "offense" else "offense"
 
     # write back
     bak = out / "plays.audit_sync_backup.jsonl"


### PR DESCRIPTION
## Summary
- add fix_jenks_side script and run it in audit-sync to derive jenks_side/metro_side from audit CSV
- update Build-Reel.ps1 to parse numeric fields with culture-invariant TryParse-Double helper
- prefer explicit jenks_side/metro_side via new side_utils.side_for in analytics scripts

## Testing
- python -m compileall scripts/fix_jenks_side.py scripts/side_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68ccbc5f2ac0832da2ac03944b825dcf