### PR TITLE
Respect jenks_side when computing tendencies

### DIFF
--- a/scripts/audit_apply_csv.py
+++ b/scripts/audit_apply_csv.py
@@ -215,8 +215,26 @@ def main():
         if is_special(p): return False
         return True
 
-    off=[p for p in plays_sorted if side_for("jenks", p)=="offense" and keep_for_analytics(p)]
-    deff=[p for p in plays_sorted if side_for("jenks", p)=="defense" and keep_for_analytics(p)]
+    valid = {"offense", "defense"}
+    off = []
+    deff = []
+    for p in plays_sorted:
+        if not keep_for_analytics(p):
+            continue
+        explicit = str(p.get("jenks_side") or "").strip().lower()
+        if explicit:
+            if explicit not in valid:
+                continue
+            side = explicit
+        else:
+            inferred = str(side_for("jenks", p) or "").strip().lower()
+            if inferred not in valid:
+                continue
+            side = inferred
+        if side == "offense":
+            off.append(p)
+        else:
+            deff.append(p)
 
     # ensure rp/dir defaults
     for p in off+deff:

--- a/scripts/rp_heuristics_fix.py
+++ b/scripts/rp_heuristics_fix.py
@@ -71,7 +71,19 @@ plays_path.write_text("\n".join(json.dumps(p, ensure_ascii=False) for p in plays
 
 # quick_tendencies.csv
 from collections import Counter
-off = [p for p in plays if str(p.get("lincoln_side_final","")).lower()=="offense" or str(p.get("lincoln_side","")).lower()=="offense" or str(p.get("side","")).lower()=="offense"]
+VALID_SIDES = {"offense", "defense"}
+
+def _resolve_side(play):
+    js = str(play.get("jenks_side") or "").strip().lower()
+    if js:
+        return js if js in VALID_SIDES else ""
+    for key in ("lincoln_side_final", "lincoln_side", "side"):
+        val = str(play.get(key) or "").strip().lower()
+        if val in VALID_SIDES:
+            return val
+    return ""
+
+off = [p for p in plays if _resolve_side(p) == "offense"]
 cnt_rp = Counter(p.get("rp","unknown") for p in off)
 cnt_rpdir = Counter(p.get("rp_dir","unknown") for p in off)
 

--- a/scripts/sync_audit_to_analytics.py
+++ b/scripts/sync_audit_to_analytics.py
@@ -71,12 +71,16 @@ def idx_from_src(src: str):
 
 
 def get_side(p):
+    explicit = safe_lower(p.get("jenks_side"), "")
+    if explicit:
+        return explicit
+
     preferred = side_for("jenks", p)
     pref_norm = safe_lower(preferred, "")
-    if pref_norm in ("offense", "defense"):
+    if pref_norm:
         return pref_norm
     for key in ("side", "lincoln_side_final", "lincoln_side", "lincoln_side_smoothed"):
-        v = safe_lower(p.get(key))
+        v = safe_lower(p.get(key), "")
         if v in ("offense", "defense"):
             return v
     return "unknown"
@@ -352,7 +356,20 @@ def main(out_dir: str):
 
     # ---------------- recompute analytics -----------------------------------
     def side_filter(side):
-        return [p for p in plays if get_side(p) == side and not is_special(p)]
+        filtered = []
+        for p in plays:
+            explicit = safe_lower(p.get("jenks_side"), "")
+            if explicit:
+                if explicit not in ("offense", "defense") or explicit != side:
+                    continue
+            else:
+                inferred = safe_lower(get_side(p), "")
+                if inferred not in ("offense", "defense") or inferred != side:
+                    continue
+            if is_special(p):
+                continue
+            filtered.append(p)
+        return filtered
 
     def compile_quick(rows, side_label):
         # rp + rp:dir counts


### PR DESCRIPTION
## Summary
- prefer the explicit `jenks_side` value when determining offense/defense, skipping special/excluded/unknown rows in the audit sync pipeline
- ensure the audit CSV rebuild and rp heuristics scripts split plays using the new side fields before aggregating tendencies

## Testing
- python -m compileall scripts/sync_audit_to_analytics.py scripts/audit_apply_csv.py scripts/rp_heuristics_fix.py

------
https://chatgpt.com/codex/tasks/task_e_68cd56324f14832daf89bdfc31dd9b75